### PR TITLE
fix: slopfairy PR#51 suggestions — printf credentials + remove redundant gitignore

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -278,9 +278,11 @@ jobs:
           git commit -m "stamp: ${{ needs.discover.outputs.tag }}" --allow-empty
 
       - name: Materialize pub.dev credentials
+        env:
+          PUB_CREDS: ${{ secrets.PUB_CREDENTIALS }}
         run: |
           mkdir -p "$HOME/.config/dart"
-          echo '${{ secrets.PUB_CREDENTIALS }}' > "$HOME/.config/dart/pub-credentials.json"
+          printf '%s' "$PUB_CREDS" > "$HOME/.config/dart/pub-credentials.json"
 
       - run: fvm dart pub get --no-example
       - run: fvm dart pub publish --force

--- a/.gitignore
+++ b/.gitignore
@@ -335,6 +335,3 @@ example/web/pdf_manipulator/
 
 # pubspec.lock (library, not app — consumers resolve their own deps)
 pubspec.lock
-
-# Deploy secrets (Bitwarden source of truth, never committed)
-deploy/.deploy/secrets.json


### PR DESCRIPTION
## Summary
- Use printf + env var for credential materialization (no shell interpretation risk)
- Remove redundant deploy/.deploy/secrets.json from .gitignore (already covered by **/secrets.json)
- macOS-specific secrets.sh paths acknowledged as fine for maintainer tooling