### PR TITLE
Added duplicate namespace declaration in build.gradle to support newer versions of AGP 

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -36,6 +36,7 @@ android {
         namespace "com.deepanshuchaudhary.pdf_manipulator"
     }
 
+    namespace "com.deepanshuchaudhary.pdf_manipulator"
     compileSdkVersion 33
 
     compileOptions {


### PR DESCRIPTION
This pull request includes a minor change to the `android/build.gradle` file. The change duplicates the `namespace` declaration for `"com.deepanshuchaudhary.pdf_manipulator"`.

**This resolves issue #13.**