### PR TITLE
fix(ci): release gate only triggers on new changelog versions

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -14,18 +14,27 @@ permissions:
   pull-requests: write
 
 env:
-  RUNNER: ubuntu-24.04
+  DEFAULT_RUNNER: ubuntu-24.04
 
 jobs:
+  inputs:
+    runs-on: ubuntu-24.04
+    outputs:
+      runner: ${{ steps.resolve.outputs.runner }}
+    steps:
+      - id: resolve
+        run: echo "runner=${{ env.DEFAULT_RUNNER }}" >> $GITHUB_OUTPUT
+
   # Revoke stale ready-to-test label when new commits are pushed.
   # Lives here (not full-test.yml) because pull_request_target gives
   # write access to labels on fork PRs.
   revoke-ready-to-test:
+    needs: inputs
     if: >-
       github.event_name == 'pull_request_target' &&
       github.event.action == 'synchronize' &&
       contains(github.event.pull_request.labels.*.name, 'ready-to-test')
-    runs-on: ${{ env.RUNNER }}
+    runs-on: ${{ needs.inputs.outputs.runner }}
     steps:
       - name: Remove label + notify
         env:
@@ -43,12 +52,13 @@ jobs:
   # run dependabot commands (no push access), so we comment asking a human.
   # Skips when dependabot itself pushes (after a recreate) to avoid loops.
   dependabot-needs-recreate:
+    needs: inputs
     if: >-
       github.event_name == 'pull_request_target' &&
       github.event.action == 'synchronize' &&
       github.event.pull_request.user.login == 'dependabot[bot]' &&
       github.event.sender.login != 'dependabot[bot]'
-    runs-on: ${{ env.RUNNER }}
+    runs-on: ${{ needs.inputs.outputs.runner }}
     steps:
       - name: Notify maintainer
         env:
@@ -59,7 +69,8 @@ jobs:
             "New commits pushed — workflows may be outdated. A maintainer with push access should comment \`@dependabot recreate\` to pick up the latest changes."
 
   assign-and-label:
-    runs-on: ${{ env.RUNNER }}
+    needs: inputs
+    runs-on: ${{ needs.inputs.outputs.runner }}
     steps:
       # Auto-assign maintainer on everything
       - name: Auto-assign

--- a/tool/release.sh
+++ b/tool/release.sh
@@ -461,11 +461,22 @@ cmd_gate() {
   fi
 
   if grep -Fqx "$target_file" <<< "$changed_files"; then
-    local found_version
-    found_version=$(get_changelog_versions "$target_file" | head -1 || true)
-    gh_output "should_run" "true"
-    gh_output "version" "${found_version:-unknown}"
-    echo "Gate: $target_file changed, version=$found_version"
+    # Only trigger if a NEW version header was added, not just edits.
+    local versions_after versions_before new_version
+    versions_after=$(get_changelog_versions "$target_file")
+    versions_before=$(git show "${BEFORE:-HEAD~1}:$target_file" 2>/dev/null \
+      | sed -n 's/^## \([^ ]*\).*/\1/p' || true)
+    new_version=$(comm -23 <(echo "$versions_after" | sort) <(echo "$versions_before" | sort) | head -1)
+
+    if [[ -n "$new_version" ]]; then
+      gh_output "should_run" "true"
+      gh_output "version" "$new_version"
+      echo "Gate: new version $new_version added to $target_file"
+    else
+      gh_output "should_run" "false"
+      gh_output "version" ""
+      echo "Gate: $target_file changed but no new version header added, skipping"
+    fi
   else
     gh_output "should_run" "false"
     gh_output "version" ""


### PR DESCRIPTION
## Summary

- Release pipeline was triggering on any `CHANGELOG.md` / `CHANGELOG.pre.md` edit — typos, formatting, reordering existing entries all triggered a full release build.
- Gate now compares version headers before vs after the push using `comm -23`. Only triggers when a NEW `## version` header exists that wasn't in the previous commit.

## Test plan

- [ ] Edit existing changelog entry, push to dev — gate skips
- [ ] Add new `## 1.0.6-dev.0` header, push to dev — gate triggers