### PR TITLE
fix(hook): append .cmd to the NDK clang linker on Windows hosts (Android cross-compile fails)

### DIFF
--- a/hook/build.dart
+++ b/hook/build.dart
@@ -302,7 +302,14 @@ Future<void> _compileNativeFromHook(
       final ndkTriple = targetTriple == 'armv7-linux-androideabi'
           ? 'armv7a-linux-androideabi'
           : targetTriple;
-      final linker = p.join(compilerDir, '${ndkTriple}21-clang');
+      // The NDK per-API clang driver is a `.cmd` batch wrapper on Windows
+      // hosts (e.g. aarch64-linux-android21-clang.cmd); passing the bare name
+      // makes cargo fail with "could not exec the linker ... program not
+      // found". Append the host executable extension so Android cross-compiles
+      // link from a Windows host as well as Linux/macOS. Platform.isWindows
+      // here is the BUILD host (which runs cargo), not the Android target.
+      final clangExt = Platform.isWindows ? '.cmd' : '';
+      final linker = p.join(compilerDir, '${ndkTriple}21-clang$clangExt');
       final ar = p.join(compilerDir, 'llvm-ar');
       final envKey =
           'CARGO_TARGET_${targetTriple.toUpperCase().replaceAll('-', '_')}';


### PR DESCRIPTION
## Problem

Cross-compiling the vendored `pdf_oxide` source for Android from a **Windows**
host fails in `cargo build`:

```
error: linker `...\toolchains\llvm\prebuilt\windows-x86_64\bin\aarch64-linux-android21-clang` not found
(could not exec the linker ... program not found)
```

Linux/macOS hosts are unaffected. This path is hit whenever the source-compile
branch runs on Windows (the `dev` / `0.0.0` version always compiles from source;
pub.dev consumers hit it on a prebuilt 404 fallback).

## Root cause

In the Android branch of `hook/build.dart` the NDK clang driver name is built
without a host-specific executable extension:

```dart
final linker = p.join(compilerDir, '${ndkTriple}21-clang');
```

In the Android NDK (r28) the per-API clang drivers are **batch wrappers** on
Windows — the file on disk is `aarch64-linux-android21-clang.cmd`, not a bare
`aarch64-linux-android21-clang`. Cargo passes the explicit `*_LINKER` value
straight to the OS exec, which cannot run a `.cmd` without the extension, so the
link fails. (`llvm-ar` is resolved by Cargo's own PATH logic, so only the
explicit linker we set is affected.)

## Fix

Append `.cmd` to the linker filename when the build host is Windows; keep it
empty elsewhere. `Platform.isWindows` here is the **build host** (which runs
cargo), not the Android target.

```dart
final clangExt = Platform.isWindows ? '.cmd' : '';
final linker = p.join(compilerDir, '${ndkTriple}21-clang$clangExt');
```

## Verification

- `flutter build apk --debug` / `--release` (Android source-compile path) now
  links successfully on a Windows 11 host with NDK r28.
- Linux/macOS hosts unchanged — `clangExt` is empty there, so the filename is
  byte-identical to before.
- Validated as a `dependency_override` in a shipping app built from Windows.

Independent of PR for the release/AOT routing fix — different region of the same
file, so the two can merge in either order.
