### PR TITLE
fix(hook): add link.dart passthrough, build.json, release-build tests

### DIFF
--- a/.github/workflows/full-test.yml
+++ b/.github/workflows/full-test.yml
@@ -157,7 +157,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with: { submodules: recursive }
-      - uses: ./.github/actions/setup-flutter
+      - uses: ./.github/actions/setup-fvm
       - run: make test-release-android
 
   release-ios:
@@ -168,7 +168,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with: { submodules: recursive }
-      - uses: ./.github/actions/setup-flutter
+      - uses: ./.github/actions/setup-fvm
       - run: make test-release-ios
 
   release-macos:
@@ -179,7 +179,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with: { submodules: recursive }
-      - uses: ./.github/actions/setup-flutter
+      - uses: ./.github/actions/setup-fvm
       - run: make test-release-macos
 
   release-linux:
@@ -190,7 +190,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with: { submodules: recursive }
-      - uses: ./.github/actions/setup-flutter
+      - uses: ./.github/actions/setup-fvm
       - run: make test-release-linux
 
   release-windows:
@@ -201,7 +201,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with: { submodules: recursive }
-      - uses: ./.github/actions/setup-flutter
+      - uses: ./.github/actions/setup-fvm
       - run: make test-release-windows
 
   release-web:
@@ -215,7 +215,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with: { submodules: recursive }
-      - uses: ./.github/actions/setup-flutter
+      - uses: ./.github/actions/setup-fvm
       - run: make test-release-web
 
   # ── Gate ───────────────────────────────────────────────────────────

--- a/.github/workflows/full-test.yml
+++ b/.github/workflows/full-test.yml
@@ -18,26 +18,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  revoke-label:
-    name: Revoke stale label
-    if: >-
-      github.event.action == 'synchronize' &&
-      contains(github.event.pull_request.labels.*.name, 'ready-to-test')
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-    steps:
-      - name: Remove ready-to-test label
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh pr edit ${{ github.event.pull_request.number }} \
-            --repo ${{ github.repository }} \
-            --remove-label "ready-to-test"
-          gh pr comment ${{ github.event.pull_request.number }} \
-            --repo ${{ github.repository }} \
-            --body "Label \`ready-to-test\` removed — new commits pushed. Re-add when ready."
-
   # ── Package tests (dart test) ──────────────────────────────────────
 
   pkg-macos:

--- a/.github/workflows/full-test.yml
+++ b/.github/workflows/full-test.yml
@@ -158,6 +158,11 @@ jobs:
       - uses: actions/checkout@v6
         with: { submodules: recursive }
       - uses: ./.github/actions/setup-fvm
+      - uses: ./.github/actions/setup-rust
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
       - run: make test-release-android
 
   release-ios:
@@ -169,6 +174,7 @@ jobs:
       - uses: actions/checkout@v6
         with: { submodules: recursive }
       - uses: ./.github/actions/setup-fvm
+      - uses: ./.github/actions/setup-rust
       - run: make test-release-ios
 
   release-macos:
@@ -180,6 +186,7 @@ jobs:
       - uses: actions/checkout@v6
         with: { submodules: recursive }
       - uses: ./.github/actions/setup-fvm
+      - uses: ./.github/actions/setup-rust
       - run: make test-release-macos
 
   release-linux:
@@ -191,6 +198,7 @@ jobs:
       - uses: actions/checkout@v6
         with: { submodules: recursive }
       - uses: ./.github/actions/setup-fvm
+      - uses: ./.github/actions/setup-rust
       - run: make test-release-linux
 
   release-windows:
@@ -202,6 +210,7 @@ jobs:
       - uses: actions/checkout@v6
         with: { submodules: recursive }
       - uses: ./.github/actions/setup-fvm
+      - uses: ./.github/actions/setup-rust
       - run: make test-release-windows
 
   release-web:
@@ -216,6 +225,8 @@ jobs:
       - uses: actions/checkout@v6
         with: { submodules: recursive }
       - uses: ./.github/actions/setup-fvm
+      - uses: ./.github/actions/setup-rust
+        with: { targets: wasm32-unknown-unknown }
       - run: make test-release-web
 
   # ── Gate ───────────────────────────────────────────────────────────

--- a/.github/workflows/full-test.yml
+++ b/.github/workflows/full-test.yml
@@ -147,9 +147,12 @@ jobs:
   # build hook. These verify the hook works in release mode too.
 
   release-android:
-    name: "release: Android"
+    name: "release: Android (${{ matrix.os }})"
     if: github.event.action == 'labeled' && github.event.label.name == 'ready-to-test'
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-14, windows-latest]
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
@@ -202,9 +205,12 @@ jobs:
       - run: make test-release-windows
 
   release-web:
-    name: "release: Web"
+    name: "release: Web (${{ matrix.os }})"
     if: github.event.action == 'labeled' && github.event.label.name == 'ready-to-test'
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-14, windows-latest]
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
@@ -250,4 +256,4 @@ jobs:
               exit 1
             fi
           done
-          echo "All 16 jobs passed"
+          echo "All jobs passed"

--- a/.github/workflows/full-test.yml
+++ b/.github/workflows/full-test.yml
@@ -3,6 +3,7 @@
 #
 # Package tests: unit + native ops on macOS/Linux/Windows + web (3 modes)
 # Integration tests: example app on macOS/Android emulator/iOS simulator + web (3 modes)
+# Release-build tests: flutter build --release on all 6 targets
 #
 # Every job composes reusable actions from .github/actions/.
 name: Full Test
@@ -141,12 +142,82 @@ jobs:
         with: { submodules: recursive }
       - uses: ./.github/actions/integration-web
 
+  # ── Release-build tests ──────────────────────────────────────────
+  # Debug and release builds exercise different code paths in the
+  # build hook. These verify the hook works in release mode too.
+
+  release-android:
+    name: "release: Android"
+    if: github.event.action == 'labeled' && github.event.label.name == 'ready-to-test'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+        with: { submodules: recursive }
+      - uses: ./.github/actions/setup-flutter
+      - run: make test-release-android
+
+  release-ios:
+    name: "release: iOS"
+    if: github.event.action == 'labeled' && github.event.label.name == 'ready-to-test'
+    runs-on: macos-14
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+        with: { submodules: recursive }
+      - uses: ./.github/actions/setup-flutter
+      - run: make test-release-ios
+
+  release-macos:
+    name: "release: macOS"
+    if: github.event.action == 'labeled' && github.event.label.name == 'ready-to-test'
+    runs-on: macos-14
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+        with: { submodules: recursive }
+      - uses: ./.github/actions/setup-flutter
+      - run: make test-release-macos
+
+  release-linux:
+    name: "release: Linux"
+    if: github.event.action == 'labeled' && github.event.label.name == 'ready-to-test'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+        with: { submodules: recursive }
+      - uses: ./.github/actions/setup-flutter
+      - run: make test-release-linux
+
+  release-windows:
+    name: "release: Windows"
+    if: github.event.action == 'labeled' && github.event.label.name == 'ready-to-test'
+    runs-on: windows-latest
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v6
+        with: { submodules: recursive }
+      - uses: ./.github/actions/setup-flutter
+      - run: make test-release-windows
+
+  release-web:
+    name: "release: Web"
+    if: github.event.action == 'labeled' && github.event.label.name == 'ready-to-test'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+        with: { submodules: recursive }
+      - uses: ./.github/actions/setup-flutter
+      - run: make test-release-web
+
   # ── Gate ───────────────────────────────────────────────────────────
 
   gate:
     name: Full Test Gate
     if: always()
