### PR TITLE
fix: auto-generate commit lists + asset hashes at publish time

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -104,6 +104,26 @@ jobs:
             # Extract release notes from changelog (everything between this ## and next ##)
             NOTES=$(awk "/^## ${VERSION//./\\.}($| )/{found=1; next} /^## /{found=0} found" "$FILE")
 
+            # Auto-append commit list since previous tag
+            PREV_TAG=$(git tag --sort=-v:refname | grep '^v' | head -1 || true)
+            if [ -n "$PREV_TAG" ]; then
+              COMMITS=$(git log "$PREV_TAG"..HEAD --oneline --no-decorate)
+              COUNT=$(echo "$COMMITS" | grep -c . || true)
+            else
+              COMMITS=$(git log --oneline --no-decorate)
+              COUNT=$(echo "$COMMITS" | grep -c . || true)
+            fi
+            if [ -n "$COMMITS" ]; then
+              COMMIT_LIST=$(echo "$COMMITS" | sed 's/^/- /')
+              NOTES="$NOTES
+
+<details><summary>Commits since ${PREV_TAG:-initial} ($COUNT)</summary>
+
+$COMMIT_LIST
+
+</details>"
+            fi
+
             echo "Creating release $TAG (prerelease=$IS_PRE)..."
 
             FLAGS=""

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -177,6 +177,7 @@ jobs:
       - name: Stamp version from tag
         run: |
           VERSION="${{ needs.validate.outputs.version }}"
+          TAG="${{ needs.validate.outputs.tag }}"
           echo "Publishing version: $VERSION"
 
           # Stamp pubspec.yaml
@@ -190,7 +191,25 @@ jobs:
             cp CHANGELOG.pre.md CHANGELOG.md
           fi
 
+          # Auto-append commit list to the changelog for pub.dev
+          PREV_TAG=$(git tag --sort=-v:refname | grep '^v' | grep -v "^$TAG$" | head -1 || true)
+          if [ -n "$PREV_TAG" ]; then
+            COMMITS=$(git log "$PREV_TAG".."$TAG" --oneline --no-decorate)
+            COUNT=$(echo "$COMMITS" | grep -c . || true)
+          else
+            COMMITS=$(git log "$TAG" --oneline --no-decorate)
+            COUNT=$(echo "$COMMITS" | grep -c . || true)
+          fi
+          if [ -n "$COMMITS" ]; then
+            COMMIT_LIST=$(echo "$COMMITS" | sed 's/^/- /')
+            printf '\n<details><summary>Commits since %s (%s)</summary>\n\n%s\n\n</details>\n' \
+              "${PREV_TAG:-initial}" "$COUNT" "$COMMIT_LIST" >> CHANGELOG.md
+          fi
+
           echo "pubspec: $(grep '^version:' pubspec.yaml)"
+
+      - name: Generate asset hashes
+        run: fvm dart run tool/write_asset_hashes.dart ${{ needs.validate.outputs.tag }}
 
       - run: fvm dart pub get --no-example
       - run: fvm dart pub publish --force

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,33 +6,16 @@
   How to add a release:
   1. Add a new ## heading at the top with the version number
   2. Write a human summary of changes (for users, not developers)
-  3. Generate the commit list for the <details> block:
-       git log v<PREVIOUS_VERSION>..HEAD --oneline --no-decorate
-     Wrap the output in a <details> block and paste at the end of your entry
-  4. Commit, push to dev, PR dev → prod, merge
-  5. CI reads the version from the top ## heading, tags, and publishes
-
-  Format:
-    ## X.Y.Z
-    
-    Human-written summary of what changed and why it matters.
-    
-    ### Features / Bug Fixes / Breaking Changes / Performance
-    - Description of each change
-    
-    <details><summary>Commits since PREV (N)</summary>
-    
-    - abc1234 feat: thing that happened
-    - def5678 fix: thing that was fixed
-    
-    </details>
+  3. Commit, push to dev, PR dev → prod, merge
+  4. CI reads the version from the top ## heading, tags, and publishes
 
   Rules:
   - Version in ## heading is the ONLY source of truth for the release version
   - pubspec.yaml stays 0.0.0 — CI stamps it from this file at publish time
   - Each entry covers ALL changes since the previous ## heading in this file
-  - The <details> block is generated via: git log vPREV..HEAD --oneline --no-decorate
   - Prerelease entries go in CHANGELOG.pre.md, not here
