### PR TITLE
fix(ci): notify maintainer to recreate dependabot PRs on new pushes

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -7,13 +7,33 @@ on:
   issues:
     types: [opened]
   pull_request_target:
-    types: [opened]
+    types: [opened, synchronize]
 
 permissions:
   issues: write
   pull-requests: write
 
 jobs:
+  # When a non-dependabot push lands on a dependabot PR (e.g. human clicks
+  # "Update branch"), workflows may be outdated. github-actions[bot] can't
+  # run dependabot commands (no push access), so we comment asking a human.
+  # Skips when dependabot itself pushes (after a recreate) to avoid loops.
+  dependabot-needs-recreate:
+    if: >-
+      github.event_name == 'pull_request_target' &&
+      github.event.action == 'synchronize' &&
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.event.sender.login != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify maintainer
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment ${{ github.event.pull_request.number }} \
+            --repo "${{ github.repository }}" --body \
+            "New commits pushed — workflows may be outdated. A maintainer with push access should comment \`@dependabot recreate\` to pick up the latest changes."
+
   assign-and-label:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

- `github-actions[bot]` can't run `@dependabot recreate` — dependabot requires push access and rejects the bot
- Added a `dependabot-needs-recreate` job that posts a comment asking a maintainer to do it manually
- Only fires on `synchronize` events where the PR author is `dependabot[bot]` but the sender (pusher) is NOT `dependabot[bot]` — avoids comment loops after a recreate