-    needs: [pkg-macos, pkg-linux, pkg-windows, pkg-web, int-macos, int-linux, int-windows, int-android, int-ios, int-web]
+    needs: [pkg-macos, pkg-linux, pkg-windows, pkg-web, int-macos, int-linux, int-windows, int-android, int-ios, int-web, release-android, release-ios, release-macos, release-linux, release-windows, release-web]
     runs-on: ubuntu-latest
     steps:
       - name: Evaluate
@@ -166,6 +237,12 @@ jobs:
             "${{ needs.int-android.result }}"
             "${{ needs.int-ios.result }}"
             "${{ needs.int-web.result }}"
+            "${{ needs.release-android.result }}"
+            "${{ needs.release-ios.result }}"
+            "${{ needs.release-macos.result }}"
+            "${{ needs.release-linux.result }}"
+            "${{ needs.release-windows.result }}"
+            "${{ needs.release-web.result }}"
           )
           for r in "${RESULTS[@]}"; do
             if [[ "$r" != "success" ]]; then
@@ -173,4 +250,4 @@ jobs:
               exit 1
             fi
           done
-          echo "All 10 jobs passed"
+          echo "All 16 jobs passed"

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -75,3 +75,18 @@ jobs:
           if echo "$FILES" | grep -qE "^vendor/"; then
             gh pr edit $PR --repo ${{ github.repository }} --add-label "upstream"
           fi
+
+          # Auto-label by PR title (conventional commits)
+          TITLE="${{ github.event.pull_request.title }}"
+          if echo "$TITLE" | grep -qE '^fix(\(|!?:)'; then
+            gh pr edit $PR --repo ${{ github.repository }} --add-label "bug"
+          elif echo "$TITLE" | grep -qE '^feat(\(|!?:)'; then
+            gh pr edit $PR --repo ${{ github.repository }} --add-label "feature"
+          fi
+
+          # Auto-label promotion PRs
+          HEAD="${{ github.event.pull_request.head.ref }}"
+          BASE="${{ github.event.pull_request.base.ref }}"
+          if [[ "$HEAD" == "dev" && "$BASE" == "prod" ]]; then
+            gh pr edit $PR --repo ${{ github.repository }} --add-label "release"
+          fi

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -14,6 +14,27 @@ permissions:
   pull-requests: write
 
 jobs:
+  # Revoke stale ready-to-test label when new commits are pushed.
+  # Lives here (not full-test.yml) because pull_request_target gives
+  # write access to labels on fork PRs.
+  revoke-ready-to-test:
+    if: >-
+      github.event_name == 'pull_request_target' &&
+      github.event.action == 'synchronize' &&
+      contains(github.event.pull_request.labels.*.name, 'ready-to-test')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove label + notify
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr edit ${{ github.event.pull_request.number }} \
+            --repo ${{ github.repository }} \
+            --remove-label "ready-to-test"
+          gh pr comment ${{ github.event.pull_request.number }} \
+            --repo ${{ github.repository }} \
+            --body "Label \`ready-to-test\` removed — new commits pushed. Re-add when ready."
+
   # When a non-dependabot push lands on a dependabot PR (e.g. human clicks
   # "Update branch"), workflows may be outdated. github-actions[bot] can't
   # run dependabot commands (no push access), so we comment asking a human.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ your fork / feature branch ──PR──► dev
                                     ↓ CI: make analyze + make test-unit + make test-ops-native
                                     ↓ PR title: Conventional Commits (feat: / fix: / etc.)
                                     ↓ squash-merge when green
-                                    ↓ Full 10-job test via "ready-to-test" label
+                                    ↓ Full test suite via "ready-to-test" label
                                       (4 pkg: macOS/Linux/Windows/web
                                        6 integration: macOS/Linux/Windows/Android/iOS/web)
 ```

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
        test test-unit test-ops test-ops-native test-ops-web test-ops-opfs test-ops-jspi test-ops-atomics \
        test-example test-example-macos test-example-linux test-example-windows test-example-android test-example-ios test-example-device \
        test-example-web test-example-web-jspi test-example-web-atomics test-example-web-opfs \
+       test-release test-release-android test-release-ios test-release-macos test-release-linux test-release-windows test-release-web \
        compile compile-natives compile-wasm \
        clean
 
@@ -37,6 +38,14 @@ FLUTTER ?= fvm flutter
 # make test-example-web-jspi    example: Chrome JSPI mode
 # make test-example-web-atomics example: Chrome Atomics mode
 # make test-example-web-opfs    example: Chrome OPFS mode
+#
+# make test-release             release-build tests (all targets)
+# make test-release-android     release: Android APK
+# make test-release-ios         release: iOS (no codesign)
+# make test-release-macos       release: macOS
+# make test-release-linux       release: Linux
+# make test-release-windows     release: Windows
+# make test-release-web         release: Web (setup + build)
 #
 # RELEASE (CI calls these — single source of truth for compile logic)
 # ────────────────────────────────────────────────────────────────────
@@ -169,6 +178,37 @@ test-example-web-atomics:
 test-example-web-opfs:
 	$(call setup_example_web)
 	$(call run_example_web,OPFS,opfs)
+
+# ── Release-build tests ────────────────────────────────────────────
+# Debug and release builds exercise different code paths in the
+# build hook. These verify the hook works in release mode too.
+
+test-release: test-release-android test-release-ios test-release-macos test-release-linux test-release-windows test-release-web
+
+test-release-android:
+	@echo "=== Release build: Android APK ==="
+	cd example && $(FLUTTER) build apk --release
+
+test-release-ios:
+	@echo "=== Release build: iOS ==="
+	cd example && $(FLUTTER) build ios --release --no-codesign
+
+test-release-macos:
+	@echo "=== Release build: macOS ==="
+	cd example && $(FLUTTER) build macos --release
+
+test-release-linux:
+	@echo "=== Release build: Linux ==="
+	cd example && $(FLUTTER) build linux --release
+
+test-release-windows:
+	@echo "=== Release build: Windows ==="
+	cd example && $(FLUTTER) build windows --release
+
+test-release-web:
+	$(call setup_example_web)
+	@echo "=== Release build: Web ==="
+	cd example && $(FLUTTER) build web --release
 
 # ── Clean ───────────────────────────────────────────────────────────
 

--- a/README.md
+++ b/README.md
@@ -60,12 +60,12 @@ pdf_manipulator: X.Y.Z  # exact version — upgrade intentionally
 ```
 
 <details>
-<summary>Extra setup options (optional / debugging)</summary>
+<summary>All setup commands</summary>
 
 ```sh
-flutter pub run pdf_manipulator:setup --native  # pre-fetch native binary
-flutter pub run pdf_manipulator:setup --all     # web + native
-flutter pub run pdf_manipulator:setup --force   # re-download everything
+flutter pub run pdf_manipulator:setup                  # web (default)
+flutter pub run pdf_manipulator:setup <target>         # web|android|ios|macos|linux|windows
+flutter pub run pdf_manipulator:setup --force <target> # re-resolve (debugging)
 ```
 
 </details>

--- a/bin/setup.dart
+++ b/bin/setup.dart
@@ -1,10 +1,15 @@
-// Thin CLI wrapper over hook/build.dart's resolveNative() and resolveWeb().
+// Setup script for pdf_manipulator.
 //