+  - DO NOT add commit lists here — CI auto-appends them at publish time
+    (GitHub Release notes + pub.dev tarball get the commits dynamically)
 -->
 
 ## 1.0.0

--- a/CHANGELOG.pre.md
+++ b/CHANGELOG.pre.md
@@ -8,11 +8,8 @@
   2. Write a summary of what changed SINCE THE PREVIOUS ENTRY IN THIS FILE
      - First prerelease after a stable: changes since the last stable version
      - Subsequent prereleases: changes since the previous prerelease
-  3. Generate the commit list for the <details> block:
-       git log v<PREVIOUS_TAG>..HEAD --oneline --no-decorate
-     Wrap the output in a <details> block and paste at the end of your entry
-  4. Commit and push to dev
-  5. CI reads the version from the top ## heading, tags, and publishes as prerelease
+  3. Commit and push to dev (via PR)
+  4. CI reads the version from the top ## heading, tags, and publishes as prerelease
 
   Rules:
   - Version in ## heading is the source of truth for the prerelease version
@@ -22,6 +19,7 @@
   - When the stable release ships, write the full summary in CHANGELOG.md
     covering everything since the last stable — this file is not consulted
   - Entries here are permanent history — don't delete old entries
+  - DO NOT add commit lists here — CI auto-appends them at publish time
 -->
 
 ## 1.0.0-dev.0
