### PR TITLE
ci: add permissions: {} to promotion-check

### DIFF
--- a/.github/workflows/promotion-check.yml
+++ b/.github/workflows/promotion-check.yml
@@ -6,6 +6,8 @@ on:
     types: [opened, edited, synchronize, reopened]
     branches: [dev, main]
 
+permissions: {}
+
 jobs:
   check:
     name: Promotion Chain


### PR DESCRIPTION
Least privilege — workflow doesn't need GITHUB_TOKEN. Suggested by slopfairy in PR #23 review.