### PR TITLE
fix: install snippets on release, generic version, cancel-in-progress

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,4 +1,8 @@
-# Release pipeline: tag → compile → upload → approve → publish.
+# Release pipeline: stamped tag → compile → upload → approve → publish.
+#
+# The tag is an orphan commit with stamped version + raw vendor source
+# (no submodule pointers). Compile jobs and git-tag consumers get a
+# self-contained tree. pub.dev tarball also ships vendor source.
 #
 # Automatic on changelog push. Manual via workflow_dispatch.
 # Publish job requires environment approval (human gate before pub.dev).
@@ -28,11 +32,18 @@ env:
   COMPILE_OUTPUT_DIR: out
 
 concurrency:
+  # github.event.inputs.branch (not bare inputs.branch) — top-level expressions
+  # are evaluated for ALL push events, not just workflow_dispatch. Bare inputs.*
+  # errors when the inputs context doesn't exist on push events.
   group: release-${{ github.event.inputs.branch || github.ref_name }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
-  # ── Find new versions + create tags ────────────────────────────────
+  # ── Discover version + create stamped tag ───────────────────────────
+  # Reads changelog → finds latest version → creates an orphan commit
+  # with stamped version + raw vendor source (no submodule pointers) →
+  # tags that commit → creates GitHub Release with notes.
+  # All downstream jobs checkout the tag and get a self-contained tree.
   discover:
     name: Discover versions
     runs-on: ubuntu-latest
@@ -45,6 +56,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ inputs.branch || github.ref_name }}
+          submodules: recursive
 
       - name: Find + create release
         id: find
@@ -84,33 +96,49 @@ jobs:
             exit 0
           fi
 
-          # Create release if it doesn't exist
+          # Skip if release already exists
           if gh release view "$TAG" --json tagName >/dev/null 2>&1; then
             echo "Release $TAG already exists."
-          else
-            NOTES=$(bash tool/stamp_release.sh "$TAG" --github-notes)
-            FLAGS=""
-            [[ "$IS_PRE" == "true" ]] && FLAGS="--prerelease"
-            gh release create "$TAG" \
-              --target "$BRANCH" \
-              --title "pdf_manipulator $VERSION" \
-              --notes "$NOTES" \
-              $FLAGS
-            echo "Created release $TAG"
+            echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+            echo "has_release=true" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+
+          # Create orphan stamped commit with raw vendor source
+          bash tool/stamp_release.sh "$TAG" --stamp-tag
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          STAMPED_SHA=$(git commit-tree -p HEAD -m "release: $TAG" $(git write-tree))
+          echo "Stamped commit: $STAMPED_SHA"
+
+          # Generate release notes and create release at the stamped commit
+          NOTES=$(bash tool/stamp_release.sh "$TAG" --github-notes)
+          FLAGS=""
+          [[ "$IS_PRE" == "true" ]] && FLAGS="--prerelease"
+          gh release create "$TAG" \
+            --target "$STAMPED_SHA" \
+            --title "pdf_manipulator $VERSION" \
+            --notes "$NOTES" \
+            $FLAGS
+          echo "Created release $TAG at $STAMPED_SHA"
 
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "has_release=true" >> "$GITHUB_OUTPUT"
 
   # ── Compile all targets ────────────────────────────────────────────
+  # Each job checks out the TAG (not the branch). The tag has raw vendor
+  # source — no submodules: recursive needed.
   compile-macos:
     needs: discover
     if: needs.discover.outputs.has_release == 'true'
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
-        with: { ref: '${{ needs.discover.outputs.tag }}', submodules: recursive }
+        with: { ref: '${{ needs.discover.outputs.tag }}' }
       - uses: ./.github/actions/compile-macos
       - uses: actions/upload-artifact@v4
         with: { name: bin-macos, path: out/ }
@@ -121,7 +149,7 @@ jobs:
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
-        with: { ref: '${{ needs.discover.outputs.tag }}', submodules: recursive }
+        with: { ref: '${{ needs.discover.outputs.tag }}' }
       - uses: ./.github/actions/compile-ios
       - uses: actions/upload-artifact@v4
         with: { name: bin-ios, path: out/ }
@@ -132,7 +160,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with: { ref: '${{ needs.discover.outputs.tag }}', submodules: recursive }
+        with: { ref: '${{ needs.discover.outputs.tag }}' }
       - uses: ./.github/actions/compile-android
       - uses: actions/upload-artifact@v4
         with: { name: bin-android, path: out/ }
