### PR TITLE
fix: flutter-upgrade PRs created as draft

### DIFF
--- a/.github/workflows/flutter-upgrade.yml
+++ b/.github/workflows/flutter-upgrade.yml
@@ -124,6 +124,7 @@ jobs:
               --head "$BRANCH" \
               --title "chore: bump Flutter $CURRENT → $LATEST" \
               --label "$LABEL" \
+              --draft \
               --body "$PR_BODY"
           else
             gh pr edit "$EXISTING_PR" \


### PR DESCRIPTION
Adds --draft to gh pr create so upgrade PRs don't trigger CI or appear as ready to merge.