### PR TITLE
fix: quote YAML expression in publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ env:
   COMPILE_OUTPUT_DIR: out
 
 concurrency:
-  group: release-${{ github.event.github.event.inputs.tag || github.ref_name }}
+  group: release-${{ github.event.inputs.tag || github.ref_name }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
-        with: { ref: ${{ github.event.inputs.tag || github.ref_name }}, submodules: recursive }
+        with: { ref: '${{ github.event.inputs.tag || github.ref_name }}', submodules: recursive }
       - uses: ./.github/actions/compile-macos
       - uses: actions/upload-artifact@v4
         with: { name: bin-macos, path: out/ }


### PR DESCRIPTION
## Summary
- Line 41 had an unquoted `${{ }}` expression — YAML parsed the bare `{` as a mapping start
- Previous PR #29 fixed `inputs.tag` → `github.event.inputs.tag` but missed the missing quotes on this one line

## Test plan
- [ ] Push to dev no longer shows "Invalid workflow file" for publish.yml