@@ -143,7 +171,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with: { ref: '${{ needs.discover.outputs.tag }}', submodules: recursive }
+        with: { ref: '${{ needs.discover.outputs.tag }}' }
       - uses: ./.github/actions/compile-linux
       - uses: actions/upload-artifact@v4
         with: { name: bin-linux, path: out/ }
@@ -154,7 +182,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with: { ref: '${{ needs.discover.outputs.tag }}', submodules: recursive }
+        with: { ref: '${{ needs.discover.outputs.tag }}' }
       - uses: ./.github/actions/compile-wasm
       - uses: actions/upload-artifact@v4
         with: { name: bin-wasm, path: out/ }
@@ -165,7 +193,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
-        with: { ref: '${{ needs.discover.outputs.tag }}', submodules: recursive }
+        with: { ref: '${{ needs.discover.outputs.tag }}' }
       - uses: ./.github/actions/compile-windows
       - uses: actions/upload-artifact@v4
         with: { name: bin-windows, path: out/ }
@@ -205,8 +233,17 @@ jobs:
           files: release/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v4
+        with: { ref: '${{ needs.discover.outputs.tag }}' }
+      - name: Add git install snippet to release notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash tool/stamp_release.sh ${{ needs.discover.outputs.tag }} --add-git-install
 
   # ── Publish to pub.dev (requires approval) ─────────────────────────
+  # Runs AFTER you approve in the GitHub Environment gate.
+  # The tag already has stamped version + raw vendor source.
+  # This job only adds: filtered changelog for pub.dev + asset hashes.
   publish:
     name: Publish to pub.dev
     needs: [discover, upload-assets]
@@ -217,7 +254,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: '${{ needs.discover.outputs.tag }}'
-          submodules: recursive
           fetch-depth: 0
       - uses: dart-lang/setup-dart@v1
       - name: Install fvm + project SDK
@@ -237,3 +273,8 @@ jobs:
 
       - run: fvm dart pub get --no-example
       - run: fvm dart pub publish --force
+
+      - name: Add pub.dev install snippet to release notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash tool/stamp_release.sh ${{ needs.discover.outputs.tag }} --add-pub-install

--- a/.pubignore
+++ b/.pubignore
@@ -1,5 +1,8 @@
-# Vendor source (consumers use prebuilt binaries from GitHub Releases)
-vendor/
+# Vendor source: INCLUDED in pub.dev tarball so consumers can compile
+# from source as a fallback if pre-built binaries are unavailable.
+# Only exclude build artifacts and git metadata inside vendor.
+vendor/*/target/
+vendor/*/.git/
 
 # CI/CD
 .github/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
   Rules:
   - Version in ## heading is the ONLY source of truth for the release version
-  - pubspec.yaml stays 0.0.0 — CI stamps it from this file at publish time
+  - pubspec.yaml stays 0.0.0 in git — CI stamps it on the release tag commit
   - Each entry covers ALL changes since the previous ## heading in this file
   - Prerelease entries go in CHANGELOG.pre.md, not here
   - DO NOT add commit lists here — CI auto-appends them at publish time

--- a/CHANGELOG.pre.md
+++ b/CHANGELOG.pre.md
@@ -14,8 +14,9 @@
   Rules:
   - Version in ## heading is the source of truth for the prerelease version
   - Each entry covers changes since the PREVIOUS entry in THIS file (not CHANGELOG.md)
-  - pub.dev shows this file as CHANGELOG.md for the prerelease version
-    (CI copies this file to CHANGELOG.md in the published tarball)
+  - pub.dev gets a FILTERED version of this file as CHANGELOG.md:
+    only versions published on pub.dev + the current one are included,
+    unpublished intermediate versions are merged into collapsibles
   - When the stable release ships, write the full summary in CHANGELOG.md
     covering everything since the last stable — this file is not consulted
   - Entries here are permanent history — don't delete old entries

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ fvm dart pub get
 fvm dart test            # build hook compiles Rust from source automatically
 ```
 
-**Requires:** [Rust](https://rustup.rs), [FVM](https://fvm.app) (`.fvmrc` pins to stable). The build hook detects `vendor/pdf_oxide/Cargo.toml` and runs `cargo build`. No manual compilation step.
+**Requires:** [Rust](https://rustup.rs), [FVM](https://fvm.app) (`.fvmrc` pins the exact Flutter version). The build hook detects `vendor/pdf_oxide/Cargo.toml` and runs `cargo build`. No manual compilation step.
 
 **Without FVM:** all Makefile commands accept `DART` and `FLUTTER` overrides:
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Cross-platform PDF manipulation for Dart & Flutter. Merge, split, render, extrac
 
 - [Install](#install)
 - [Quick start](#quick-start)
+- [Sources & sinks](#sources--sinks)
 - [What you can do](#what-you-can-do)
   - [Combine & split](#combine--split)
   - [Read & query](#read--query)
@@ -49,20 +50,28 @@ import 'package:pdf_manipulator/pdf_manipulator.dart';
 
 final pdf = Pdf();
 
-// Open and inspect
+// Open a PDF from bytes in memory
+final source = MemorySource(pdfBytes);      // your Uint8List
 final doc = await pdf.open(source);
-print('${doc.pageCount} pages, v${doc.version}');
-final text = await doc.extract(pages: PdfPages.all());
+print('${doc.pageCount} pages');
 await doc.dispose();
 
-// One-shot operations
-await pdf.merge([sourceA, sourceB], outputSink);
-await pdf.watermark(source, sink, text: 'DRAFT');
+// Merge two PDFs into one
+final output = MemorySink();
+await pdf.merge([sourceA, sourceB], output);
+final mergedBytes = output.takeBytes();
 
+// Always dispose when done
 pdf.dispose();
 ```
 