@@ -66,70 +64,3 @@ Complete ground-up rewrite. New engine, new API, every platform. See the [migrat
 - Resource pruning on GC save
 - Images to PDF
 - 21 sugar methods on PdfOperations extension
-
-<details><summary>Commits since a99fbdb (62)</summary>
-
-- 95a196b build: update pdf_oxide submodule — watermark position/layer + comboBox fix
-- e814e6d Merge remote-tracking branch 'origin/dev' into chore/rename-main-to-prod
-- e547a68 fix(ci): handle large PR diffs in triage workflow
-- e154b4c docs: add 1.0.0-dev.0 prerelease changelog entry
-- 4f8d16a feat!: v1 architecture — symmetric dispatch, sealed types, behavioral tests, release system
-- ff59008 feat: streaming I/O for ALL ops + incremental writer + sign via editor
-- 846a67f refactor: shared split algorithms + O(n²) → O(k log n) splitBySize
-- f49835d feat: 200-page stress tests with splitBySize edge cases
-- 51aaf3b feat: stress tests + fix multi-page builder bug
-- b46ed40 feat: example covers all 37 Pdf methods + editor redaction
-- 479fbab fix: build hook PATH stripping + example app update
-- 2149445 fix: update example app + integration test for current API
-- 3886973 feat: tests for all new features + bookmarked PDF fixture
-- fbc9cd1 feat: Rust bridge handlers for bookmarks, classify, redaction
-- d07a9ee feat: wire upstream features — bookmarks, classify, convert, redaction
-- 80ebb12 docs: update UPDATING.md — branch rename step, v0.3.53 provenance
-- 890c793 build: sync upstream v0.3.53 + rebuild WASM
-- dcbbece feat: streaming I/O redesign — restructure, web parity, sealed sign API
-- d97803e feat: wire Layer 1 + delete old code (B20-B21)
-- 2d2b2dd feat: new bridge architecture — thread pool, condvar streaming, arena allocator
-- 7456369 chore: rename main → prod (workflows, docs, ruleset) (#26)
-- 3c1876e chore: simplify merge protection — native GitHub only, no rulesets
-- 645a2c3 feat: review policy CI check replaces rulesets
-- 3f799dc docs: fix stale workflow refs — pr-lint→pr-checks, Android→ubuntu
-- 0fd8b09 docs: re-stamp AGENTS.md — pr-lint.yml → pr-checks.yml, main → prod
-- ef5e821 docs: fix last two main → prod references (slopfairy review)
-- 7406e75 perf: sccache + mold + disable incremental for faster CI builds
-- d37ef5c ci: merge 3 PR workflows into one pr-checks.yml
-- 14f917f docs: fix remaining main → prod references (slopfairy review)
-- 17974a0 chore: update all workflow branches + docs from main → prod
-- 76e2917 chore: rename main → prod everywhere (branch, workflows, docs, ruleset)
-- 8dcc13f ci: commit-msg hook (merge blocker + printf), promotion-check, hooksPath docs (#23)
-- 074868f ci: fix release-please config and PR formatting (#21)
-- 945a51f ci: add release-please + tag-triggered release pipeline (#19)
-- e5e698e ci: enforce conventional commits via hook + PR title check (#17)
-- 67edc60 add pre-commit hook: reject commits with gitignored files
-- da16d8a untrack example/pubspec.lock (gitignored, should never have been tracked)
-- 9a3dc68 fix: .pubignore for vendor/ + compile WASM before web tests
-- 02e92a5 fix(ci): checkout in workflows before local composite actions
-- 55d9e58 ci: 10 composite actions, zero duplication, test-first flow
-- e6bf54b release: manual re-trigger + overwrite existing releases
-- 9328919 ci: split WASM into its own compile job
-- dfcd65f fix: WASM target + Rust warnings in release CI
-- 2dbb00e hook: rewrite using native_toolchain_rust patterns
-- 28daa58 hook: use StaticLinking for iOS + install both device and sim targets
-- c8f4bfe hook: set NDK linker for Android cargo cross-compilation
-- 4e72a4a ci: add x86_64-linux-android rust target for Android emulator tests
-- c9c26ab ci: fix android emulator-runner cd not persisting between commands
-- eef11c8 ci: commit .metadata, remove destructive flutter create
-- f144ba5 ci: fix Android + iOS integration test failures
-- 6b9e7d7 updating.md: add submodule commit discipline (3-step sequence)
-- bf50a39 submodule: update to include all Rust patches
-- 8fcec5f ci: fix pub get failure — skip example deps in Dart-only jobs
-- a62a36b roadmap: add upstream v0.3.48 office conversion features
-- 621f091 fix upstream URL + expand S1 bump recipe
-- 8e67064 provenance: link to fork repo + branch, document fork convention
-- b93b9ec v1.0.0 API redesign + web feature parity + doc cleanup
-- e7e0338 editor: add missing addStamp + addWatermarkPositioned wrappers
-- 4ba4264 fix migration guide + expand contributing
-- 0374c59 readme: feature×platform matrix, docs table, community files
-- c0e712c bump to 1.0.0, fix stale README references
-- 581e844 v1.0.0 — complete ground-up rewrite
-
-</details>

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -217,21 +217,25 @@ releases are skipped, pub.dev rejects duplicate versions.
 ### Stable release
 
 ```
-1. Add ## X.Y.Z at top of CHANGELOG.md
-2. git log v<PREV>..HEAD --oneline --no-decorate → paste in entry
-3. PR to prod → merge
-4. (automatic) create-release.yml → tag + GitHub Release
-5. (automatic) publish.yml → compile + upload + pub.dev
+1. Add ## X.Y.Z at top of CHANGELOG.md (human summary only, no commit list)
+2. PR to prod → merge
+3. (automatic) create-release.yml → tag + GitHub Release (commits auto-appended)
+4. (automatic) publish.yml → compile + upload + generate hashes + pub.dev (commits auto-appended)
 ```
 
 ### Prerelease
 
 ```
-1. Add ## X.Y.Z-dev.N at top of CHANGELOG.pre.md
-2. PR to dev → merge (or push to dev via PR)
-3. (automatic) create-release.yml → tag + GitHub Release
-4. (automatic) publish.yml → compile + upload + pub.dev
+1. Add ## X.Y.Z-dev.N at top of CHANGELOG.pre.md (human summary only, no commit list)
+2. PR to dev → merge
+3. (automatic) create-release.yml → tag + GitHub Release (commits auto-appended)
+4. (automatic) publish.yml → compile + upload + generate hashes + pub.dev (commits auto-appended)
 ```
+
+Commit lists are never in the changelog files. CI generates them
+dynamically from `git log` at release time — GitHub Release notes
+and pub.dev tarball each get fresh commit lists. Asset hashes are
+generated from the uploaded binaries before `dart pub publish`.
 
 ### Hotfix
 


### PR DESCRIPTION
## Summary
- Remove hardcoded commit lists from both changelog files — human summaries only
- `create-release.yml` auto-appends commit list to GitHub Release notes via `git log`
- `publish.yml` auto-appends commit list to changelog in working tree before `dart pub publish`
- `publish.yml` generates asset hashes from uploaded binaries before publish
- UPDATING.md updated to reflect the new flow

## Test plan
- [ ] Delete existing release + tag, merge this PR, retrigger create-release + publish
- [ ] GitHub Release shows commit list in notes
- [ ] pub.dev tarball includes commit list in CHANGELOG.md + populated asset_hashes.dart