### PR TITLE
fix: compile per-platform — CI builds only the targets it installed

### DIFF
--- a/.github/actions/compile-android/action.yml
+++ b/.github/actions/compile-android/action.yml
@@ -1,5 +1,5 @@
 name: Compile Android
-description: Build pdf_oxide for Android arm64, arm, x64, x86 via Makefile
+description: Build pdf_oxide for Android arm64, arm, x64, x86
 
 runs:
   using: composite
@@ -7,4 +7,4 @@ runs:
     - uses: ./.github/actions/setup-rust
       with: { targets: "aarch64-linux-android,armv7-linux-androideabi,x86_64-linux-android,i686-linux-android" }
     - shell: bash
-      run: make compile-natives
+      run: bash tool/compile_rust.sh android

--- a/.github/actions/compile-ios/action.yml
+++ b/.github/actions/compile-ios/action.yml
@@ -1,5 +1,5 @@
 name: Compile iOS
-description: Build pdf_oxide for iOS device + simulators via Makefile
+description: Build pdf_oxide for iOS device + simulators
 
 runs:
   using: composite
@@ -7,4 +7,4 @@ runs:
     - uses: ./.github/actions/setup-rust
       with: { targets: "aarch64-apple-ios,aarch64-apple-ios-sim,x86_64-apple-ios" }
     - shell: bash
-      run: make compile-natives
+      run: bash tool/compile_rust.sh ios

--- a/.github/actions/compile-linux/action.yml
+++ b/.github/actions/compile-linux/action.yml
@@ -1,12 +1,12 @@
 name: Compile Linux
-description: Build pdf_oxide for Linux x64 + arm64 via Makefile
+description: Build pdf_oxide for Linux x64 + arm64 (cross-compile)
 
 runs:
   using: composite
   steps:
     - shell: bash
-      run: sudo apt-get update && sudo apt-get install -y gcc-aarch64-linux-gnu mold
+      run: sudo apt-get update && sudo apt-get install -y gcc-aarch64-linux-gnu
     - uses: ./.github/actions/setup-rust
       with: { targets: "x86_64-unknown-linux-gnu,aarch64-unknown-linux-gnu" }
     - shell: bash
-      run: make compile-natives
+      run: bash tool/compile_rust.sh linux

--- a/.github/actions/compile-macos/action.yml
+++ b/.github/actions/compile-macos/action.yml
@@ -1,5 +1,5 @@
 name: Compile macOS
-description: Build pdf_oxide for macOS arm64 + x64 via Makefile
+description: Build pdf_oxide for macOS arm64 + x64
 
 runs:
   using: composite
@@ -7,4 +7,4 @@ runs:
     - uses: ./.github/actions/setup-rust
       with: { targets: "aarch64-apple-darwin,x86_64-apple-darwin" }
     - shell: bash
-      run: make compile-natives
+      run: bash tool/compile_rust.sh macos

--- a/.github/actions/compile-wasm/action.yml
+++ b/.github/actions/compile-wasm/action.yml
@@ -11,7 +11,7 @@ runs:
         cargo install wasm-bindgen-cli --version 0.2.121
         sudo apt-get update && sudo apt-get install -y binaryen
     - shell: bash
-      run: make compile-wasm
+      run: bash tool/compile_rust.sh wasm
     - shell: bash
       run: |
         mkdir -p out/wasm

--- a/.github/actions/compile-windows/action.yml
+++ b/.github/actions/compile-windows/action.yml
@@ -1,5 +1,5 @@
 name: Compile Windows
-description: Build pdf_oxide for Windows x64 + arm64 via Makefile
+description: Build pdf_oxide for Windows x64 + arm64
 
 runs:
   using: composite
@@ -7,4 +7,4 @@ runs:
     - uses: ./.github/actions/setup-rust
       with: { targets: "x86_64-pc-windows-msvc,aarch64-pc-windows-msvc" }
     - shell: bash
