### PR TITLE
fix: publish fails on dirty git + create-release YAML syntax

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -115,13 +115,9 @@ jobs:
             fi
             if [ -n "$COMMITS" ]; then
               COMMIT_LIST=$(echo "$COMMITS" | sed 's/^/- /')
-              NOTES="$NOTES
-
-<details><summary>Commits since ${PREV_TAG:-initial} ($COUNT)</summary>
-
-$COMMIT_LIST
-
-</details>"
+              DETAILS_OPEN="<details><summary>Commits since ${PREV_TAG:-initial} ($COUNT)</summary>"
+              DETAILS_CLOSE="</details>"
+              printf -v NOTES '%s\n\n%s\n\n%s\n\n%s' "$NOTES" "$DETAILS_OPEN" "$COMMIT_LIST" "$DETAILS_CLOSE"
             fi
 
             echo "Creating release $TAG (prerelease=$IS_PRE)..."

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -211,5 +211,10 @@ jobs:
       - name: Generate asset hashes
         run: fvm dart run tool/write_asset_hashes.dart ${{ needs.validate.outputs.tag }}
 
+      - name: Ephemeral commit (clean git for pub publish)
+        run: |
+          git add -A
+          git commit -m "stamp: ${{ needs.validate.outputs.tag }}" --allow-empty
+
       - run: fvm dart pub get --no-example
       - run: fvm dart pub publish --force

--- a/.pubignore
+++ b/.pubignore
@@ -9,3 +9,6 @@ example/pubspec.lock
 
 # Development files
 .gitmodules
+
+# Internal docs (consumers have README + API docs from dartdoc)
+docs/


### PR DESCRIPTION
## Summary
- Add ephemeral `git commit` after version/changelog/hash stamping so `dart pub publish` sees clean git
- Fix bare `<details>` HTML in create-release.yml (YAML parse error, PR #35 fix didn't stick)
- Add `docs/` to `.pubignore` — internal docs don't belong in pub.dev tarball
- All 7 workflow YAML files validated with `yaml.safe_load`

## Test plan
- [ ] Delete release + tag, merge, retrigger full flow
- [ ] publish.yml publishes to pub.dev without dirty-git error
- [ ] create-release.yml doesn't show "Invalid workflow file"