### PR TITLE
fix: add vendor false_secrets at stamp-tag time

### DIFF
--- a/tool/stamp_release.sh
+++ b/tool/stamp_release.sh
@@ -94,6 +94,12 @@ if [[ "$MODE" == "--stamp-tag" ]]; then
     echo "  .gitmodules removed"
   fi
 
+  # Add false_secrets for vendor test keys (only needed when vendor is shipped)
+  if ! grep -q '/vendor/\*\*' pubspec.yaml; then
+    sed -i.bak '/^false_secrets:/a\  - /vendor/**' pubspec.yaml && rm -f pubspec.yaml.bak
+    echo "  pubspec.yaml += false_secrets /vendor/**"
+  fi
+
   echo "=== Tag tree ready ==="
   exit 0
 fi


### PR DESCRIPTION
Vendor test PEM keys are only shipped in the stamped tag commit. false_secrets /vendor/** added by stamp_release.sh --stamp-tag, not permanently in pubspec.