### PR TITLE
chore: add 1.0.1-dev.0 prerelease changelog entry

### DIFF
--- a/CHANGELOG.pre.md
+++ b/CHANGELOG.pre.md
@@ -23,6 +23,12 @@
   - DO NOT add commit lists here — CI auto-appends them at publish time
 -->
 
+## 1.0.1-dev.0
+
+- Added public API doc comments across all exported classes and methods
+- Minimum Android API corrected from 35 to 21 (Android 5.0)
+- Setup command is now `flutter pub run pdf_manipulator:setup` (avoids triggering native build hooks with `dart run`)
+
 ## 1.0.0-dev.0
 
 Complete ground-up rewrite. New engine, new API, every platform. See the [migration guide](docs/MIGRATION.md) for upgrading from the old Android-only version.


### PR DESCRIPTION
## Summary

- Prerelease changelog entry for work since v1.0.0-dev.0
- API doc comments, Android API minimum fix, setup command fix