-      run: make compile-natives
+      run: bash tool/compile_rust.sh windows

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,52 +33,96 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # ── Validate tag before doing anything ─────────────────────────────
+  validate:
+    name: Validate tag
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.resolve.outputs.tag }}
+      version: ${{ steps.resolve.outputs.version }}
+    steps:
+      - name: Resolve + validate tag
+        id: resolve
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ github.event.inputs.tag || github.ref_name }}"
+
+          # Must match vX.Y.Z or vX.Y.Z-pre.N
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "::error::Invalid tag format: '$TAG' (expected vX.Y.Z or vX.Y.Z-pre.N)"
+            exit 1
+          fi
+
+          # Tag must exist as a git ref
+          if ! gh api "repos/${{ github.repository }}/git/ref/tags/$TAG" --silent 2>/dev/null; then
+            echo "::error::Tag '$TAG' does not exist"
+            exit 1
+          fi
+
+          # GitHub Release must exist for this tag
+          if ! gh release view "$TAG" --repo "${{ github.repository }}" --json tagName --jq '.tagName' >/dev/null 2>&1; then
+            echo "::error::No GitHub Release found for '$TAG'"
+            exit 1
+          fi
+
+          VERSION="${TAG#v}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Validated: $TAG → $VERSION"
+
   # ── Compile all targets ────────────────────────────────────────────
   compile-macos:
+    needs: validate
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
-        with: { ref: '${{ github.event.inputs.tag || github.ref_name }}', submodules: recursive }
+        with: { ref: '${{ needs.validate.outputs.tag }}', submodules: recursive }
       - uses: ./.github/actions/compile-macos
       - uses: actions/upload-artifact@v4
         with: { name: bin-macos, path: out/ }
   compile-ios:
+    needs: validate
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
-        with: { ref: '${{ github.event.inputs.tag || github.ref_name }}', submodules: recursive }
+        with: { ref: '${{ needs.validate.outputs.tag }}', submodules: recursive }
       - uses: ./.github/actions/compile-ios
       - uses: actions/upload-artifact@v4
         with: { name: bin-ios, path: out/ }
   compile-android:
+    needs: validate
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with: { ref: '${{ github.event.inputs.tag || github.ref_name }}', submodules: recursive }
+        with: { ref: '${{ needs.validate.outputs.tag }}', submodules: recursive }
       - uses: ./.github/actions/compile-android
       - uses: actions/upload-artifact@v4
         with: { name: bin-android, path: out/ }
   compile-linux:
+    needs: validate
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with: { ref: '${{ github.event.inputs.tag || github.ref_name }}', submodules: recursive }
+        with: { ref: '${{ needs.validate.outputs.tag }}', submodules: recursive }
       - uses: ./.github/actions/compile-linux
       - uses: actions/upload-artifact@v4
         with: { name: bin-linux, path: out/ }
   compile-wasm:
+    needs: validate
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with: { ref: '${{ github.event.inputs.tag || github.ref_name }}', submodules: recursive }
+        with: { ref: '${{ needs.validate.outputs.tag }}', submodules: recursive }
       - uses: ./.github/actions/compile-wasm
       - uses: actions/upload-artifact@v4
         with: { name: bin-wasm, path: out/ }
   compile-windows:
+    needs: validate
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
-        with: { ref: '${{ github.event.inputs.tag || github.ref_name }}', submodules: recursive }
+        with: { ref: '${{ needs.validate.outputs.tag }}', submodules: recursive }
       - uses: ./.github/actions/compile-windows
       - uses: actions/upload-artifact@v4
         with: { name: bin-windows, path: out/ }
@@ -86,7 +130,7 @@ jobs:
   # ── Upload binaries to the GitHub Release ──────────────────────────
   upload-assets:
     name: Upload Release Assets
-    needs: [compile-macos, compile-ios, compile-android, compile-linux, compile-windows, compile-wasm]
+    needs: [validate, compile-macos, compile-ios, compile-android, compile-linux, compile-windows, compile-wasm]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4
@@ -113,7 +157,7 @@ jobs:
           ls -lh release/
       - uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.event.inputs.tag || github.ref_name }}