-`source` is a `DataSource` — random-access byte source. The engine reads arbitrary offsets (xref at end of file, objects scattered throughout), so forward-only pipes (one-shot sockets, stdin) can't be used directly — buffer them first. `outputSink` is a `DataSink` — receives sequential chunks. Two interfaces, two methods each:
+That's it. Every operation follows the same pattern: **source in, sink out**.
+
+---
+
+## Sources & sinks
+
+A `DataSource` is where the PDF bytes come from. A `DataSink` is where the output goes. Two tiny interfaces:
 
 ```dart
 abstract interface class DataSource {
@@ -75,16 +84,11 @@ abstract interface class DataSink {
 }
 ```
 
-Wrap whatever you have — `Uint8List` for memory, `RandomAccessFile` for disk, `Blob.slice` for web file pickers, HTTP Range requests for servers. The engine reads at most 64KB per `readAt` call, never the whole file. Constant memory regardless of file size.
-
-<details>
-<summary>Example implementations (memory, file, HTTP, web blob)</summary>
+The simplest implementations — good for getting started:
 
 ```dart
-// Memory — tests, small files
 class MemorySource implements DataSource {
   MemorySource(this._data);
-
   final Uint8List _data;
 
   @override
@@ -92,8 +96,7 @@ class MemorySource implements DataSource {
 
   @override
   Uint8List readAt(int offset, int count) =>
-      Uint8List.sublistView(
-        _data, offset, (offset + count).clamp(0, _data.length));
+      Uint8List.sublistView(_data, offset, (offset + count).clamp(0, _data.length));
 }
 
 class MemorySink implements DataSink {
@@ -105,6 +108,11 @@ class MemorySink implements DataSink {
   Uint8List takeBytes() => _buf.takeBytes();
 }
 ```
+
+Wrap whatever you have — `Uint8List` for memory, `RandomAccessFile` for disk, `Blob.slice` for web file pickers, HTTP Range requests for remote files. The engine reads at most 64KB per call, never the whole file. Constant memory regardless of file size.
+
+<details>
+<summary>More implementations: file, HTTP, web blob</summary>
 
 ```dart
 // File — mobile/desktop, constant memory for any size
@@ -172,6 +180,8 @@ class BlobSource implements DataSource {
 
 </details>
 
+> **Note:** `DataSource` is random-access — the engine jumps to arbitrary positions in the file. Forward-only streams (like a network socket or stdin) need to be buffered into memory or disk first.
+
 ---
 
 ## What you can do
@@ -206,7 +216,7 @@ await pdf.movePage(source, sink, from: 0, to: 4);
 
 ### Read & query
 
-Open a PDF once, run any number of queries, dispose when done. All queries go through the `PdfDoc` handle:
+Open a PDF once, run any number of queries, dispose when done:
 
 ```dart
 final doc = await pdf.open(source);
