### PR TITLE
fix: YAML syntax error in create-release.yml

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -115,13 +115,9 @@ jobs:
             fi
             if [ -n "$COMMITS" ]; then
               COMMIT_LIST=$(echo "$COMMITS" | sed 's/^/- /')
-              NOTES="$NOTES
-
-<details><summary>Commits since ${PREV_TAG:-initial} ($COUNT)</summary>
-
-$COMMIT_LIST
-
-</details>"
+              DETAILS_OPEN="<details><summary>Commits since ${PREV_TAG:-initial} ($COUNT)</summary>"
+              DETAILS_CLOSE="</details>"
+              printf -v NOTES '%s\n\n%s\n\n%s\n\n%s' "$NOTES" "$DETAILS_OPEN" "$COMMIT_LIST" "$DETAILS_CLOSE"
             fi
 
             echo "Creating release $TAG (prerelease=$IS_PRE)..."


### PR DESCRIPTION
## Summary
- Bare `<details>` HTML inside YAML `run:` block caused parse error
- Replaced with `printf` to build the string without inline HTML in YAML source
- Validated all 7 workflow files with `yaml.safe_load` — all pass

## Test plan
- [ ] create-release.yml no longer shows "Invalid workflow file" on push