### PR TITLE
fix: auto-detect wasm-bindgen-cli version from Cargo.lock

### DIFF
--- a/.github/actions/compile-wasm/action.yml
+++ b/.github/actions/compile-wasm/action.yml
@@ -7,9 +7,7 @@ runs:
     - uses: ./.github/actions/setup-rust
       with: { targets: wasm32-unknown-unknown }
     - shell: bash
-      run: |
-        cargo install wasm-bindgen-cli --version 0.2.121
-        sudo apt-get update && sudo apt-get install -y binaryen
+      run: sudo apt-get update && sudo apt-get install -y binaryen
     - shell: bash
       run: bash tool/compile_rust.sh wasm
     - shell: bash

--- a/.github/actions/setup-web-testing/action.yml
+++ b/.github/actions/setup-web-testing/action.yml
@@ -62,7 +62,6 @@ runs:
     # ── WASM toolchain + build ──
     - shell: bash
       run: |
-        cargo install wasm-bindgen-cli --version 0.2.121
         sudo apt-get update && sudo apt-get install -y binaryen xvfb
     - shell: bash
       run: make build-wasm

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -17,7 +17,9 @@ patch branch. `main` on each fork stays a clean mirror of upstream.
 
 pdf_oxide depends on office_oxide as a path dependency
 (`office_oxide = { path = "../office_oxide" }`).
-wasm-bindgen version: `0.2.121`.
+wasm-bindgen-cli version is read from `vendor/pdf_oxide/Cargo.lock`
+at build time — never hardcoded. `compile_rust.sh` auto-installs the
+matching version before WASM builds.
 
 ---
 

--- a/tool/compile_rust.sh
+++ b/tool/compile_rust.sh
@@ -203,6 +203,16 @@ WASM_OPT_FLAGS=(
 do_wasm() {
   local out="$PKG_ROOT/web_assets"
 
+  # Ensure wasm-bindgen-cli matches the Cargo.lock version exactly
+  local wb_required
+  wb_required=$(grep -A1 'name = "wasm-bindgen"' "$VENDOR/Cargo.lock" | grep version | head -1 | sed 's/.*"\(.*\)"/\1/')
+  local wb_installed
+  wb_installed=$(wasm-bindgen --version 2>/dev/null | sed 's/wasm-bindgen //' || echo "none")
+  if [[ "$wb_installed" != "$wb_required" ]]; then
+    echo "=== WASM: installing wasm-bindgen-cli $wb_required (have: $wb_installed) ==="
+    cargo install wasm-bindgen-cli --version "$wb_required"
+  fi
+
   echo "=== WASM: compile ==="
   cd "$VENDOR"
   cargo build --lib \


### PR DESCRIPTION
Reads from Cargo.lock, installs if mismatched. Single source of truth. No hardcoded versions.