@@ -433,17 +443,26 @@ Every error is a typed subclass of `PdfError`. No string matching. No `PlatformE
 
 ## Platforms
 
-### Native
+| Platform | Architectures | Engine |
+|---|---|---|
+| macOS | arm64, x64 | Native (Rust) |
+| iOS | arm64 device, arm64 + x64 simulator | Native (Rust) |
+| Android | arm64, arm, x64, x86 | Native (Rust) |
+| Linux | x64, arm64 | Native (Rust) |
+| Windows | x64, arm64 | Native (Rust) |
+| Web | All modern browsers | WASM |
 
-| Platform | Architectures |
-|---|---|
-| macOS | arm64, x64 |
-| iOS | arm64, simulator (arm64, x64) |
-| Android | arm64, arm, x86_64, x86 |
-| Linux | x64, arm64 |
-| Windows | x64, arm64 |
+### How native binaries are resolved
 
-The PDF engine is compiled Rust. For consumers (installed via pub.dev), the build hook downloads a pre-built binary from GitHub Releases automatically — no Rust toolchain needed. For contributors (cloned with `--recursive`), it compiles from the vendored source.
+The build hook resolves the native library automatically — no manual steps:
+
+| Priority | Method | When | Requires |
+|:---:|---|---|---|
+| 1 | **Pre-built binary** | Default for pub.dev + git tag users | Nothing |
+| 2 | **Source compile** | Binary unavailable (fallback) | [Rust](https://rustup.rs) |
+| 3 | **Submodule init** | Git dep `ref: dev` (no vendor dir) | [Rust](https://rustup.rs) + git |
+
+The vendored Rust source ships in both the pub.dev tarball and git tags. If the repo disappears, published versions still compile from source.
 
 ### Web
 
@@ -457,7 +476,7 @@ Works out of the box on all modern browsers:
 | Chrome Android | 102+ | May 2022 |
 | Samsung Internet | 21+ | 2023 |
 
-Run once after install (and after each package update):
+**Setup** — run once after install (and after each package update):
 
 ```sh
 dart run pdf_manipulator:setup
@@ -465,26 +484,26 @@ dart run pdf_manipulator:setup
 
 The engine compiles to WASM and runs in a Web Worker pool. Your UI thread never does PDF work.
 
-Three I/O modes, auto-detected (best first):
+### Web I/O modes
 
-| Mode | What it does | Requires |
-|---|---|---|
-| **JSPI** | True streaming via WebAssembly promise suspension | Chrome 137+ / Firefox 139+ |
-| **Atomics** | True streaming via SharedArrayBuffer | COOP/COEP headers (see below) |
-| **OPFS** | Pre-copies entire source to disk, then processes (O(N) latency + disk) | All modern browsers |
+Three modes, auto-detected (best first). No code changes between them:
 
-The package detects which mode is available and picks the best one automatically. No code changes needed. To force a specific mode:
+| Mode | How it works | Streaming | Requires |
+|---|---|:---:|---|
+| **JSPI** | WASM promise suspension | ✅ | Chrome 137+ · Firefox 139+ |
+| **Atomics** | SharedArrayBuffer blocking | ✅ | COOP/COEP headers |
+| **OPFS** | Pre-copy to disk, then process | ❌ | All modern browsers |
+
+Force a mode or check which was selected:
 
 ```dart
+// Force
 final pdf = Pdf(config: PdfConfig(webIoMode: PdfIoMode.atomics));
-```
 
-To check which mode was selected (useful for detecting OPFS fallback):
-
-```dart
+// Check
 final mode = await pdf.ensureInitialized();
 if (mode == PdfIoMode.opfs) {
-  // OPFS mode: pre-copies each source to disk before processing.
+  // OPFS: pre-copies each source to disk before processing.
   // Slower first byte + uses disk quota vs streaming modes.
   // To get streaming: deploy with COOP/COEP headers (Atomics)
   // or target Chrome 137+ / Firefox 139+ (JSPI auto-detected).
@@ -492,7 +511,7 @@ if (mode == PdfIoMode.opfs) {
 ```
 
 <details>
-<summary>Advanced: faster web with COOP/COEP headers (has trade-offs)</summary>
+<summary>Advanced: COOP/COEP headers for Atomics on older browsers</summary>
 
 By default on browsers without JSPI support, the package copies your PDF to temporary disk storage (OPFS) before processing — works everywhere, no server config needed.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -212,11 +212,12 @@ web_assets/                                 ← committed in git, shipped to web
 └── pdf_oxide_bg.wasm                       ← WASM binary (one binary, all 3 modes)
 
 hook/
-└── build.dart                              ← compile from source OR download pre-built
+└── build.dart                              ← binary-first → source-fallback → submodule-init
 
 tool/
 ├── compile_rust.sh                         ← Rust → native / wasm / per-platform / both
-├── stamp_release.sh                        ← stamp version + changelog + hashes before publish
+├── stamp_release.sh                        ← 5 modes: --stamp-tag, --github-notes, (default),
+│                                              --add-git-install, --add-pub-install
 ├── run_web_test.sh                         ← flutter drive wrapper with clean exit
 └── chrome_with_sab.sh                      ← Chrome launcher with SharedArrayBuffer
 

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -209,18 +209,25 @@ Publish to pub.dev requires human approval via GitHub Environments.
 Changelog push to dev or prod
   → create-release.yml (automatic)
     1. Scan changelog for the latest version