-// Usage:
-//   flutter pub run pdf_manipulator:setup           # web (default)
-//   flutter pub run pdf_manipulator:setup --native  # native for current OS
-//   flutter pub run pdf_manipulator:setup --all     # both
-//   flutter pub run pdf_manipulator:setup --force   # re-resolve everything
+//   flutter pub run pdf_manipulator:setup                  # web (default)
+//   flutter pub run pdf_manipulator:setup <target>        # web|android|ios|macos|linux|windows
+//   flutter pub run pdf_manipulator:setup --force <target> # re-resolve (debugging)
+//
+// Web: resolves WASM + JS into web/pdf_manipulator/. Hash-verified —
+//   stale files from a previous version are re-downloaded automatically.
+// Native: runs `flutter build <target> --debug` which triggers the build
+//   hook and caches the binary in Flutter's shared cache.
+// --force: web skips hash check and re-downloads. Native runs
+//   `flutter clean` first then rebuilds.
 //
 // Use `flutter pub run`, NOT `dart run`.
 
@@ -16,19 +21,29 @@ import '../hook/build.dart' as build;
 import 'package:pdf_manipulator/src/hook/resolver.dart';
 
 const _help = '''
-Usage: flutter pub run pdf_manipulator:setup [options]
-
-Resolves pdf_manipulator assets (download, compile, or cache).
+Usage: flutter pub run pdf_manipulator:setup [--force] [target]
 
 Targets:
-  (default)    Web assets only (WASM + JS glue)
-  --native     Native binary for current platform only
-  --all        Both web and native
+  (default)        web
+  web              Download/compile WASM + JS (auto stale detection)
+  android          Build + cache native binary for Android
+  ios              Build + cache native binary for iOS
+  macos            Build + cache native binary for macOS
+  linux            Build + cache native binary for Linux
+  windows          Build + cache native binary for Windows
 
 Options:
-  --force      Re-resolve even if files exist and hashes match
-  -h, --help   Show this help
+  --force          Re-resolve target (debugging)
+  -h, --help       Show this help
 ''';
