### PR TITLE
fix: push stamped commit before creating release tag

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -111,8 +111,12 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A
-          STAMPED_SHA=$(git commit-tree -p HEAD -m "release: $TAG" $(git write-tree))
+          git commit -m "release: $TAG"
+          STAMPED_SHA=$(git rev-parse HEAD)
           echo "Stamped commit: $STAMPED_SHA"
+
+          # Push the stamped commit so GitHub knows about it before we create the tag
+          git push origin "$STAMPED_SHA:refs/heads/_release-staging"
 
           # Generate release notes and create release at the stamped commit
           NOTES=$(bash tool/stamp_release.sh "$TAG" --github-notes)
@@ -124,6 +128,9 @@ jobs:
             --notes "$NOTES" \
             $FLAGS
           echo "Created release $TAG at $STAMPED_SHA"
+
+          # Clean up the staging branch (tag holds the reference now)
+          git push origin --delete refs/heads/_release-staging 2>/dev/null || true
 
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
gh release create --target SHA fails when the SHA only exists locally. Push to a temp branch first, create the release, then delete the branch.