### PR TITLE
chore: 1.0.5 release — fix README stamp + Roadmap WasmAsset/JsAsset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 <!-- Stable releases. Add ## heading at top, CI handles the rest. -->
 
+## 1.0.5
+
+- Fixed README version not stamped on pub.dev
+- Updated tracking links for web build hook support
+
 ## 1.0.4
 
 - Web setup now verifies all assets against release hashes — detects stale files automatically

--- a/CHANGELOG.pre.md
+++ b/CHANGELOG.pre.md
@@ -2,6 +2,11 @@
 
 <!-- Prereleases. Add ## heading at top, CI handles the rest. -->
 
+## 1.0.5-dev.0
+
+- Fixed README version not stamped on pub.dev
+- Updated tracking links for web build hook support
+
 ## 1.0.4-dev.0
 
 - Web setup now verifies all assets against release hashes — detects stale files automatically

--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ yet. The setup command fills that gap: it downloads the pre-built
 WASM engine, or compiles it from the vendored Rust source if the
 download isn't available.
 
-This will go away when Flutter adds web asset support to build hooks.
-Tracking: [dart-lang/native#2829](https://github.com/dart-lang/native/issues/2829)
+This will go away when Dart/Flutter adds WASM/JS asset support to
+build hooks. Tracking: [dart-lang/native#988](https://github.com/dart-lang/native/issues/988)
 
 </details>
 

--- a/docs/CAPABILITY_ROADMAP.md
+++ b/docs/CAPABILITY_ROADMAP.md
@@ -218,6 +218,45 @@ Five files, strict rules:
 
 ---
 
+## Build & distribution
+
+| Capability | Status | Notes |
+|---|---|---|
+| Native binary resolution (5-step waterfall) | DONE | cached → download → compile → submodule → error |
+| Web asset resolution (same waterfall) | DONE | WASM + JS glue, hash-verified |
+| `setup --web` (default) | DONE | Downloads or compiles web assets |
+| `setup --native` | DONE | Pre-fetches native binary for current OS |
+| `setup --all` / `--force` | DONE | Both platforms / re-resolve everything |
+| SHA-256 hash verification (all assets) | DONE | Native + web, stale detection on setup |
+| Automatic web setup via build hook | BLOCKED | See details below |
+
+### Automatic web setup — what's blocking, what to track
+
+The web setup step (`flutter pub run pdf_manipulator:setup`) exists
+because Flutter's build hook system only supports native code assets
+(`CodeAsset`). WASM modules and JS workers need dedicated asset types
+that don't exist yet.
+
+**What will solve it:**
+[`WasmAsset` / `JsAsset`](https://github.com/dart-lang/native/issues/988) —
+dedicated web asset types where the framework (Flutter, Dart, Jaspr)
+handles bundling and exposes a runtime URI. Web workers and WASM
+modules need URLs, not raw bytes — `DataAsset` can't provide that.
+Same problem affects [drift](https://github.com/simolus3/drift/issues/3770)
+and [sqlite3](https://github.com/simolus3/sqlite3.dart) — all waiting
+on the same feature.
+
+**What's ready on our side:**
+`hook/build.dart` already implements `resolveWeb()` with the full
+5-step waterfall. When the Dart SDK adds the asset type and Flutter
+wires the trigger, `main()` adds one call to `resolveWeb()` and
+`setup` becomes optional. Zero new logic needed.
+
+**Track:** [dart-lang/native#988](https://github.com/dart-lang/native/issues/988)
+(P3, Native Assets v1.x milestone, no ETA).
+
+---
+
 ## Out of scope
 
 | Feature | Why not |

--- a/tool/release.sh
+++ b/tool/release.sh
@@ -161,7 +161,7 @@ stamp_version() {
   sed -i.bak "s/const packageVersion = '[^']*'/const packageVersion = '$ver'/" \
     lib/src/version.dart && rm -f lib/src/version.dart.bak
   echo "  version.dart → $ver"
-  sed -i.bak "s/  ${PKG_NAME}: .*/  ${PKG_NAME}: ^$ver/" README.md && rm -f README.md.bak
+  sed -i.bak "s/  ${PKG_NAME}:.*/  ${PKG_NAME}: ^$ver/" README.md && rm -f README.md.bak
   sed -i.bak "s/${PKG_NAME}: X\.Y\.Z/${PKG_NAME}: $ver/" README.md && rm -f README.md.bak
   echo "  README.md → $ver"
 }


### PR DESCRIPTION
## Summary

- Fixed `stamp_version()` sed pattern — `pdf_manipulator:` (bare, no space) wasn't matching
- README and roadmap now only track dart-lang/native#988 (WasmAsset/JsAsset), removed #2829 (DataAsset doesn't help our use case)
- 1.0.5 changelog entries