### PR TITLE
fix: force-push temp branch + stale comment refs

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -115,8 +115,8 @@ jobs:
           STAMPED_SHA=$(git rev-parse HEAD)
           echo "Stamped commit: $STAMPED_SHA"
 
-          # Push the stamped commit so GitHub knows about it before we create the tag
-          git push origin "$STAMPED_SHA:refs/heads/_release-staging"
+          # Push stamped commit so GitHub knows about it (local-only commits can't be tagged)
+          git push origin --force "$STAMPED_SHA:refs/heads/_release-staging"
 
           # Generate release notes and create release at the stamped commit
           NOTES=$(bash tool/stamp_release.sh "$TAG" --github-notes)
@@ -129,7 +129,7 @@ jobs:
             $FLAGS
           echo "Created release $TAG at $STAMPED_SHA"
 
-          # Clean up the staging branch (tag holds the reference now)
+          # Clean up staging branch (tag holds the reference now)
           git push origin --delete refs/heads/_release-staging 2>/dev/null || true
 
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"

--- a/tool/stamp_release.sh
+++ b/tool/stamp_release.sh
@@ -9,7 +9,7 @@
 #                              - Stamp version into pubspec.yaml + version.dart
 #                              - Convert submodule pointers to raw source files
 #                              - Remove .gitmodules
-#                              Called by CI discover job BEFORE git commit-tree.
+#                              Called by CI discover job BEFORE git commit.
 #
 #   --github-notes            Print GitHub Release notes to stdout:
 #                              - Extract changelog entry for this version
@@ -32,7 +32,7 @@
 #                              Called by CI after pub.dev publish.
 #
 # Release pipeline flow (for context):
-#   1. discover:  --stamp-tag → git commit-tree → --github-notes → gh release create
+#   1. discover:  --stamp-tag → git commit → push temp branch → --github-notes → gh release create
 #   2. compile:   checkout tag (has raw source, no submodules needed)
 #   3. upload:    binaries to release → --add-git-install
 #   4. publish:   (default) stamp → dart pub publish → --add-pub-install
@@ -57,7 +57,7 @@ REPO_URL="https://github.com/$REPO"
 
 # ── Stamp tag mode: prepare the tree for a release tag commit ───────
 # Stamps version + converts submodule pointers to raw source files.
-# Called BEFORE git commit-tree in the CI discover job.
+# Called BEFORE git commit in the CI discover job.
 
 if [[ "$MODE" == "--stamp-tag" ]]; then
   if [[ -z "${CI:-}" && -z "${GITHUB_ACTIONS:-}" ]]; then


### PR DESCRIPTION
Slopfairy PR#45 review: --force on temp branch push (cancelled runs leave it behind), update commit-tree → commit in comments.