+
+const Map<String, List<String>> _nativeBuildArgs = {
+  'android': ['apk', '--debug'],
+  'ios': ['ios', '--debug', '--no-codesign'],
+  'macos': ['macos', '--debug'],
+  'linux': ['linux', '--debug'],
+  'windows': ['windows', '--debug'],
+};
 
 void main(List<String> args) async {
   if (args.contains('-h') || args.contains('--help')) {
@@ -37,9 +52,28 @@ void main(List<String> args) async {
   }
 
   final force = args.contains('--force');
-  final doNative = args.contains('--native') || args.contains('--all');
-  final doWeb = args.contains('--all') || !args.contains('--native');
+  final targets = args.where((a) => !a.startsWith('-')).toList();
 
+  if (targets.isEmpty) {
+    targets.add('web');
+  }
+
+  for (final target in targets) {
+    if (target == 'web') {
+      await _setupWeb(force);
+    } else if (_nativeBuildArgs.containsKey(target)) {
+      await _setupNative(target, force);
+    } else {
+      stderr.writeln('Error: unknown target "$target".');
+      stderr.writeln('Valid: web, ${_nativeBuildArgs.keys.join(', ')}');
+      exit(1);
+    }
+  }
+}
+
+// ── Web ───────────────────────────────────────────────────────────
+
+Future<void> _setupWeb(bool force) async {
   final config = await findPackageConfig(Directory.current);
   if (config == null) {
     stderr.writeln('Error: not inside a Dart/Flutter project.');
@@ -57,35 +91,46 @@ void main(List<String> args) async {
   final packageRoot = pkg.root;
   final version = readVersion(packageRoot);
 
-  if (doWeb) {
-    stdout.writeln('=== Web assets (v$version) ===');
-    final destDir = Directory('web/pdf_manipulator');
-    final count = await build.resolveWeb(
-      packageRoot: packageRoot,
-      version: version,
-      destDir: destDir,
-      force: force,
+  stdout.writeln('=== Web assets (v$version) ===');
+  final destDir = Directory('web/pdf_manipulator');
+  final count = await build.resolveWeb(
+    packageRoot: packageRoot,
+    version: version,
+    destDir: destDir,
+    force: force,
+  );
+  stdout.writeln(count > 0
+      ? '$count file(s) installed to ${destDir.path}/'
+      : 'All web assets up to date.');
+}
+
+// ── Native ────────────────────────────────────────────────────────
+
+Future<void> _setupNative(String target, bool force) async {
+  final buildArgs = _nativeBuildArgs[target]!;
+
+  stdout.writeln('=== Native ($target) ===');
+
+  if (force) {
+    stdout.writeln('  flutter clean');
+    final clean = await Process.start(
+      'flutter', ['clean'],
+      mode: ProcessStartMode.inheritStdio,
     );
-    stdout.writeln(count > 0
-        ? '$count file(s) installed to ${destDir.path}/'
-        : 'All web assets up to date.');
+    await clean.exitCode;
   }
 
-  if (doNative) {
-    stdout.writeln('=== Native binary (v$version) ===');
-    final platform = build.currentPlatformKey();
-    final libFileName = build.currentLibFileName();
-    final destDir = Directory('.dart_tool/pdf_manipulator');
-    if (!destDir.existsSync()) destDir.createSync(recursive: true);
+  stdout.writeln('  flutter build ${buildArgs.join(' ')}');
+  final process = await Process.start(
+    'flutter',
+    ['build', ...buildArgs],
+    mode: ProcessStartMode.inheritStdio,
+  );
 
-    await build.resolveNative(
-      packageRoot: packageRoot,
-      version: version,
-      platform: platform,
-      libFileName: libFileName,
-      dest: File('${destDir.path}/$libFileName'),
-      force: force,
-    );
-    stdout.writeln('  $libFileName — resolved');
+  final exitCode = await process.exitCode;
+  if (exitCode != 0) {
+    stderr.writeln('  Build failed (exit $exitCode).');
+    exit(exitCode);
   }
+  stdout.writeln('  Native binary cached for $target.');
 }

--- a/build.json
+++ b/build.json
@@ -1,0 +1,15 @@
+{
+  "crate": "pdf_oxide",
+  "repo": "whuppi/pdf_manipulator",
+  "features": {
+    "native": "icc,legacy-crypto,rendering,signatures,native-bridge",
+    "wasm": "wasm,rendering"
+  },
+  "web": {
+    "pdf_oxide_bg.wasm": "wasm-pdf_oxide_bg.wasm",
+    "pdf_oxide.js": "wasm-pdf_oxide.js",
+    "coordinator.js": "wasm-coordinator.js",
+    "worker.js": "wasm-worker.js"
+  },
+  "wasmBuildOutputs": ["pdf_oxide_bg.wasm", "pdf_oxide.js"]
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -212,20 +212,28 @@ web_assets/                                 ← committed in git (except .wasm �
 ├── pdf_oxide.js                            ← wasm-bindgen glue (committed, paired with .wasm)
 └── pdf_oxide_bg.wasm                       ← WASM binary (gitignored — downloaded from releases)
 
+build.json                                  ← single source of truth: crate name, repo,
+                                               cargo features, web asset map
+
 hook/
-└── build.dart                              ← asset resolution brain: resolveNative() + resolveWeb()
-                                               Flutter hook entry + library for bin/setup.dart
+├── build.dart                              ← Flutter hook entry (native) + resolveWeb() (web)
+│                                              reads build.json, private _resolveNative
+└── link.dart                               ← passthrough today; foundation for tree-shaking
 
 bin/
-└── setup.dart                              ← thin CLI: --web (default) / --native / --all / --force
-                                               delegates to hook/build.dart
+└── setup.dart                              ← CLI: setup <target> (web|android|ios|macos|linux|windows)
 
 tool/
 ├── compile_rust.sh                         ← Rust → native / wasm / per-platform / both
-├── release.sh                        ← 7 modes: --gate, --discover, --github-notes,
+│                                              reads features from build.json
+├── release.sh                              ← 7 modes: --gate, --discover, --github-notes,
 │                                              --update-tag-hashes, --stamp-changelog,
 │                                              --add-git-install, --add-pub-install
 └── run_web_test.sh                         ← flutter drive -d web-server wrapper
+
+vendor/
+├── pdf_oxide/                              ← forked yfedoseev/pdf_oxide (submodule)
+└── office_oxide/                           ← forked yfedoseev/office_oxide (submodule)
 
 vendor/pdf_oxide/src/
 ├── host/                                   ← OUR CODE

--- a/docs/CAPABILITY_ROADMAP.md
+++ b/docs/CAPABILITY_ROADMAP.md
@@ -224,10 +224,14 @@ Five files, strict rules:
 |---|---|---|
 | Native binary resolution (5-step waterfall) | DONE | cached → download → compile → submodule → error |
 | Web asset resolution (same waterfall) | DONE | WASM + JS glue, hash-verified |
-| `setup --web` (default) | DONE | Downloads or compiles web assets |
-| `setup --native` | DONE | Pre-fetches native binary for current OS |
-| `setup --all` / `--force` | DONE | Both platforms / re-resolve everything |
+| `setup web` (default) | DONE | Downloads or compiles web assets, hash-verified |
+| `setup <target>` | DONE | Triggers `flutter build` to cache native binary |
+| `setup --force web` | DONE | Re-download web assets (debugging) |
 | SHA-256 hash verification (all assets) | DONE | Native + web, stale detection on setup |
+| `build.json` | DONE | Single source of truth for crate, repo, features, web assets |
+| Link hook (`hook/link.dart`) | DONE | Passthrough today — see tree-shaking rows below |
+| Per-feature opt-out via `user_defines` | PLANNED | Consumers disable features in pubspec → smaller binary. Pattern proven by icu_kit. Works today, no SDK changes needed. |
+| Automatic tree-shaking via `@RecordUse` | PLANNED | Compiler detects used APIs, link hook maps to cargo features. Zero config. Blocked: [dart-lang/native#2902](https://github.com/dart-lang/native/issues/2902), [dart-lang/sdk#52970](https://github.com/dart-lang/sdk/issues/52970) |
 | Automatic web setup via build hook | BLOCKED | See details below |
 
 ### Automatic web setup — what's blocking, what to track

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -356,7 +356,7 @@ gh api repos/whuppi/pdf_manipulator/branches/prod/protection -X PUT \
 |---|---|---|
 | `ci.yml` | PR to prod/dev | `make analyze` + `make test-unit` + `make test-ops-native` |
 | `pr-lint.yml` | PR to prod/dev | Conventional commit title + promotion chain |
-| `full-test.yml` | `ready-to-test` label | 10 jobs: 4 pkg + 6 integration |
+| `full-test.yml` | `ready-to-test` label | 4 pkg + 6 integration + release-build per target |
 | `create-release.yml` | Push to dev/prod changing changelog, or `workflow_dispatch` | Full release pipeline (7 steps) |
 | `flutter-upgrade.yml` | Daily or `workflow_dispatch` | Auto-detect new Flutter stable |
 | `triage.yml` | Issues/PRs | Auto-label, auto-assign, dependabot notifications |

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -89,21 +89,23 @@ const _assetId = 'src/ffi/native_bindings.g.dart';
 // ── build.json — single source of truth for all build constants ──
 // Loaded once per hook invocation. Every constant that's shared with
 // tool/release.sh and tool/compile_rust.sh lives here.
-late final Map<String, dynamic> _buildConfig;
-late final String _crateName;
-late final String _repo;
-late final Map<String, String> _webAssets;
-late final Set<String> _wasmBuildOutputs;
-late final String _nativeFeatures;
+Map<String, dynamic>? _buildConfig;
+late String _crateName;
+late String _repo;
+late Map<String, String> _webAssets;
+late Set<String> _wasmBuildOutputs;
+late String _nativeFeatures;
 
 void _loadBuildConfig(Uri packageRoot) {
+  if (_buildConfig != null) return;
   final file = File.fromUri(packageRoot.resolve('build.json'));
-  _buildConfig = jsonDecode(file.readAsStringSync()) as Map<String, dynamic>;
-  _crateName = _buildConfig['crate'] as String;
-  _repo = _buildConfig['repo'] as String;
-  _webAssets = Map<String, String>.from(_buildConfig['web'] as Map);
-  _wasmBuildOutputs = Set<String>.from(_buildConfig['wasmBuildOutputs'] as List);
-  _nativeFeatures = (_buildConfig['features'] as Map)['native'] as String;
+  final json = jsonDecode(file.readAsStringSync()) as Map<String, dynamic>;
+  _buildConfig = json;
+  _crateName = json['crate'] as String;
+  _repo = json['repo'] as String;
+  _webAssets = Map<String, String>.from(json['web'] as Map);
+  _wasmBuildOutputs = Set<String>.from(json['wasmBuildOutputs'] as List);
+  _nativeFeatures = (json['features'] as Map)['native'] as String;
 }
 
 String _downloadUrl(String version, String assetName) =>

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -168,9 +168,14 @@ void main(List<String> args) async {
         linkMode: linkMode,
         file: outFile.uri,
       ),
-      routing: input.config.linkingEnabled
-          ? ToLinkHook(input.packageName)
-          : const ToAppBundle(),
+      // libpdf_oxide is a DynamicLoadingBundled runtime library: there is
+      // nothing to tree-shake or statically link, so it must always go to the
+      // app bundle. Routing it to ToLinkHook() in release/AOT builds (where
+      // input.config.linkingEnabled is true) fails because this package ships
+      // no hook/link.dart, so every release build aborts with
+      // "is sent to package ... for linking, but that package does not have a
+      // link hook." ToAppBundle() is correct for both debug and release.
+      routing: const ToAppBundle(),
     );
     output.dependencies.add(input.packageRoot.resolve('hook/build.dart'));
     output.dependencies.add(input.packageRoot.resolve('pubspec.yaml'));

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -1,29 +1,32 @@
-// Build hook for pdf_manipulator — the single brain for asset resolution.
+// Build hook for pdf_manipulator.
 //
 // ═══════════════════════════════════════════════════════════════════
-// TWO ROLES, ONE FILE
+// STRUCTURE
 // ═══════════════════════════════════════════════════════════════════
 //
-//   1. Flutter hook entry point — called automatically by Flutter's
-//      build system for native platforms. Receives BuildInput,
-//      resolves the native binary, registers CodeAsset.
+//   main()           Flutter hook entry point (native platforms only).
+//                    Resolves the binary, registers it with Flutter.
 //
-//   2. Library for bin/setup.dart — exports resolveNative() and
-//      resolveWeb() for manual CLI-triggered resolution. setup.dart
-//      is a thin wrapper that parses --web/--native/--all and calls
-//      these functions.
+//   resolveWeb()     Public API for bin/setup.dart (web assets).
+//                    Same waterfall, no registration needed — Flutter
+//                    serves web/ as static files.
+//
+//   _resolveNative() Private. Only main() calls this — the correct
+//                    cache path and target config only exist inside
+//                    the build hook. setup --native delegates to
+//                    `flutter build` which triggers main().
 //
 // ═══════════════════════════════════════════════════════════════════
 // RESOLUTION WATERFALL (same for native and web)
 // ═══════════════════════════════════════════════════════════════════
 //
-//   1. CACHED   — file exists + SHA-256 matches assetHashes → use it
-//   2. DOWNLOAD — fetch from GitHub Releases → cache → use it
-//   3. COMPILE  — vendor/pdf_oxide/ exists → cargo/wasm-pack → use it
+//   1. CACHED    — file exists + SHA-256 matches assetHashes → use it
+//   2. DOWNLOAD  — fetch from GitHub Releases → cache → use it
+//   3. COMPILE   — vendor/pdf_oxide/ exists → cargo/wasm-pack → use it
 //   4. SUBMODULE — .gitmodules exists → git init recursive → compile
-//   5. ERROR    — nothing worked, clear message with options
+//   5. ERROR     — nothing worked, clear message with options
 //
-//   --force skips step 1 (always re-resolves).
+//   --force skips step 1 (web only, via setup.dart).
 //   Version 0.0.0 (dev) skips step 2 (no release exists).
 //
 // ═══════════════════════════════════════════════════════════════════
@@ -31,18 +34,18 @@
 // ═══════════════════════════════════════════════════════════════════
 //
 //   pub.dev consumer (pdf_manipulator: ^X.Y.Z):
-//     Native: automatic via build hook. Steps 1→2 (download prebuilt).
-//             If binary missing from release: step 3 (vendor source
-//             ships in tarball, compiles from source).
+//     Native: automatic via build hook. Downloads prebuilt binary.
+//             If binary missing: compiles from vendor source (ships
+//             in tarball).
 //     Web:    manual `flutter pub run pdf_manipulator:setup`.
-//             Same waterfall. Downloads from release or compiles.
+//             Same waterfall. Downloads or compiles.
 //
 //   Git tag consumer (ref: vX.Y.Z):
 //     Same as pub.dev — tag has vendor source + release has binaries.
 //
 //   Git branch consumer (ref: dev, version 0.0.0):
-//     Download skipped (no release). Compiles from vendor source.
-//     If not cloned with --recursive: submodule init first.
+//     Download skipped. Compiles from vendor source or inits
+//     submodules first.
 //
 //   Contributor (path dependency):
 //     Same as branch consumer. Always compiles from source.
@@ -51,59 +54,24 @@
 // STALENESS
 // ═══════════════════════════════════════════════════════════════════
 //
-//   Native: fully automatic. Flutter re-runs the build hook when
-//     pubspec.yaml changes (registered as dependency). Package
-//     update → new assetHashes → cached binary hash mismatch →
-//     re-downloads. User never thinks about it.
+//   Native: fully automatic. Flutter re-runs the hook when
+//     pubspec.yaml changes. New assetHashes → hash mismatch →
+//     re-downloads.
 //
 //   Web: NOT automatic. User must run `setup` after package update.
-//     The setup script hash-checks every installed file against
-//     assetHashes and re-resolves any mismatches. If user forgets,
-//     stale assets stay until the next setup run.
-//     This is a Flutter limitation — no build hook for web assets.
-//     Tracked: dart-lang/native#2829 (DataAsset support).
-//
-//   When --force is passed: cache check skipped entirely,
-//     everything re-resolved from download or compile.
-//
-//   When no hash is available (dev version, or missing entry):
-//     Published versions: warning logged, cached file used anyway.
-//     Dev version (0.0.0): cached file used silently (just compiled).
-//
-// ═══════════════════════════════════════════════════════════════════
-// WEB SUPPORT
-// ═══════════════════════════════════════════════════════════════════
-//
-//   resolveWeb() is fully implemented. It resolves all 4 web assets:
-//     pdf_oxide_bg.wasm — WASM binary (compiled by wasm-pack)
-//     pdf_oxide.js      — JS glue (compiled by wasm-pack)
-//     coordinator.js    — worker pool manager (hand-written)
-//     worker.js         — WASM worker (hand-written)
-//
-//   WASM build outputs (wasm + js glue) are always resolved together
-//   from the same source — both downloaded from the same release, or
-//   both compiled from the same wasm-pack run. Never mix versions.
-//
-//   Hand-written JS files fall back to copying from the package's
-//   web_assets/ directory if download fails (they always ship).
-//
-//   When Flutter adds DataAsset support, main() adds one call to
-//   resolveWeb() and setup.dart becomes optional. Zero new code.
+//     Hash check detects stale files and re-resolves automatically.
+//     Tracked: dart-lang/native#988 (WasmAsset/JsAsset support).
 //
 // ═══════════════════════════════════════════════════════════════════
 // ASSET HASHES
 // ═══════════════════════════════════════════════════════════════════
 //
-//   assetHashes is a flat Map<String, String> keyed by GitHub Release
-//   asset name (e.g. 'macos-arm64-libpdf_oxide.dylib',
-//   'wasm-pdf_oxide_bg.wasm'). Generated by tool/release.sh
-//   --update-tag-hashes at release time from two sources:
+//   Flat Map<String, String> keyed by GitHub Release asset name.
+//   Generated by tool/release.sh --update-tag-hashes from:
 //     1. GitHub Release API digests (native + WASM build outputs)
 //     2. Local SHA-256 of hand-written JS (coordinator.js, worker.js)
-//
-//   The resolver uses these to verify cached files and detect stale
-//   assets after a package update.
 
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:code_assets/code_assets.dart';
@@ -117,25 +85,42 @@ import 'package:pdf_manipulator/src/hook/resolver.dart';
 final _log = Logger('pdf_manipulator:build');
 
 const _assetId = 'src/ffi/native_bindings.g.dart';
-const _crateName = 'pdf_oxide';
-const _featuresFallback =
-    'icc,legacy-crypto,rendering,signatures,native-bridge';
 
-// Web assets — GitHub Release asset names. Keyed by local filename.
-const webAssets = {
-  'pdf_oxide_bg.wasm': 'wasm-pdf_oxide_bg.wasm',
-  'pdf_oxide.js': 'wasm-pdf_oxide.js',
-  'coordinator.js': 'wasm-coordinator.js',
-  'worker.js': 'wasm-worker.js',
-};
+// ── build.json — single source of truth for all build constants ──
+// Loaded once per hook invocation. Every constant that's shared with
+// tool/release.sh and tool/compile_rust.sh lives here.
+late final Map<String, dynamic> _buildConfig;
+late final String _crateName;
+late final String _repo;
+late final Map<String, String> _webAssets;
+late final Set<String> _wasmBuildOutputs;
+late final String _nativeFeatures;
+
+void _loadBuildConfig(Uri packageRoot) {
+  final file = File.fromUri(packageRoot.resolve('build.json'));
+  _buildConfig = jsonDecode(file.readAsStringSync()) as Map<String, dynamic>;
+  _crateName = _buildConfig['crate'] as String;
+  _repo = _buildConfig['repo'] as String;
+  _webAssets = Map<String, String>.from(_buildConfig['web'] as Map);
+  _wasmBuildOutputs = Set<String>.from(_buildConfig['wasmBuildOutputs'] as List);
+  _nativeFeatures = (_buildConfig['features'] as Map)['native'] as String;
+}
+
+String _downloadUrl(String version, String assetName) =>
+    'https://github.com/$_repo/releases/download/v$version/$assetName';
 
 // ══════════════════════════════════════════════════════════════════
-// Flutter hook entry point
+// § 1 — Flutter hook entry point (native only)
+//
+// Called automatically for iOS, Android, macOS, Linux, Windows.
+// NOT called for web — web goes through resolveWeb() via setup.dart.
 // ══════════════════════════════════════════════════════════════════
 
 void main(List<String> args) async {
   await build(args, (BuildInput input, BuildOutputBuilder output) async {
     if (!input.config.buildCodeAssets) return;
+
+    _loadBuildConfig(input.packageRoot);
 
     final codeConfig = input.config.code;
     final targetTriple = _targetTriple(codeConfig);
@@ -144,13 +129,12 @@ void main(List<String> args) async {
         codeConfig.targetOS.libraryFileName(_crateName, linkMode);
     final outFile =
         File.fromUri(input.outputDirectory.resolve(libFileName));
-    final platform = _platformKey(codeConfig);
-    final version = readVersion(input.packageRoot);
 
-    await resolveNative(
+    // ── Resolve the binary (download, compile, or cache) ──
+    await _resolveNative(
       packageRoot: input.packageRoot,
-      version: version,
-      platform: platform,
+      version: readVersion(input.packageRoot),
+      platform: _platformKey(codeConfig),
       libFileName: libFileName,
       dest: outFile,
       cacheFile: File.fromUri(
@@ -161,49 +145,22 @@ void main(List<String> args) async {
       buildInput: input,
     );
 
-    output.assets.code.add(
-      CodeAsset(
-        package: input.packageName,
-        name: _assetId,
-        linkMode: linkMode,
-        file: outFile.uri,
-      ),
-      // libpdf_oxide is a DynamicLoadingBundled runtime library: there is
-      // nothing to tree-shake or statically link, so it must always go to the
-      // app bundle. Routing it to ToLinkHook() in release/AOT builds (where
-      // input.config.linkingEnabled is true) fails because this package ships
-      // no hook/link.dart, so every release build aborts with
-      // "is sent to package ... for linking, but that package does not have a
-      // link hook." ToAppBundle() is correct for both debug and release.
-      routing: const ToAppBundle(),
-    );
-    output.dependencies.add(input.packageRoot.resolve('hook/build.dart'));
-    output.dependencies.add(input.packageRoot.resolve('pubspec.yaml'));
-    output.dependencies.add(
-      input.packageRoot.resolve('vendor/pdf_oxide/Cargo.toml'),
-    );
-
-    if (hasVendorSource(input.packageRoot)) {
-      final targetDir =
-          p.join(p.fromUri(input.outputDirectory), 'cargo_target');
-      final depInfoPath = p.join(
-        targetDir, targetTriple, 'release', 'deps', 'pdf_oxide.d',
-      );
-      _registerCargoDeps(output, depInfoPath, input.packageRoot);
-    }
+    // ── Register with Flutter ──
+    _registerCodeAsset(input, output, outFile, linkMode);
+    _registerDependencies(input, output, targetTriple);
   });
 }
 
 // ══════════════════════════════════════════════════════════════════
-// Public API — called by both main() above and bin/setup.dart
+// § 2 — Resolution
 // ══════════════════════════════════════════════════════════════════
 
-/// Resolve the native binary for one platform.
-///
-/// [buildInput] is only needed when called from the Flutter hook
-/// (provides NDK compiler info for Android). Null when called from
-/// setup.dart.
-Future<void> resolveNative({
+// ── Native (private) ─────────────────────────────────────────────
+// Not public because the correct cache path, target triple, link
+// mode, and NDK config all come from Flutter's BuildInput — which
+// only exists inside the hook. Calling from outside writes to the
+// wrong cache. setup --native delegates to `flutter build` instead.
+Future<void> _resolveNative({
   required Uri packageRoot,
   required String version,
   required String platform,
@@ -219,6 +176,7 @@ Future<void> resolveNative({
 
   await resolveAsset(ResolveRequest(
     assetName: assetName,
+    downloadUrl: _downloadUrl(version, assetName),
     dest: dest,
     cacheFile: cacheFile,
     expectedHash: assetHashes[assetName],
@@ -227,8 +185,7 @@ Future<void> resolveNative({
     force: force,
     compile: (File d) async {
       if (buildInput != null && targetTriple != null && linkMode != null) {
-        await _compileNativeFromHook(
-            buildInput, targetTriple, linkMode, d);
+        await _compileNativeFromHook(buildInput, targetTriple, linkMode, d);
       } else {
         await _compileNativeFromCli(packageRoot, d);
       }
@@ -236,31 +193,39 @@ Future<void> resolveNative({
   ));
 }
 
-/// Resolve all web assets into [destDir].
-///
-/// Returns the number of files installed (0 if all up to date).
+// ── Web (public — called by bin/setup.dart) ──────────────────────
+// Resolves WASM + JS into destDir (typically web/pdf_manipulator/).
+// Flutter serves destDir as static files — no registration needed.
+//
+// Two asset types with different compile fallbacks:
+//   WASM build outputs (pdf_oxide_bg.wasm, pdf_oxide.js) → wasm-pack
+//   Hand-written JS (coordinator.js, worker.js) → copy from package
+//
+// Returns the number of files freshly resolved (0 = all cached).
 Future<int> resolveWeb({
   required Uri packageRoot,
   required String version,
   required Directory destDir,
   bool force = false,
 }) async {
+  _loadBuildConfig(packageRoot);
+
   if (!destDir.existsSync()) {
     destDir.createSync(recursive: true);
   }
 
   var installed = 0;
 
-  for (final entry in webAssets.entries) {
+  for (final entry in _webAssets.entries) {
     final localName = entry.key;
     final assetName = entry.value;
     final dest = File('${destDir.path}/$localName');
 
-    final isWasmBuildOutput =
-        localName == 'pdf_oxide_bg.wasm' || localName == 'pdf_oxide.js';
+    final isWasmBuildOutput = _wasmBuildOutputs.contains(localName);
 
     final fresh = await resolveAsset(ResolveRequest(
       assetName: assetName,
+      downloadUrl: _downloadUrl(version, assetName),
       dest: dest,
       expectedHash: assetHashes[assetName],
       version: version,
@@ -278,11 +243,60 @@ Future<int> resolveWeb({
 }
 
 // ══════════════════════════════════════════════════════════════════
-// Compile callbacks
+// § 3 — Flutter registration (native only)
 // ══════════════════════════════════════════════════════════════════
 
-/// Compile native from the Flutter build hook (has BuildInput with
-/// NDK info, target triple, link mode).
+/// Register the native binary as a code asset.
+/// Release/AOT routes through hook/link.dart (passthrough today —
+/// see hook/link.dart for the tree-shaking roadmap).
+void _registerCodeAsset(
+  BuildInput input,
+  BuildOutputBuilder output,
+  File outFile,
+  LinkMode linkMode,
+) {
+  output.assets.code.add(
+    CodeAsset(
+      package: input.packageName,
+      name: _assetId,
+      linkMode: linkMode,
+      file: outFile.uri,
+    ),
+    routing: input.config.linkingEnabled
+        ? ToLinkHook(input.packageName)
+        : const ToAppBundle(),
+  );
+}
+
+/// Register files Flutter should watch for changes. When any of
+/// these change, Flutter re-runs the hook.
+void _registerDependencies(
+  BuildInput input,
+  BuildOutputBuilder output,
+  String targetTriple,
+) {
+  output.dependencies.add(input.packageRoot.resolve('hook/build.dart'));
+  output.dependencies.add(input.packageRoot.resolve('pubspec.yaml'));
+  output.dependencies.add(
+    input.packageRoot.resolve('vendor/pdf_oxide/Cargo.toml'),
+  );
+
+  if (hasVendorSource(input.packageRoot)) {
+    final targetDir =
+        p.join(p.fromUri(input.outputDirectory), 'cargo_target');
+    final depInfoPath = p.join(
+      targetDir, targetTriple, 'release', 'deps', 'pdf_oxide.d',
+    );
+    _registerCargoDeps(output, depInfoPath, input.packageRoot);
+  }
+}
+
+// ══════════════════════════════════════════════════════════════════
+// § 4 — Compile callbacks
+// ══════════════════════════════════════════════════════════════════
+
+// ── Native: from build hook (has BuildInput with NDK, triple) ────
+
 Future<void> _compileNativeFromHook(
   BuildInput input,
   String targetTriple,
@@ -300,6 +314,7 @@ Future<void> _compileNativeFromHook(
   final env = <String, String>{};
   final codeConfig = input.config.code;
 
+  // Android: use the NDK clang driver Flutter provides
   if (codeConfig.targetOS == OS.android) {
     final cc = codeConfig.cCompiler;
     if (cc != null) {
@@ -317,6 +332,7 @@ Future<void> _compileNativeFromHook(
     }
   }
 
+  // macOS: strip Xcode Developer PATH injections that break cargo
   if (Platform.isMacOS) {
     env['PATH'] = Platform.environment['PATH']!
         .split(':')
@@ -333,7 +349,7 @@ Future<void> _compileNativeFromHook(
       '--release',
       '--target', targetTriple,
       '--target-dir', targetDir,
-      '--features', _resolveFeatures(input.packageRoot),
+      '--features', _resolveFeatures(),
     ],
     environment: {...Platform.environment, ...env},
   );
@@ -365,7 +381,8 @@ Future<void> _compileNativeFromHook(
   _log.info('compiled → ${outFile.path}');
 }
 
-/// Compile native from CLI (no BuildInput — uses compile_rust.sh).
+// ── Native: from CLI (no BuildInput — uses compile_rust.sh) ──────
+
 Future<void> _compileNativeFromCli(Uri packageRoot, File dest) async {
   final script =
       File.fromUri(packageRoot.resolve('tool/compile_rust.sh'));
@@ -389,7 +406,7 @@ Future<void> _compileNativeFromCli(Uri packageRoot, File dest) async {
     );
   }
 
-  final libFileName = currentLibFileName();
+  final libFileName = _currentLibFileName();
   final compiled = File(p.join(
     p.fromUri(packageRoot),
     'vendor/pdf_oxide/target/release',
@@ -402,18 +419,21 @@ Future<void> _compileNativeFromCli(Uri packageRoot, File dest) async {
   compiled.copySync(dest.path);
 }
 
-/// Compile WASM outputs (pdf_oxide.js + pdf_oxide_bg.wasm).
+// ── Web: WASM build outputs (pdf_oxide.js + pdf_oxide_bg.wasm) ───
+
 Future<void> _compileWasm(
     Uri packageRoot, File dest, String targetFile) async {
   final existing =
       File.fromUri(packageRoot.resolve('web_assets/$targetFile'));
 
+  // Contributor has locally built WASM — copy directly
   if (existing.existsSync()) {
     dest.parent.createSync(recursive: true);
     existing.copySync(dest.path);
     return;
   }
 
+  // Compile from source
   final script =
       File.fromUri(packageRoot.resolve('tool/compile_rust.sh'));
   if (!script.existsSync()) {
@@ -446,7 +466,8 @@ Future<void> _compileWasm(
   existing.copySync(dest.path);
 }
 
-/// Copy hand-written JS from package web_assets/.
+// ── Web: hand-written JS (coordinator.js, worker.js) ─────────────
+
 Future<void> _copyWebAsset(
     Uri packageRoot, File dest, String fileName) async {
   final src = File.fromUri(packageRoot.resolve('web_assets/$fileName'));
@@ -458,54 +479,17 @@ Future<void> _copyWebAsset(
 }
 
 // ══════════════════════════════════════════════════════════════════
-// Platform detection — used by both hook and setup.dart
+// § 5 — CodeConfig mapping
 // ══════════════════════════════════════════════════════════════════
 
-/// Platform key for the current machine.
-String currentPlatformKey() {
-  if (Platform.isMacOS) return _isArm64() ? 'macos-arm64' : 'macos-x64';
-  if (Platform.isLinux) return _isArm64() ? 'linux-arm64' : 'linux-x64';
-  if (Platform.isWindows) {
-    return _isArm64() ? 'windows-arm64' : 'windows-x64';
-  }
-  throw UnsupportedError(
-      'Unsupported platform: ${Platform.operatingSystem}');
-}
+String _resolveFeatures() => _nativeFeatures;
 
-/// Library filename for the current platform.
-String currentLibFileName() {
+String _currentLibFileName() {
   if (Platform.isMacOS) return 'lib$_crateName.dylib';
   if (Platform.isLinux) return 'lib$_crateName.so';
   if (Platform.isWindows) return '$_crateName.dll';
   throw UnsupportedError(
       'Unsupported platform: ${Platform.operatingSystem}');
-}
-
-bool _isArm64() {
-  if (Platform.isWindows) {
-    return Platform.environment['PROCESSOR_ARCHITECTURE'] == 'ARM64';
-  }
-  final result = Process.runSync('uname', ['-m']);
-  final arch = (result.stdout as String).trim();
-  return arch == 'arm64' || arch == 'aarch64';
-}
-
-// ══════════════════════════════════════════════════════════════════
-// Internal helpers
-// ══════════════════════════════════════════════════════════════════
-
-String _resolveFeatures(Uri packageRoot) {
-  final script =
-      File.fromUri(packageRoot.resolve('tool/compile_rust.sh'));
-  if (script.existsSync()) {
-    final result =
-        Process.runSync('bash', [script.path, '--features', 'native']);
-    if (result.exitCode == 0) {
-      final features = (result.stdout as String).trim();
-      if (features.isNotEmpty) return features;
-    }
-  }
-  return _featuresFallback;
 }
 
 LinkMode _linkMode(CodeConfig code) {
@@ -567,6 +551,10 @@ String _platformKey(CodeConfig code) {
         'Unsupported: ${code.targetOS} ${code.targetArchitecture}'),
   };
 }
+
+// ══════════════════════════════════════════════════════════════════
+// § 6 — Cargo dep-info registration
+// ══════════════════════════════════════════════════════════════════
 
 void _registerCargoDeps(
   BuildOutputBuilder output,

--- a/hook/link.dart
+++ b/hook/link.dart
@@ -1,0 +1,72 @@
+// Link hook for pdf_manipulator.
+//
+// ═══════════════════════════════════════════════════════════════════
+// TODAY — passthrough
+// ═══════════════════════════════════════════════════════════════════
+//
+// Forwards the native binary to the app bundle unchanged. The Rust
+// engine compiles as one monolithic binary with all features enabled.
+//
+// ═══════════════════════════════════════════════════════════════════
+// NEAR-TERM — user_defines (works today, see icu_kit)
+// ═══════════════════════════════════════════════════════════════════
+//
+// Consumers opt out of features they don't need via pubspec:
+//
+//   hooks:
+//     user_defines:
+//       pdf_manipulator:
+//         rendering: false
+//         office: false
+//
+// The build hook reads these and passes matching --features to cargo.
+// One smaller binary, no link hook changes needed — user_defines flow
+// through BuildInput, not through the linker.
+//
+// This pattern is proven by icu_kit (bundleCldrData user_define
+// toggles the compiled_data cargo feature).
+//
+// ═══════════════════════════════════════════════════════════════════
+// LONG-TERM — automatic tree-shaking via @RecordUse
+// ═══════════════════════════════════════════════════════════════════
+//
+// The compiler records which Dart APIs the app actually calls. This
+// hook reads the usage record, maps methods to cargo features, and
+// recompiles with only the needed features. Zero user config — the
+// compiler decides.
+//
+// Blocked:
+//   @RecordUse instance methods — dart-lang/native#2902
+//   FFI tree-shaking umbrella   — dart-lang/sdk#52970
+//
+// ═══════════════════════════════════════════════════════════════════
+// WEB — different tradeoff
+// ═══════════════════════════════════════════════════════════════════
+//
+// WASM is served over the network — size matters more than native.
+// Native gets one smaller binary via cargo features (no duplicate
+// deps). Web could ship multiple per-feature WASM binaries and have
+// setup download only the ones needed, but that adds too much user
+// complexity for marginal gain.
+//
+// Better path: wait for web build hook support (dart-lang/native#988)
+// which gives web the same automatic cargo-features approach as
+// native. Until then, web ships the full WASM binary.
+//
+// Note: unlike icu_kit where the binary is big because of DATA
+// (CLDR locales — solvable by lazy per-locale loading), pdf_manipulator's
+// size is CODE (rendering engine, office converter, signing).
+// Data splitting doesn't apply here — only code stripping helps.
+
+// Called by Flutter on release/AOT builds when build.dart routes
+// the native binary via ToLinkHook. Not called on debug builds
+// (routed directly to ToAppBundle) or for web assets.
+import 'package:hooks/hooks.dart';
+
+void main(List<String> args) async {
+  await link(args, (LinkInput input, LinkOutputBuilder output) async {
+    for (final asset in input.assets.encodedAssets) {
+      output.assets.addEncodedAsset(asset);
+    }
+  });
+}

--- a/lib/src/hook/resolver.dart
+++ b/lib/src/hook/resolver.dart
@@ -19,9 +19,6 @@ import 'package:path/path.dart' as p;
 
 final _log = Logger('pdf_manipulator:resolver');
 
-const _releaseRepo =
-    'https://github.com/whuppi/pdf_manipulator/releases/download';
-
 /// Everything the resolver needs to resolve one asset.
 ///
 /// Built by the Flutter build hook or by setup.dart. The resolver
@@ -30,6 +27,7 @@ class ResolveRequest {
   /// Create a resolve request.
   const ResolveRequest({
     required this.assetName,
+    required this.downloadUrl,
     required this.dest,
     required this.version,
     required this.packageRoot,
@@ -40,9 +38,11 @@ class ResolveRequest {
   });
 
   /// GitHub Release asset name (e.g. `macos-arm64-libpdf_oxide.dylib`
-  /// or `wasm-pdf_oxide_bg.wasm`). Used to build the download URL and
-  /// as the hash lookup key.
+  /// or `wasm-pdf_oxide_bg.wasm`). Used as the hash lookup key.
   final String assetName;
+
+  /// Full download URL for this asset on GitHub Releases.
+  final String downloadUrl;
 
   /// Final output location for the resolved file.
   final File dest;
@@ -108,7 +108,7 @@ Future<bool> resolveAsset(ResolveRequest req) async {
 
   // Step 2 — Download
   if (req.version != '0.0.0') {
-    final url = '$_releaseRepo/v${req.version}/${req.assetName}';
+    final url = req.downloadUrl;
     final target = req.cacheFile ?? req.dest;
     if (await _download(url, target)) {
       _copyIfNeeded(target, req.dest);

--- a/tool/compile_rust.sh
+++ b/tool/compile_rust.sh
@@ -28,12 +28,20 @@ set -euo pipefail
 
 
 # ═══════════════════════════════════════════════════════════════════
-# Feature flags (single source of truth)
+# Paths
 # ═══════════════════════════════════════════════════════════════════
-# build.dart and analyze.sh read these via: ./tool/compile_rust.sh --features native
 
-NATIVE_FEATURES="icc,legacy-crypto,rendering,signatures,native-bridge"
-WASM_FEATURES="wasm,rendering"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PKG_ROOT="$(dirname "$SCRIPT_DIR")"
+MANIFEST="$PKG_ROOT/vendor/pdf_oxide/Cargo.toml"
+VENDOR="$PKG_ROOT/vendor/pdf_oxide"
+
+# ═══════════════════════════════════════════════════════════════════
+# Feature flags — read from build.json (single source of truth)
+# ═══════════════════════════════════════════════════════════════════
+
+NATIVE_FEATURES=$(python3 -c "import json; print(json.load(open('$PKG_ROOT/build.json'))['features']['native'])")
+WASM_FEATURES=$(python3 -c "import json; print(json.load(open('$PKG_ROOT/build.json'))['features']['wasm'])")
 
 if [[ "${1:-}" == "--features" ]]; then
   case "${2:-all}" in
@@ -43,16 +51,6 @@ if [[ "${1:-}" == "--features" ]]; then
   esac
   exit 0
 fi
-
-
-# ═══════════════════════════════════════════════════════════════════
-# Paths
-# ═══════════════════════════════════════════════════════════════════
-
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-PKG_ROOT="$(dirname "$SCRIPT_DIR")"
-MANIFEST="$PKG_ROOT/vendor/pdf_oxide/Cargo.toml"
-VENDOR="$PKG_ROOT/vendor/pdf_oxide"
 
 if [ ! -f "$MANIFEST" ]; then
   echo "Error: run from package root (vendor/pdf_oxide/Cargo.toml not found)"

--- a/tool/release.sh
+++ b/tool/release.sh
@@ -55,7 +55,8 @@ MODE="${1:---help}"
 TAG="${2:-}"
 VERSION="${TAG:+${TAG#v}}"
 
-REPO="${GITHUB_REPOSITORY:-whuppi/pdf_manipulator}"
+_REPO_FROM_JSON=$(python3 -c "import json; print(json.load(open('build.json'))['repo'])")
+REPO="${GITHUB_REPOSITORY:-$_REPO_FROM_JSON}"
 REPO_URL="https://github.com/$REPO"
 PKG_NAME="pdf_manipulator"
 
@@ -197,16 +198,25 @@ stamp_asset_hashes() {
     done)
 
   # Hand-written web assets — hash from the tag's web_assets/ directory.
+  # Reads local filenames + asset names from build.json, skipping
+  # wasmBuildOutputs (those get hashes from the Release API above).
   local web_entries=""
-  for js_file in coordinator.js worker.js; do
-    local src="web_assets/$js_file"
+  while IFS=$'\t' read -r local_name asset_name; do
+    local src="web_assets/$local_name"
     if [ -f "$src" ]; then
       local hash
       hash=$( (sha256sum "$src" 2>/dev/null || shasum -a 256 "$src") | cut -d' ' -f1)
-      web_entries+="  'wasm-$js_file': '$hash',"$'\n'
-      echo "  wasm-$js_file ... ${hash:0:12}..." >&2
+      web_entries+="  '$asset_name': '$hash',"$'\n'
+      echo "  $asset_name ... ${hash:0:12}..." >&2
     fi
-  done
+  done < <(python3 -c "
+import json
+d = json.load(open('build.json'))
+skip = set(d['wasmBuildOutputs'])
+for local, asset in d['web'].items():
+    if local not in skip:
+        print(f'{local}\t{asset}')
+")
 
   local all_entries
   all_entries=$(printf '%s\n%s' "$release_entries" "$web_entries" | sed '/^$/d')


### PR DESCRIPTION
## Summary

- Added `hook/link.dart` passthrough instead of removing `ToLinkHook` routing — fixes release builds while keeping the infrastructure for future tree-shaking
- Added `build.json` as single source of truth for crate name, repo, cargo features, web asset map
- Refactored `setup.dart` to target-based CLI (`setup web`, `setup android`, etc.) — native delegates to `flutter build`
- Made `_resolveNative` private — correct cache path only exists inside the build hook
- Added release-build tests to Makefile + full-test.yml (all 6 targets, Android + Web as 3-OS matrix)
- Updated docs, labels, triage auto-labeling

## Original issue

Release/AOT builds failed because `ToLinkHook` routed to a link hook that didn't exist. Fixed by shipping the link hook, not by removing the routing.