### PR TITLE
fix: commit-msg hook blocks merge commits

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,32 @@
+#!/bin/sh
+# Enforce Conventional Commits format.
+# Valid: feat: add watermark | fix(web): handle empty PDF | feat!: breaking change
+# Invalid: added watermark | WIP | misc changes
+
+msg=$(head -1 "$1")
+
+# Allow reverts (squash-reverts have conventional titles, but git revert doesn't)
+echo "$msg" | grep -qE '^Revert ' && exit 0
+
+# Block merge commits — all branch-to-branch moves go through PRs (squash-merge)
+if echo "$msg" | grep -qE '^Merge '; then
+  echo "ERROR: Merge commits are not allowed."
+  echo "  All branch-to-branch promotions go through GitHub PRs (squash-merge)."
+  echo "  Never use 'git merge' locally between branches."
+  exit 1
+fi
+
+if ! echo "$msg" | grep -qE '^(feat|fix|docs|chore|ci|test|refactor|perf|build|deps)(\(.+\))?!?: .+'; then
+  echo "ERROR: Commit message must follow Conventional Commits format."
+  echo ""
+  echo "  <type>[optional scope]: <description>"
+  echo ""
+  echo "  Types: feat fix docs chore ci test refactor perf build deps"
+  echo "  Examples:"
+  echo "    feat: add watermark support"
+  echo "    fix(web): handle empty PDF edge case"
+  echo "    feat!: redesign API (breaking change)"
+  echo ""
+  echo "  Your message: $msg"
+  exit 1
+fi

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -6,17 +6,17 @@
 msg=$(head -1 "$1")
 
 # Allow reverts (squash-reverts have conventional titles, but git revert doesn't)
-echo "$msg" | grep -qE '^Revert ' && exit 0
+printf '%s\n' "$msg" | grep -qE '^Revert ' && exit 0
 
 # Block merge commits — all branch-to-branch moves go through PRs (squash-merge)
-if echo "$msg" | grep -qE '^Merge '; then
+if printf '%s\n' "$msg" | grep -qE '^Merge '; then
   echo "ERROR: Merge commits are not allowed."
   echo "  All branch-to-branch promotions go through GitHub PRs (squash-merge)."
   echo "  Never use 'git merge' locally between branches."
   exit 1
 fi
 
-if ! echo "$msg" | grep -qE '^(feat|fix|docs|chore|ci|test|refactor|perf|build|deps)(\(.+\))?!?: .+'; then
+if ! printf '%s\n' "$msg" | grep -qE '^(feat|fix|docs|chore|ci|test|refactor|perf|build|deps)(\(.+\))?!?: .+'; then
   echo "ERROR: Commit message must follow Conventional Commits format."
   echo ""
   echo "  <type>[optional scope]: <description>"
@@ -27,6 +27,6 @@ if ! echo "$msg" | grep -qE '^(feat|fix|docs|chore|ci|test|refactor|perf|build|d
   echo "    fix(web): handle empty PDF edge case"
   echo "    feat!: redesign API (breaking change)"
   echo ""
-  echo "  Your message: $msg"
+  printf '  Your message: %s\n' "$msg"
   exit 1
 fi

--- a/.github/workflows/promotion-check.yml
+++ b/.github/workflows/promotion-check.yml
@@ -1,0 +1,33 @@
+# Enforce linear promotion: feature → dev → main. No skipping.
+name: Promotion Check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    branches: [dev, main]
+
+jobs:
+  check:
+    name: Promotion Chain
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate promotion path
+        env:
+          BASE: ${{ github.base_ref }}
+          HEAD: ${{ github.head_ref }}
+        run: |
+          echo "PR: $HEAD → $BASE"
+
+          # main only accepts PRs from dev
+          if [[ "$BASE" == "main" && "$HEAD" != "dev" ]]; then
+            echo "::error::main only accepts PRs from dev. Got: $HEAD → main"
+            exit 1
+          fi
+
+          # dev accepts PRs from any feature branch (but not main)
+          if [[ "$BASE" == "dev" && "$HEAD" == "main" ]]; then
+            echo "::error::dev does not accept PRs from main. Got: main → dev"
+            exit 1
+          fi
+
+          echo "✓ Valid promotion path: $HEAD → $BASE"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,9 +9,13 @@ Contributions are welcome.
 ```bash
 git clone --recursive https://github.com/whuppi/pdf_manipulator.git
 cd pdf_manipulator
+git config core.hooksPath .githooks
 dart pub get
 dart test  # build hook compiles Rust from source automatically
 ```
+
+The `core.hooksPath` step activates git hooks that enforce conventional commits
+and block accidental commits of gitignored files.
 
 **Requires:** [Rust](https://rustup.rs). The build hook detects `vendor/pdf_oxide/Cargo.toml` and runs `cargo build`. No manual compilation step.
 

--- a/README.md
+++ b/README.md
@@ -427,6 +427,18 @@ Every feature works on every platform. Native binaries are downloaded automatica
 
 | Document | What's inside |
 |---|---|
+## Contributing
+
+```bash
+git clone https://github.com/whuppi/pdf_manipulator.git
+cd pdf_manipulator
+git config core.hooksPath .githooks
+```
+
+The hooks enforce conventional commits and block accidental gitignored files.
+
+---
+
 | [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) | Source tree, three-layer design, conditional import dispatch, worker model, build hook |
 | [`docs/CAPABILITY_ROADMAP.md`](docs/CAPABILITY_ROADMAP.md) | Every feature with shipped/planned status |
 | [`docs/MIGRATION.md`](docs/MIGRATION.md) | Method-by-method mapping from the old Android-only package |

--- a/README.md
+++ b/README.md
@@ -427,18 +427,6 @@ Every feature works on every platform. Native binaries are downloaded automatica
 
 | Document | What's inside |
 |---|---|
-## Contributing
-
-```bash
-git clone https://github.com/whuppi/pdf_manipulator.git
-cd pdf_manipulator
-git config core.hooksPath .githooks
-```
-
-The hooks enforce conventional commits and block accidental gitignored files.
-
----
-
 | [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) | Source tree, three-layer design, conditional import dispatch, worker model, build hook |
 | [`docs/CAPABILITY_ROADMAP.md`](docs/CAPABILITY_ROADMAP.md) | Every feature with shipped/planned status |
 | [`docs/MIGRATION.md`](docs/MIGRATION.md) | Method-by-method mapping from the old Android-only package |


### PR DESCRIPTION
Blocks local git merge — all promotions via GitHub PRs (squash-merge).