-    2. Create tag + GitHub Release (if not exists, idempotent)
-    3. Compile all 6 targets in parallel
-    4. Upload binaries to GitHub Release
-    5. ⏸ PAUSE — publish job waits for approval (GitHub Environment gate)
-    6. You approve → stamp_release.sh runs:
-       - stamps version into pubspec.yaml + version.dart
-       - builds CHANGELOG.md for pub.dev (filters unpublished versions,
-         merges their content into collapsibles, appends commit list
-         since last pub.dev version)
+    2. Create orphan stamped commit:
+       - stamp version into pubspec.yaml + version.dart
+       - convert submodule pointers to raw vendor source
+       - remove .gitmodules
+    3. Create tag + GitHub Release at that commit
+    4. Compile all 6 targets in parallel (checkout tag — no submodules needed)
+    5. Upload binaries + add git install snippet to release notes
+    6. ⏸ PAUSE — publish job waits for approval (GitHub Environment gate)
+    7. You approve → stamp_release.sh runs:
+       - builds filtered CHANGELOG.md for pub.dev (only published versions +
+         current, unpublished intermediate versions merged into collapsibles,
+         commit list since last pub.dev version)
        - generates asset hashes from GitHub Release API
-    7. dart pub publish
+    8. dart pub publish + add pub.dev install snippet to release notes
 ```
+
+The tag is self-contained: stamped version + raw vendor source (no
+submodule pointers). Git tag consumers (`ref: vX.Y.Z`) get the same
+tree as pub.dev consumers. Compile jobs don't need submodule init.
 
 Idempotent. Rerun skips existing releases, clobbers existing assets,
 pub.dev rejects duplicate versions.

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -57,41 +57,83 @@ void main(List<String> args) async {
         .libraryFileName(_crateName, linkMode);
     final outFile = File.fromUri(input.outputDirectory.resolve(libFileName));
 
+    // Resolution order:
+    // 1. Try pre-built binary (fast, no toolchain needed)
+    // 2. Compile from source if vendor/pdf_oxide exists
+    // 3. Init submodules if .gitmodules exists (git dep with ref: dev)
+    // 4. Clear error with options
+
     final cargoToml = File.fromUri(
       input.packageRoot.resolve('vendor/pdf_oxide/Cargo.toml'),
     );
+    final version = _readVersion(input.packageRoot);
+    final isDevVersion = version == '0.0.0';
 
-    if (cargoToml.existsSync()) {
+    // Step 1: Try pre-built binary (skip for 0.0.0 — no release exists)
+    if (!isDevVersion) {
+      final downloaded = await _tryDownloadPrebuilt(
+        input, codeConfig, libFileName, outFile,
+      );
+      if (downloaded) {
+        // Success — skip to asset registration below
+      } else if (cargoToml.existsSync()) {
+        // Step 2: Binary unavailable, but source exists — compile
+        _log.warning(
+          'Pre-built binary unavailable. Compiling from source '
+          '(requires Rust toolchain).',
+        );
+        await _compileFromSource(input, targetTriple, linkMode, outFile);
+      } else {
+        throw StateError(
+          'Pre-built binary unavailable and no Rust source found.\n\n'
+          'Options:\n'
+          '  1. Use a published version: pdf_manipulator: ^X.Y.Z\n'
+          '  2. Use a git tag with binaries: ref: vX.Y.Z\n'
+          '  3. Clone with --recursive and use a path dependency\n',
+        );
+      }
+    } else if (cargoToml.existsSync()) {
+      // Step 2: Dev version (0.0.0) with source — compile directly
       await _compileFromSource(input, targetTriple, linkMode, outFile);
     } else {
-      // Consumer path: download prebuilt binary, cached in shared output dir.
-      // Pattern from sqlite3.dart — cache survives across builds of the same
-      // version. SHA256 verification catches corruption or stale cache.
-      final platform = _platformKey(codeConfig);
-      final assetKey = '$platform-$libFileName';
-      final cachedFile = File.fromUri(
-        input.outputDirectoryShared.resolve(libFileName),
+      // Step 3: Dev version, no source — try init submodules (git dep user)
+      final gitmodules = File.fromUri(
+        input.packageRoot.resolve('.gitmodules'),
       );
-
-      if (cachedFile.existsSync()) {
-        final expectedHash = assetHashesSha256[assetKey];
-        if (expectedHash != null) {
-          final actualHash = sha256.convert(await cachedFile.readAsBytes()).toString();
-          if (actualHash == expectedHash) {
-            _log.info('using cached ${cachedFile.path} (hash verified)');
-          } else {
-            _log.info('cached file hash mismatch — re-downloading');
-            await _downloadPrebuilt(input, codeConfig, libFileName, cachedFile);
-          }
-        } else {
-          _log.info('using cached ${cachedFile.path} (no hash to verify)');
+      if (gitmodules.existsSync()) {
+        _log.warning(
+          'No pre-built binary for dev version. Initializing submodules '
+          'and compiling from source (requires Rust toolchain).',
+        );
+        final initResult = await Process.run(
+          'git',
+          ['submodule', 'update', '--init', '--recursive'],
+          workingDirectory: p.fromUri(input.packageRoot),
+        );
+        if (initResult.exitCode != 0) {
+          throw StateError(
+            'Failed to initialize submodules.\n'
+            'stderr: ${initResult.stderr}\n\n'
+            'Clone manually with --recursive and use a path dependency.',
+          );
         }
+        if (!cargoToml.existsSync()) {
+          throw StateError(
+            'Submodules initialized but vendor/pdf_oxide/Cargo.toml '
+            'still missing. The submodule may be misconfigured.',
+          );
+        }
+        await _compileFromSource(input, targetTriple, linkMode, outFile);
       } else {
-        await _downloadPrebuilt(input, codeConfig, libFileName, cachedFile);
+        // Step 4: No binary, no source, no submodules — nothing we can do
+        throw StateError(
+          'No pre-built binary and no Rust source available.\n\n'
+          'Options:\n'
+          '  1. Use a published version: pdf_manipulator: ^X.Y.Z\n'
+          '  2. Use a git tag with binaries: ref: vX.Y.Z\n'
+          '  3. Clone with --recursive and use a path dependency\n',
+        );
       }
-
-      outFile.parent.createSync(recursive: true);
-      cachedFile.copySync(outFile.path);
     }
 
     output.assets.code.add(
@@ -217,9 +259,9 @@ Future<void> _compileFromSource(
   _log.info('compiled → ${outFile.path}');
 }
 
-// ── Path 2: Download from GitHub Releases ──────────────────────────────
+// ── Path 1: Try download from GitHub Releases (returns false on 404) ────
 
-Future<void> _downloadPrebuilt(
+Future<bool> _tryDownloadPrebuilt(
   BuildInput input,
   CodeConfig codeConfig,
   String libFileName,
@@ -227,8 +269,33 @@ Future<void> _downloadPrebuilt(
 ) async {
   final version = _readVersion(input.packageRoot);
   final platform = _platformKey(codeConfig);
-  final url = '$_releaseRepo/v$version/$platform-$libFileName';
+  final assetKey = '$platform-$libFileName';
+  final cachedFile = File.fromUri(
+    input.outputDirectoryShared.resolve(libFileName),
+  );
 
+  // Check cache first
+  if (cachedFile.existsSync()) {
+    final expectedHash = assetHashesSha256[assetKey];
+    if (expectedHash != null) {
+      final actualHash = sha256.convert(await cachedFile.readAsBytes()).toString();
+      if (actualHash == expectedHash) {
+        _log.info('using cached ${cachedFile.path} (hash verified)');
+        outFile.parent.createSync(recursive: true);
+        cachedFile.copySync(outFile.path);
+        return true;
+      }
+      _log.info('cached file hash mismatch — re-downloading');
+    } else {
+      _log.info('using cached ${cachedFile.path} (no hash to verify)');
+      outFile.parent.createSync(recursive: true);
+      cachedFile.copySync(outFile.path);
+      return true;
+    }
+  }
+
+  // Download
+  final url = '$_releaseRepo/v$version/$platform-$libFileName';
   _log.info('downloading $url');
 
   final client = HttpClient();
@@ -251,26 +318,22 @@ Future<void> _downloadPrebuilt(
 
     if (response.statusCode != 200) {
       await response.drain<void>();
-      throw StateError(
-        'Failed to download pre-built binary.\n'
-        'URL: $url\n'
-        'Status: ${response.statusCode}\n\n'
-        'This usually means pre-built binaries are not available for this version.\n\n'
-        'Options:\n'
-        '  1. Use a published version from pub.dev: pdf_manipulator: ^1.0.0\n'
-        '  2. Use a git tag that has binaries: ref: v1.0.0-dev.0\n'
-        '     (check the GitHub Releases page for tags with binary assets)\n'
-        '  3. Compile from source (requires Rust toolchain):\n'
-        '       git clone --recursive https://github.com/whuppi/pdf_manipulator.git\n'
-        '       # Then use a path dependency in your pubspec.yaml\n',
-      );
+      _log.info('binary not available (HTTP ${response.statusCode})');
+      return false;
     }
 
-    outFile.parent.createSync(recursive: true);
-    final sink = outFile.openWrite();
+    cachedFile.parent.createSync(recursive: true);
+    final sink = cachedFile.openWrite();
     await response.pipe(sink);
-    final mb = (outFile.lengthSync() / 1024 / 1024).toStringAsFixed(1);
-    _log.info('downloaded ${outFile.path} ($mb MB)');
+    final mb = (cachedFile.lengthSync() / 1024 / 1024).toStringAsFixed(1);
+    _log.info('downloaded ${cachedFile.path} ($mb MB)');
+
+    outFile.parent.createSync(recursive: true);
+    cachedFile.copySync(outFile.path);
+    return true;
+  } catch (e) {
+    _log.warning('download failed: $e');
+    return false;
   } finally {
     client.close();
   }

--- a/tool/stamp_release.sh
+++ b/tool/stamp_release.sh
@@ -1,23 +1,41 @@
 #!/bin/bash
-# Stamp all release artifacts for a given tag. Single source of truth.
-# Called by CI before publish AND usable locally.
+# Single source of truth for all release stamping. Called by CI and usable locally.
 #
 # Usage:
-#   ./tool/stamp_release.sh <tag> [--github-notes]
+#   ./tool/stamp_release.sh <tag> [mode]
 #
-# Modes:
-#   <tag>                  Stamp for pub.dev publish (version + changelog + hashes)
-#   <tag> --github-notes   Print GitHub Release notes to stdout (changelog + commits)
+# Modes (5):
+#   --stamp-tag               Prepare tree for the release tag commit:
+#                              - Stamp version into pubspec.yaml + version.dart
+#                              - Convert submodule pointers to raw source files
+#                              - Remove .gitmodules
+#                              Called by CI discover job BEFORE git commit-tree.
 #
-# What "stamp for publish" does (in order):
-#   1. Stamps version into pubspec.yaml
-#   2. Stamps version into lib/src/version.dart
-#   3. Builds CHANGELOG.md for pub.dev:
-#      - For prereleases: starts from CHANGELOG.pre.md
-#      - Filters to only versions published on pub.dev + current
-#      - Merges unpublished intermediate versions into collapsibles
-#      - Appends commit list since last pub.dev version
-#   4. Generates asset hashes from GitHub Release API
+#   --github-notes            Print GitHub Release notes to stdout:
+#                              - Extract changelog entry for this version
+#                              - Append commit list since previous tag
+#                              Called by CI discover job for gh release create --notes.
+#
+#   (default, no flag)        Stamp for pub.dev publish:
+#                              - Re-stamp version (idempotent, tag already has it)
+#                              - Build filtered CHANGELOG.md for pub.dev:
+#                                only versions published on pub.dev + current,
+#                                unpublished intermediate versions merged into
+#                                collapsibles, commit list since last pub.dev version
+#                              - Generate asset hashes from GitHub Release API
+#                              Called by CI publish job AFTER approval.
+#
+#   --add-git-install         Append git tag install snippet to GitHub Release notes.
+#                              Called by CI after binary upload.
+#
+#   --add-pub-install         Append pub.dev install snippet to GitHub Release notes.
+#                              Called by CI after pub.dev publish.
+#
+# Release pipeline flow (for context):
+#   1. discover:  --stamp-tag → git commit-tree → --github-notes → gh release create
+#   2. compile:   checkout tag (has raw source, no submodules needed)
+#   3. upload:    binaries to release → --add-git-install
+#   4. publish:   (default) stamp → dart pub publish → --add-pub-install
 #
 # Requires: gh CLI authenticated (GH_TOKEN env var or gh auth login)
 # Run from package root.
@@ -25,18 +43,100 @@
 set -euo pipefail
 
 if [ -z "${1:-}" ]; then
-  echo "Usage: $0 <tag> [--github-notes]"
+  echo "Usage: $0 <tag> [mode]"
+  echo "Modes: (none)=stamp, --github-notes, --add-git-install, --add-pub-install"
   echo "Example: $0 v1.0.0-dev.0"
-  echo "Example: $0 v1.0.0-dev.0 --github-notes"
   exit 1
 fi
 
 TAG="$1"
 VERSION="${TAG#v}"
+MODE="${2:---stamp}"
 REPO="${GITHUB_REPOSITORY:-whuppi/pdf_manipulator}"
-GITHUB_NOTES_MODE=false
-if [[ "${2:-}" == "--github-notes" ]]; then
-  GITHUB_NOTES_MODE=true
+REPO_URL="https://github.com/$REPO"
+
+# ── Stamp tag mode: prepare the tree for a release tag commit ───────
+# Stamps version + converts submodule pointers to raw source files.
+# Called BEFORE git commit-tree in the CI discover job.
+
+if [[ "$MODE" == "--stamp-tag" ]]; then
+  if [[ -z "${CI:-}" && -z "${GITHUB_ACTIONS:-}" ]]; then
+    echo "⚠ --stamp-tag modifies the working tree (version stamp + submodule de-registration)."
+    echo "  This is intended for CI only. Ctrl+C to abort, or press Enter to continue."
+    read -r
+  fi
+  echo "=== Stamping tag tree for $TAG ==="
+
+  # Stamp version
+  sed -i.bak "s/^version: .*/version: $VERSION/" pubspec.yaml && rm -f pubspec.yaml.bak
+  echo "  pubspec.yaml → $VERSION"
+
+  sed -i.bak "s/const packageVersion = '[^']*'/const packageVersion = '$VERSION'/" lib/src/version.dart && rm -f lib/src/version.dart.bak
+  echo "  version.dart → $VERSION"
+
+  # Convert submodule pointers to raw source files.
+  # The checkout already has submodules initialized (recursive checkout).
+  # We de-register the submodules so git treats vendor/ as regular files.
+  for sub in vendor/pdf_oxide vendor/office_oxide; do
+    if [ -d "$sub/.git" ] || [ -f "$sub/.git" ]; then
+      # Remove submodule registration so git tracks files directly
+      git rm --cached "$sub" 2>/dev/null || true
+      rm -rf "$sub/.git"
+      git add "$sub/"
+      echo "  $sub → raw source (de-registered submodule)"
+    fi
+  done
+
+  # Remove .gitmodules (not needed when source is inline)
+  if [ -f .gitmodules ]; then
+    git rm --cached .gitmodules 2>/dev/null || true
+    rm -f .gitmodules
+    echo "  .gitmodules removed"
+  fi
+
+  echo "=== Tag tree ready ==="
+  exit 0
+fi
+
+# ── Quick modes that just edit the GitHub Release notes ─────────────
+
+if [[ "$MODE" == "--add-git-install" ]]; then
+  EXISTING=$(gh release view "$TAG" --repo "$REPO" --json body --jq '.body')
+  SNIPPET="---
+
+### Install (git tag)
+
+\`\`\`yaml
+dependencies:
+  pdf_manipulator:
+    git:
+      url: $REPO_URL.git
+      ref: $TAG
+\`\`\`"
+  gh release edit "$TAG" --repo "$REPO" --notes "$EXISTING"$'\n\n'"$SNIPPET"
+  echo "Added git install snippet to $TAG release notes"
+  exit 0
+fi
+
+if [[ "$MODE" == "--add-pub-install" ]]; then
+  EXISTING=$(gh release view "$TAG" --repo "$REPO" --json body --jq '.body')
+  SNIPPET="### Install (pub.dev)
+
+\`\`\`yaml
+dependencies:
+  pdf_manipulator: ^$VERSION
+\`\`\`"
+  gh release edit "$TAG" --repo "$REPO" --notes "$EXISTING"$'\n\n'"$SNIPPET"
+  echo "Added pub.dev install snippet to $TAG release notes"
+  exit 0
+fi
+
+# ── Guard: reject unknown modes before falling through to stamp ──────
+
+if [[ "$MODE" == --* && "$MODE" != "--stamp" ]]; then
+  echo "Unknown mode: $MODE"
+  echo "Valid modes: (none), --stamp-tag, --github-notes, --add-git-install, --add-pub-install"
+  exit 1
 fi
 
 # ── Helper: get published versions from pub.dev ─────────────────────
@@ -72,7 +172,7 @@ get_changelog_versions() {
 # MODE: GitHub Release notes
 # ═════════════════════════════════════════════════════════════════════
 
-if [[ "$GITHUB_NOTES_MODE" == "true" ]]; then
+if [[ "$MODE" == "--github-notes" ]]; then
   # Determine changelog file
   if [[ "$VERSION" == *-* ]]; then
     FILE="CHANGELOG.pre.md"


### PR DESCRIPTION
## Summary
- After binaries upload: git tag install snippet appended to GitHub Release notes
- After pub.dev publish: pub.dev install snippet appended to GitHub Release notes
- build.dart: generic `^X.Y.Z` instead of hardcoded `^1.0.0` in error message
- Concurrency: `cancel-in-progress: true` + comment explaining `github.event.inputs` quirk
- Addresses slopfairy's review suggestions from PR #42

## Test plan
- [ ] Delete release + tag, merge, retrigger — release notes show install snippets progressively