+          tag_name: ${{ needs.validate.outputs.tag }}
           files: release/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -121,19 +165,18 @@ jobs:
   # ── Publish to pub.dev ─────────────────────────────────────────────
   publish:
     name: Publish to pub.dev
-    needs: upload-assets
+    needs: [validate, upload-assets]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with: { ref: '${{ github.event.inputs.tag || github.ref_name }}', submodules: recursive }
+        with: { ref: '${{ needs.validate.outputs.tag }}', submodules: recursive }
       - uses: dart-lang/setup-dart@v1
       - name: Install fvm + project SDK
         run: dart pub global activate fvm && fvm install
 
       - name: Stamp version from tag
         run: |
-          TAG="${{ github.event.inputs.tag || github.ref_name }}"
-          VERSION="${TAG#v}"
+          VERSION="${{ needs.validate.outputs.version }}"
           echo "Publishing version: $VERSION"
 
           # Stamp pubspec.yaml

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -30,7 +30,21 @@ final _log = Logger('pdf_manipulator:build');
 const _assetId = 'src/ffi/native_bindings.g.dart';
 const _crateName = 'pdf_oxide';
 const _releaseRepo = 'https://github.com/whuppi/pdf_manipulator/releases/download';
-const _features = 'icc,legacy-crypto,rendering,signatures,native-bridge';
+const _featuresFallback = 'icc,legacy-crypto,rendering,signatures,native-bridge';
+
+/// Read features from compile_rust.sh (single source of truth).
+/// Falls back to hardcoded value for pub.dev consumers who don't have the script.
+String _resolveFeatures(Uri packageRoot) {
+  final script = File.fromUri(packageRoot.resolve('tool/compile_rust.sh'));
+  if (script.existsSync()) {
+    final result = Process.runSync('bash', [script.path, '--features', 'native']);
+    if (result.exitCode == 0) {
+      final features = (result.stdout as String).trim();
+      if (features.isNotEmpty) return features;
+    }
+  }
+  return _featuresFallback;
+}
 
 void main(List<String> args) async {
   await build(args, (BuildInput input, BuildOutputBuilder output) async {
@@ -167,7 +181,7 @@ Future<void> _compileFromSource(
       '--release',
       '--target', targetTriple,
       '--target-dir', targetDir,
-      '--features', _features,
+      '--features', _resolveFeatures(input.packageRoot),
     ],
     environment: {...Platform.environment, ...env},
   );

--- a/tool/compile_rust.sh
+++ b/tool/compile_rust.sh
@@ -1,28 +1,34 @@
 #!/bin/bash
-# Compile pdf_oxide for any target: native platforms, WASM, or both.
+# Compile pdf_oxide for any target: specific platform, WASM, or auto-detect.
 #
 # Usage:
-#   ./tool/compile_rust.sh native       Compile all native targets for this host
-#   ./tool/compile_rust.sh wasm         Compile WASM + wasm-bindgen + wasm-opt
-#   ./tool/compile_rust.sh all          Both
-#   ./tool/compile_rust.sh --features   Print feature flags (used by Makefile)
+#   ./tool/compile_rust.sh macos        macOS arm64 + x64
+#   ./tool/compile_rust.sh ios          iOS device + simulators
+#   ./tool/compile_rust.sh linux        Linux x64 + arm64 (cross-compile)
+#   ./tool/compile_rust.sh android      Android arm64 + arm + x64 + x86
+#   ./tool/compile_rust.sh windows      Windows x64 (+ arm64 on MSVC)
+#   ./tool/compile_rust.sh wasm         WASM + wasm-bindgen + wasm-opt
+#   ./tool/compile_rust.sh native       Auto-detect what this host can build
+#   ./tool/compile_rust.sh all          native + wasm
+#   ./tool/compile_rust.sh --features   Print feature flags (used by Makefile + build.dart)
 #
-# Run from package root. Auto-detects what native targets the host can build.
+# CI calls the specific platform (macos/ios/linux/android/windows/wasm).
+# Local dev calls native (auto-detect) or all.
 #
 # Prerequisites:
-#   - Rust toolchain with targets installed
-#   - WASM: rustup target add wasm32-unknown-unknown
+#   - Rust toolchain with targets installed (rustup target add ...)
 #   - WASM: cargo install wasm-bindgen-cli; brew/apt install binaryen
 #   - Android: ANDROID_NDK_HOME set
+#   - Linux arm64 cross: apt install gcc-aarch64-linux-gnu
 
 set -euo pipefail
 
 # ── Feature flags (single source of truth) ──────────────────────────
+# build.dart reads these via: ./tool/compile_rust.sh --features native
 
 NATIVE_FEATURES="icc,legacy-crypto,rendering,signatures,native-bridge"
 WASM_FEATURES="wasm,rendering"
 
-# Query mode — Makefile calls this to get features without building.
 if [[ "${1:-}" == "--features" ]]; then
   case "${2:-all}" in
     native) echo "$NATIVE_FEATURES" ;;
@@ -44,13 +50,13 @@ if [ ! -f "$MANIFEST" ]; then
   exit 1
 fi
 
-MODE="${1:-all}"
+MODE="${1:-native}"
 
 # ═════════════════════════════════════════════════════════════════════
-# NATIVE
+# NATIVE — shared helpers
 # ═════════════════════════════════════════════════════════════════════
 
-compile_native() {
+compile_one() {
   local target=$1 outdir=$2 libname=$3
   local out="${COMPILE_OUTPUT_DIR:-$PKG_ROOT/build_output}"
 
@@ -63,7 +69,7 @@ compile_native() {
   echo "  → $out/$outdir/$libname ($(du -h "$out/$outdir/$libname" | cut -f1))"
 }
 
-compile_android() {
+compile_android_target() {
   local target=$1 outdir=$2 clang_prefix=$3
   local ndk="${ANDROID_NDK_HOME:-$HOME/Library/Android/sdk/ndk/28.0.12433566}"
   local toolchain="$ndk/toolchains/llvm/prebuilt"
@@ -80,46 +86,11 @@ compile_android() {
 
   local linker_var="CARGO_TARGET_$(echo "$target" | tr '[:lower:]-' '[:upper:]_')_LINKER"
   export "$linker_var=$host_dir/bin/${clang_prefix}21-clang"
-  compile_native "$target" "$outdir" "libpdf_oxide.so"
+  compile_one "$target" "$outdir" "libpdf_oxide.so"
   unset "$linker_var"
 }
 
-do_native() {
-  # macOS + iOS
-  if [[ "$(uname)" == "Darwin" ]]; then
-    compile_native "aarch64-apple-darwin" "macos-arm64" "libpdf_oxide.dylib"
-    compile_native "x86_64-apple-darwin"  "macos-x64"   "libpdf_oxide.dylib"
-    compile_native "aarch64-apple-ios"     "ios-arm64"     "libpdf_oxide.a"
-    compile_native "aarch64-apple-ios-sim" "ios-sim-arm64" "libpdf_oxide.a"
-    compile_native "x86_64-apple-ios"      "ios-sim-x64"   "libpdf_oxide.a"
-    local out="${COMPILE_OUTPUT_DIR:-$PKG_ROOT/build_output}"
-    strip -S "$out/ios-arm64/libpdf_oxide.a" 2>/dev/null || true
-    strip -S "$out/ios-sim-arm64/libpdf_oxide.a" 2>/dev/null || true
-    strip -S "$out/ios-sim-x64/libpdf_oxide.a" 2>/dev/null || true
-  fi
-
-  # Linux
-  if [[ "$(uname)" == "Linux" ]]; then
-    compile_native "x86_64-unknown-linux-gnu"  "linux-x64"  "libpdf_oxide.so"
-    compile_native "aarch64-unknown-linux-gnu" "linux-arm64" "libpdf_oxide.so"
-  fi
-
-  # Windows
-  if command -v x86_64-w64-mingw32-gcc &>/dev/null; then
-    compile_native "x86_64-pc-windows-gnu" "windows-x64" "pdf_oxide.dll"
-  elif [[ "$(uname -s)" == MINGW* ]] || [[ "$(uname -s)" == MSYS* ]]; then
-    compile_native "x86_64-pc-windows-msvc" "windows-x64" "pdf_oxide.dll"
-    compile_native "aarch64-pc-windows-msvc" "windows-arm64" "pdf_oxide.dll"
-  fi
-
-  # Android
-  if [ -d "${ANDROID_NDK_HOME:-$HOME/Library/Android/sdk/ndk}" ]; then
-    compile_android "aarch64-linux-android"   "android-arm64" "aarch64-linux-android"
-    compile_android "armv7-linux-androideabi" "android-arm"   "armv7a-linux-androideabi"
-    compile_android "x86_64-linux-android"    "android-x64"   "x86_64-linux-android"
-    compile_android "i686-linux-android"      "android-x86"   "i686-linux-android"
-  fi
-
+native_summary() {
   echo ""
   local out="${COMPILE_OUTPUT_DIR:-$PKG_ROOT/build_output}"
   echo "=== Native summary ==="
@@ -127,11 +98,96 @@ do_native() {
 }
 
 # ═════════════════════════════════════════════════════════════════════
+# PLATFORM COMMANDS — CI calls these directly
+# ═════════════════════════════════════════════════════════════════════
+
+do_macos() {
+  compile_one "aarch64-apple-darwin" "macos-arm64" "libpdf_oxide.dylib"
+  compile_one "x86_64-apple-darwin"  "macos-x64"   "libpdf_oxide.dylib"
+  native_summary
+}
+
+do_ios() {
+  compile_one "aarch64-apple-ios"     "ios-arm64"     "libpdf_oxide.a"
+  compile_one "aarch64-apple-ios-sim" "ios-sim-arm64" "libpdf_oxide.a"
+  compile_one "x86_64-apple-ios"      "ios-sim-x64"   "libpdf_oxide.a"
+
+  local out="${COMPILE_OUTPUT_DIR:-$PKG_ROOT/build_output}"
+  strip -S "$out/ios-arm64/libpdf_oxide.a" 2>/dev/null || true
+  strip -S "$out/ios-sim-arm64/libpdf_oxide.a" 2>/dev/null || true
+  strip -S "$out/ios-sim-x64/libpdf_oxide.a" 2>/dev/null || true
+  native_summary
+}
+
+do_linux() {
+  compile_one "x86_64-unknown-linux-gnu" "linux-x64" "libpdf_oxide.so"
+
+  # aarch64 cross-compile needs the cross-linker
+  export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER="aarch64-linux-gnu-gcc"
+  compile_one "aarch64-unknown-linux-gnu" "linux-arm64" "libpdf_oxide.so"
+  unset CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER
+
+  native_summary
+}
+
+do_android() {
+  compile_android_target "aarch64-linux-android"   "android-arm64" "aarch64-linux-android"
+  compile_android_target "armv7-linux-androideabi"  "android-arm"   "armv7a-linux-androideabi"
+  compile_android_target "x86_64-linux-android"     "android-x64"   "x86_64-linux-android"
+  compile_android_target "i686-linux-android"        "android-x86"   "i686-linux-android"
+  native_summary
+}
+
+do_windows() {
+  if command -v x86_64-w64-mingw32-gcc &>/dev/null; then
+    compile_one "x86_64-pc-windows-gnu" "windows-x64" "pdf_oxide.dll"
+  elif [[ "$(uname -s)" == MINGW* ]] || [[ "$(uname -s)" == MSYS* ]]; then
+    compile_one "x86_64-pc-windows-msvc" "windows-x64" "pdf_oxide.dll"
+    compile_one "aarch64-pc-windows-msvc" "windows-arm64" "pdf_oxide.dll"
+  else
+    echo "⚠ Windows cross-compile not available on this host"
+    return
+  fi
+  native_summary
+}
+
+# ═════════════════════════════════════════════════════════════════════
+# AUTO-DETECT — local dev convenience (builds what this host supports)
+# ═════════════════════════════════════════════════════════════════════
+
+do_native() {
+  if [[ "$(uname)" == "Darwin" ]]; then
+    do_macos
+    do_ios
+  fi
+
+  if [[ "$(uname)" == "Linux" ]]; then
+    # Only x64 in auto-detect (arm64 cross needs gcc-aarch64 installed)
+    compile_one "x86_64-unknown-linux-gnu" "linux-x64" "libpdf_oxide.so"
+    if command -v aarch64-linux-gnu-gcc &>/dev/null; then
+      export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER="aarch64-linux-gnu-gcc"
+      compile_one "aarch64-unknown-linux-gnu" "linux-arm64" "libpdf_oxide.so"
+      unset CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER
+    fi
+  fi
+
+  if command -v x86_64-w64-mingw32-gcc &>/dev/null; then
+    compile_one "x86_64-pc-windows-gnu" "windows-x64" "pdf_oxide.dll"
+  elif [[ "$(uname -s)" == MINGW* ]] || [[ "$(uname -s)" == MSYS* ]]; then
+    do_windows
+  fi
+
+  if [ -d "${ANDROID_NDK_HOME:-$HOME/Library/Android/sdk/ndk}" ]; then
+    do_android
+  fi
+
+  native_summary
+}
+
+# ═════════════════════════════════════════════════════════════════════
 # WASM
 # ═════════════════════════════════════════════════════════════════════
 
-# wasm-opt feature flags (Rust's wasm32 target enables these by default;
-# wasm-opt must be told about them or it rejects the binary).
 WASM_OPT_FLAGS=(
   --enable-bulk-memory
   --enable-multivalue
@@ -181,8 +237,13 @@ do_wasm() {
 # ═════════════════════════════════════════════════════════════════════
 
 case "$MODE" in
-  native) do_native ;;
-  wasm)   do_wasm ;;
-  all)    do_native; do_wasm ;;
-  *)      echo "Usage: $0 {native|wasm|all|--features [native|wasm]}"; exit 1 ;;
+  macos)    do_macos ;;
+  ios)      do_ios ;;
+  linux)    do_linux ;;
+  android)  do_android ;;
+  windows)  do_windows ;;
+  wasm)     do_wasm ;;
+  native)   do_native ;;
+  all)      do_native; do_wasm ;;
+  *)        echo "Usage: $0 {macos|ios|linux|android|windows|wasm|native|all|--features [native|wasm]}"; exit 1 ;;
 esac


### PR DESCRIPTION
## Summary
- `compile_rust.sh` gains per-platform subcommands: `macos`, `ios`, `linux`, `android`, `windows`, `wasm`
- CI compile actions call the script directly with their platform instead of `make compile-natives` (which built everything the OS detected)
- Linux aarch64 cross-compile sets `CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc`
- `hook/build.dart` reads features from the script instead of hardcoding (fallback for pub.dev consumers)
- Features defined once in `compile_rust.sh`, read by Makefile + build.dart — zero drift

## Root cause
CI compile actions installed platform-specific Rust targets but called `make compile-natives` → `compile_rust.sh native` → which auto-detected and tried to build ALL targets the OS supports. Missing targets → `can't find crate for core`. Wrong linker → `incompatible with elf64-x86-64`.

## Test plan
- [ ] `bash tool/compile_rust.sh --features native` prints features
- [ ] `dart analyze hook/build.dart` — no issues
- [ ] CI publish workflow: all 6 compile jobs pass