### PR TITLE
fix: false_secrets for test PEM keys + pin example .fvmrc

### DIFF
--- a/.github/workflows/flutter-upgrade.yml
+++ b/.github/workflows/flutter-upgrade.yml
@@ -81,15 +81,17 @@ jobs:
             git checkout -b "$BRANCH"
           fi
 
-          # Update .fvmrc
-          python3 -c "
+          # Update both .fvmrc files (root + example)
+          for fvmrc in .fvmrc example/.fvmrc; do
+            python3 -c "
           import json
-          with open('.fvmrc') as f: data = json.load(f)
+          with open('$fvmrc') as f: data = json.load(f)
           data['flutter'] = '$LATEST'
-          with open('.fvmrc', 'w') as f: json.dump(data, f, indent=2); f.write('\n')
+          with open('$fvmrc', 'w') as f: json.dump(data, f, indent=2); f.write('\n')
           "
+          done
 
-          git add .fvmrc
+          git add .fvmrc example/.fvmrc
           git commit -m "chore: bump Flutter $CURRENT → $LATEST" || {
             echo ".fvmrc already at $LATEST"
             exit 0

--- a/example/.fvmrc
+++ b/example/.fvmrc
@@ -1,4 +1,4 @@
 {
-  "flutter": "stable",
+  "flutter": "3.44.0",
   "flavors": {}
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,6 +47,10 @@ dependencies:
   # Web transport — JS interop via dart:js_interop types
   web: ^1.1.0
 
+false_secrets:
+  - /test/helpers/fixtures.dart
+  - /example/lib/main.dart
+
 dev_dependencies:
   # Test runner
   test: ^1.25.0


### PR DESCRIPTION
## Summary
- `false_secrets` in pubspec.yaml tells pub.dev the test PEM keys aren't real secrets
- Pin `example/.fvmrc` to `3.44.0` (was `"stable"`)
- `flutter-upgrade.yml` updates both `.fvmrc` files when a new version is detected

## Test plan
- [ ] Delete release + tag, merge, retrigger — pub.dev publish succeeds