### PR TITLE
chore: add 1.0.3 changelog entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 <!-- Stable releases. Add ## heading at top, CI handles the rest. -->
 
+## 1.0.3
+
+- Changelog preview visible in CI logs before publish approval
+- Release pipeline idempotency fixes (staging branch, asset hashes)
+
 ## 1.0.2
 
 - Fixed changelog on pub.dev missing commit history between versions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@
 
 ## 1.0.3
 
-- Changelog preview visible in CI logs before publish approval
-- Release pipeline idempotency fixes (staging branch, asset hashes)
+- Fixed changelog on pub.dev
 
 ## 1.0.2
 

--- a/CHANGELOG.pre.md
+++ b/CHANGELOG.pre.md
@@ -4,8 +4,7 @@
 
 ## 1.0.3-dev.0
 
-- Changelog preview visible in CI logs before publish approval
-- Release pipeline idempotency fixes (staging branch, asset hashes)
+- Fixed changelog on pub.dev
 
 ## 1.0.2-dev.0
 

--- a/CHANGELOG.pre.md
+++ b/CHANGELOG.pre.md
@@ -2,6 +2,11 @@
 
 <!-- Prereleases. Add ## heading at top, CI handles the rest. -->
 
+## 1.0.3-dev.0
+
+- Changelog preview visible in CI logs before publish approval
+- Release pipeline idempotency fixes (staging branch, asset hashes)
+
 ## 1.0.2-dev.0
 
 - Fixed changelog on pub.dev missing commit history between versions


### PR DESCRIPTION
## Summary

- Bump prerelease to 1.0.3-dev.0 and stable to 1.0.3
- Test release with changelog preview + all pipeline fixes