### PR TITLE
fix(ci): replace broken @dependabot recreate with maintainer notification

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -14,22 +14,25 @@ permissions:
   pull-requests: write
 
 jobs:
-  # When a dependabot PR gets updated (e.g. "Update branch" button),
-  # ask dependabot to recreate — picks up any new workflow files.
-  dependabot-recreate:
+  # When a non-dependabot push lands on a dependabot PR (e.g. human clicks
+  # "Update branch"), workflows may be outdated. github-actions[bot] can't
+  # run dependabot commands (no push access), so we comment asking a human.
+  # Skips when dependabot itself pushes (after a recreate) to avoid loops.
+  dependabot-needs-recreate:
     if: >-
       github.event_name == 'pull_request_target' &&
       github.event.action == 'synchronize' &&
-      github.event.pull_request.user.login == 'dependabot[bot]'
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.event.sender.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
-      - name: Ask dependabot to recreate
+      - name: Notify maintainer
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh pr comment ${{ github.event.pull_request.number }} \
-            --repo ${{ github.repository }} \
-            --body "@dependabot recreate"
+            --repo "${{ github.repository }}" --body \
+            "New commits pushed — workflows may be outdated. A maintainer with push access should comment \`@dependabot recreate\` to pick up the latest changes."
 
   assign-and-label:
     runs-on: ubuntu-latest

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -7,13 +7,30 @@ on:
   issues:
     types: [opened]
   pull_request_target:
-    types: [opened]
+    types: [opened, synchronize]
 
 permissions:
   issues: write
   pull-requests: write
 
 jobs:
+  # When a dependabot PR gets updated (e.g. "Update branch" button),
+  # ask dependabot to recreate — picks up any new workflow files.
+  dependabot-recreate:
+    if: >-
+      github.event_name == 'pull_request_target' &&
+      github.event.action == 'synchronize' &&
+      github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ask dependabot to recreate
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment ${{ github.event.pull_request.number }} \
+            --repo ${{ github.repository }} \
+            --body "@dependabot recreate"
+
   assign-and-label:
     runs-on: ubuntu-latest
     steps:

--- a/test/ops/native/native_finalizer_test.dart
+++ b/test/ops/native/native_finalizer_test.dart
@@ -18,9 +18,12 @@ import 'package:test/test.dart';
 void registerNativeFinalizerTests() {
   test('dispose exits cleanly (no dangling NativeCallable)',
       () async {
-    // Use `dart <file>` not `dart run <file>` — `dart run` triggers build
-    // hooks which recompile the Rust binary. On Windows MSVC this exceeds the
-    // timeout even with cache hits. Direct file execution skips hooks entirely.
+    // Do NOT change to `dart run` — it will fail on Windows with:
+    //   PathAccessException: Cannot delete file, path = '...pdf_oxide.dll'
+    //   (OS Error: Access is denied, errno = 5)
+    // Windows locks loaded DLLs. The parent test process has pdf_oxide.dll
+    // loaded via @Native FFI. `dart run` triggers build hooks which try to
+    // copy the DLL → Access denied. `dart <file>` skips hooks entirely.
     final repro = File('test/ops/native/native_gc_repro.dart').absolute.path;
     final process = await Process.start(Platform.resolvedExecutable, [repro]);
     final exitCode = await process.exitCode.timeout(


### PR DESCRIPTION
## Summary

- `github-actions[bot]` can't run dependabot commands — dependabot requires push access and rejects the bot with "Sorry, only users with push access can use that command"
- Replaced the auto `@dependabot recreate` comment with a human-readable notification asking a maintainer to do it
- Added `sender.login != 'dependabot[bot]'` guard so the notification doesn't fire when dependabot itself pushes after a recreate (avoids comment loops)