### PR TITLE
feat(ci): stamp README.md version on release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 <!-- Stable releases. Add ## heading at top, CI handles the rest. -->
 
+## 1.0.3
+
+- Changelog preview visible in CI logs before publish approval
+- Release pipeline idempotency fixes (staging branch, asset hashes)
+
 ## 1.0.2
 
 - Fixed changelog on pub.dev missing commit history between versions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@
 
 ## 1.0.3
 
-- Changelog preview visible in CI logs before publish approval
-- Release pipeline idempotency fixes (staging branch, asset hashes)
+- Fixed changelog on pub.dev
 
 ## 1.0.2
 

--- a/CHANGELOG.pre.md
+++ b/CHANGELOG.pre.md
@@ -4,8 +4,7 @@
 
 ## 1.0.3-dev.0
 
-- Changelog preview visible in CI logs before publish approval
-- Release pipeline idempotency fixes (staging branch, asset hashes)
+- Fixed changelog on pub.dev
 
 ## 1.0.2-dev.0
 

--- a/CHANGELOG.pre.md
+++ b/CHANGELOG.pre.md
@@ -2,6 +2,11 @@
 
 <!-- Prereleases. Add ## heading at top, CI handles the rest. -->
 
+## 1.0.3-dev.0
+
+- Changelog preview visible in CI logs before publish approval
+- Release pipeline idempotency fixes (staging branch, asset hashes)
+
 ## 1.0.2-dev.0
 
 - Fixed changelog on pub.dev missing commit history between versions

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Cross-platform PDF manipulation for Dart & Flutter. Merge, split, render, extrac
 
 ```yaml
 dependencies:
-  pdf_manipulator: ^1.0.0
+  pdf_manipulator:
 ```
 
 **Web only** — run once after install (and after each package update):

--- a/README.md
+++ b/README.md
@@ -46,8 +46,11 @@ Native platforms need nothing extra — the build hook handles everything.
 
 Flutter's build hook system (`hooks: build`) supports native binaries
 (`.so`, `.dylib`, `.dll`) automatically, but has no equivalent for web
-assets (WASM, JS). The setup command copies the pre-built WASM module
-into your project's `web/` directory where Flutter's web build can find it.
+assets (WASM, JS). The setup command copies JS glue files from the
+package and downloads the pre-built WASM binary from GitHub Releases
+into your project's `web/` directory where Flutter's web build can
+find it. If you've built WASM locally, it copies from your local build
+instead of downloading.
 
 This is a Flutter/Dart platform limitation, not specific to this package.
 Tracking issues:

--- a/README.md
+++ b/README.md
@@ -41,6 +41,22 @@ flutter pub run pdf_manipulator:setup
 
 Native platforms need nothing extra — the build hook handles everything.
 
+<details>
+<summary>Why is this step needed for web?</summary>
+
+Flutter's build hook system (`hooks: build`) supports native binaries
+(`.so`, `.dylib`, `.dll`) automatically, but has no equivalent for web
+assets (WASM, JS). The setup command copies the pre-built WASM module
+into your project's `web/` directory where Flutter's web build can find it.
+
+This is a Flutter/Dart platform limitation, not specific to this package.
+Tracking issues:
+- [dart-lang/native#2829](https://github.com/dart-lang/native/issues/2829) — `data_assets` support in Dart SDK
+- [dart-lang/native#2114](https://github.com/dart-lang/native/issues/2114) — `DataConfig` with a target
+
+When `data_assets` ships, this step will be removed.
+</details>
+
 ---
 
 ## Quick start

--- a/tool/release.sh
+++ b/tool/release.sh
@@ -153,7 +153,7 @@ except Exception:
 " 2>/dev/null || true
 }
 
-# Stamp a version string into pubspec.yaml and lib/src/version.dart.
+# Stamp a version string into pubspec.yaml, version.dart, and README.md.
 stamp_version() {
   local ver="$1"
   sed -i.bak "s/^version: .*/version: $ver/" pubspec.yaml && rm -f pubspec.yaml.bak
@@ -161,6 +161,8 @@ stamp_version() {
   sed -i.bak "s/const packageVersion = '[^']*'/const packageVersion = '$ver'/" \
     lib/src/version.dart && rm -f lib/src/version.dart.bak
   echo "  version.dart → $ver"
+  sed -i.bak "s/  ${PKG_NAME}:.*/  ${PKG_NAME}: ^$ver/" README.md && rm -f README.md.bak
+  echo "  README.md → ^$ver"
 }
 
 # Generate lib/src/hook/asset_hashes.dart from the GitHub Release API


### PR DESCRIPTION
## Summary

- README.md in git shows `pdf_manipulator:` (no version) — clean placeholder
- `stamp_version()` in release.sh now stamps `pdf_manipulator: ^X.Y.Z` into README.md at publish time
- pub.dev always shows the correct version, GitHub shows the placeholder