### PR TITLE
chore: add 1.0.6 changelog entries

### DIFF
--- a/.github/actions/capabilities/android-emulator/action.yml
+++ b/.github/actions/capabilities/android-emulator/action.yml
@@ -25,10 +25,6 @@ inputs:
     description: "Android API level (30 is lightest ATD available)"
     required: false
     default: '30'
-  script-timeout:
-    description: "Max seconds for script before force-kill (0 = no limit)"
-    required: false
-    default: '2700'
 
 runs:
   using: composite
@@ -38,45 +34,6 @@ runs:
       run: |
         $ANDROID_HOME/platform-tools/adb start-server
         $ANDROID_HOME/platform-tools/adb devices
-
-    # Write the user script + cleanup to a temp file, then wrap it
-    # with a timeout. The emulator-runner action splits multi-line
-    # script: blocks into separate /bin/sh -c calls, breaking if/while.
-    # A file-based approach avoids that entirely.
-    - name: Write emulator scripts
-      if: runner.os != 'Windows'
-      shell: bash
-      run: |
-        cat > /tmp/emulator-script.sh << 'EMUSCRIPT'
-        ${{ inputs.script }}
-        adb -s emulator-5554 emu kill 2>/dev/null; true
-        pkill -f 'crashpad[_]handler' 2>/dev/null; true
-        EMUSCRIPT
-        cat > /tmp/emulator-timeout.sh << 'EMUWRAP'
-        #!/usr/bin/env bash
-        LIMIT=${1:-2700}
-        if [ "$LIMIT" -gt 0 ] 2>/dev/null; then
-          bash /tmp/emulator-script.sh &
-          PID=$!
-          ELAPSED=0
-          while kill -0 $PID 2>/dev/null; do
-            if [ $ELAPSED -ge $LIMIT ]; then
-              echo "::warning::Script still running after ${LIMIT}s — killing (likely hung on teardown)"
-              kill -9 $PID 2>/dev/null
-              wait $PID 2>/dev/null
-              exit 0
-            fi
-            sleep 5
-            ELAPSED=$((ELAPSED + 5))
-          done
-          wait $PID 2>/dev/null
-          exit $?
-        else
-          bash /tmp/emulator-script.sh
-          exit $?
-        fi
-        EMUWRAP
-        chmod +x /tmp/emulator-timeout.sh /tmp/emulator-script.sh
 
     # ── Linux / macOS — use the action ──
     - name: Emulator (Linux/macOS)
@@ -90,7 +47,7 @@ runs:
         emulator-options: -no-snapshot-save -no-window -noaudio -no-boot-anim
         emulator-boot-timeout: 600
         disable-animations: true
-        script: /tmp/emulator-timeout.sh ${{ inputs.script-timeout }}
+        script: ${{ inputs.script }}
 
     # ── Windows — manual boot (action doesn't support Windows) ──
     # Git Bash needs Unix paths — cygpath converts C:\Android\... to /c/Android/...
@@ -151,25 +108,7 @@ runs:
     - name: Run script (Windows)
       if: runner.os == 'Windows'
       shell: bash
-      run: |
-        LIMIT=${{ inputs.script-timeout }}
-        bash -c '${{ inputs.script }}' &
-        SCRIPT_PID=$!
-        if [ "$LIMIT" -gt 0 ] 2>/dev/null; then
-          ELAPSED=0
-          while kill -0 $SCRIPT_PID 2>/dev/null; do
-            if [ $ELAPSED -ge $LIMIT ]; then
-              echo "::warning::Script still running after ${LIMIT}s — killing"
-              kill -9 $SCRIPT_PID 2>/dev/null; true
-              break
-            fi
-            sleep 5
-            ELAPSED=$((ELAPSED + 5))
-          done
-        fi
-        wait $SCRIPT_PID 2>/dev/null; SCRIPT_EXIT=$?
-        [ $SCRIPT_EXIT -eq 137 ] && SCRIPT_EXIT=0
-        exit $SCRIPT_EXIT
+      run: ${{ inputs.script }}
 
     - name: Kill emulator (Windows)
       if: always() && runner.os == 'Windows'

--- a/.github/actions/capabilities/android-emulator/action.yml
+++ b/.github/actions/capabilities/android-emulator/action.yml
@@ -50,7 +50,7 @@ runs:
         script: |
           ${{ inputs.script }}
           adb -s emulator-5554 emu kill 2>/dev/null; true
-          pkill -f crashpad_handler 2>/dev/null; true
+          pkill -f 'crashpad[_]handler' 2>/dev/null; true
 
     # ── Windows — manual boot (action doesn't support Windows) ──
     # Git Bash needs Unix paths — cygpath converts C:\Android\... to /c/Android/...

--- a/.github/actions/capabilities/android-emulator/action.yml
+++ b/.github/actions/capabilities/android-emulator/action.yml
@@ -55,21 +55,26 @@ runs:
         cat > /tmp/emulator-timeout.sh << 'EMUWRAP'
         #!/usr/bin/env bash
         LIMIT=${1:-2700}
-        bash /tmp/emulator-script.sh &
-        PID=$!
-        ELAPSED=0
-        while kill -0 $PID 2>/dev/null; do
-          if [ $ELAPSED -ge $LIMIT ]; then
-            echo "::warning::Script still running after ${LIMIT}s — killing (likely hung on teardown)"
-            kill -9 $PID 2>/dev/null
-            wait $PID 2>/dev/null
-            exit 0
-          fi
-          sleep 5
-          ELAPSED=$((ELAPSED + 5))
-        done
-        wait $PID 2>/dev/null
-        exit $?
+        if [ "$LIMIT" -gt 0 ] 2>/dev/null; then
+          bash /tmp/emulator-script.sh &
+          PID=$!
+          ELAPSED=0
+          while kill -0 $PID 2>/dev/null; do
+            if [ $ELAPSED -ge $LIMIT ]; then
+              echo "::warning::Script still running after ${LIMIT}s — killing (likely hung on teardown)"
+              kill -9 $PID 2>/dev/null
+              wait $PID 2>/dev/null
+              exit 0
+            fi
+            sleep 5
+            ELAPSED=$((ELAPSED + 5))
+          done
+          wait $PID 2>/dev/null
+          exit $?
+        else
+          bash /tmp/emulator-script.sh
+          exit $?
+        fi
         EMUWRAP
         chmod +x /tmp/emulator-timeout.sh /tmp/emulator-script.sh
 

--- a/.github/actions/capabilities/android-emulator/action.yml
+++ b/.github/actions/capabilities/android-emulator/action.yml
@@ -39,6 +39,40 @@ runs:
         $ANDROID_HOME/platform-tools/adb start-server
         $ANDROID_HOME/platform-tools/adb devices
 
+    # Write the user script + cleanup to a temp file, then wrap it
+    # with a timeout. The emulator-runner action splits multi-line
+    # script: blocks into separate /bin/sh -c calls, breaking if/while.
+    # A file-based approach avoids that entirely.
+    - name: Write emulator scripts
+      if: runner.os != 'Windows'
+      shell: bash
+      run: |
+        cat > /tmp/emulator-script.sh << 'EMUSCRIPT'
+        ${{ inputs.script }}
+        adb -s emulator-5554 emu kill 2>/dev/null; true
+        pkill -f 'crashpad[_]handler' 2>/dev/null; true
+        EMUSCRIPT
+        cat > /tmp/emulator-timeout.sh << 'EMUWRAP'
+        #!/usr/bin/env bash
+        LIMIT=${1:-2700}
+        bash /tmp/emulator-script.sh &
+        PID=$!
+        ELAPSED=0
+        while kill -0 $PID 2>/dev/null; do
+          if [ $ELAPSED -ge $LIMIT ]; then
+            echo "::warning::Script still running after ${LIMIT}s — killing (likely hung on teardown)"
+            kill -9 $PID 2>/dev/null
+            wait $PID 2>/dev/null
+            exit 0
+          fi
+          sleep 5
+          ELAPSED=$((ELAPSED + 5))
+        done
+        wait $PID 2>/dev/null
+        exit $?
+        EMUWRAP
+        chmod +x /tmp/emulator-timeout.sh /tmp/emulator-script.sh
+
     # ── Linux / macOS — use the action ──
     - name: Emulator (Linux/macOS)
       if: runner.os != 'Windows'
@@ -51,27 +85,7 @@ runs:
         emulator-options: -no-snapshot-save -no-window -noaudio -no-boot-anim
         emulator-boot-timeout: 600
         disable-animations: true
-        script: |
-          LIMIT=${{ inputs.script-timeout }}
-          bash -c '${{ inputs.script }}' &
-          SCRIPT_PID=$!
-          if [ "$LIMIT" -gt 0 ] 2>/dev/null; then
-            ELAPSED=0
-            while kill -0 $SCRIPT_PID 2>/dev/null; do
-              if [ $ELAPSED -ge $LIMIT ]; then
-                echo "::warning::Script still running after ${LIMIT}s — killing (tests likely passed but process hung on teardown)"
-                kill -9 $SCRIPT_PID 2>/dev/null; true
-                break
-              fi
-              sleep 5
-              ELAPSED=$((ELAPSED + 5))
-            done
-          fi
-          wait $SCRIPT_PID 2>/dev/null; SCRIPT_EXIT=$?
-          [ $SCRIPT_EXIT -eq 137 ] && SCRIPT_EXIT=0
-          adb -s emulator-5554 emu kill 2>/dev/null; true
-          pkill -f 'crashpad[_]handler' 2>/dev/null; true
-          exit $SCRIPT_EXIT
+        script: /tmp/emulator-timeout.sh ${{ inputs.script-timeout }}
 
     # ── Windows — manual boot (action doesn't support Windows) ──
     # Git Bash needs Unix paths — cygpath converts C:\Android\... to /c/Android/...

--- a/.github/actions/capabilities/android-emulator/action.yml
+++ b/.github/actions/capabilities/android-emulator/action.yml
@@ -49,8 +49,8 @@ runs:
         disable-animations: true
         script: |
           ${{ inputs.script }}
-          adb -s emulator-5554 emu kill || true
-          pkill -f crashpad_handler || true
+          adb -s emulator-5554 emu kill 2>/dev/null; true
+          pkill -f crashpad_handler 2>/dev/null; true
 
     # ── Windows — manual boot (action doesn't support Windows) ──
     # Git Bash needs Unix paths — cygpath converts C:\Android\... to /c/Android/...

--- a/.github/actions/capabilities/android-emulator/action.yml
+++ b/.github/actions/capabilities/android-emulator/action.yml
@@ -25,6 +25,10 @@ inputs:
     description: "Android API level (30 is lightest ATD available)"
     required: false
     default: '30'
+  script-timeout:
+    description: "Max seconds for script before force-kill (0 = no limit)"
+    required: false
+    default: '2700'
 
 runs:
   using: composite
@@ -48,9 +52,26 @@ runs:
         emulator-boot-timeout: 600
         disable-animations: true
         script: |
-          ${{ inputs.script }}
+          LIMIT=${{ inputs.script-timeout }}
+          bash -c '${{ inputs.script }}' &
+          SCRIPT_PID=$!
+          if [ "$LIMIT" -gt 0 ] 2>/dev/null; then
+            ELAPSED=0
+            while kill -0 $SCRIPT_PID 2>/dev/null; do
+              if [ $ELAPSED -ge $LIMIT ]; then
+                echo "::warning::Script still running after ${LIMIT}s — killing (tests likely passed but process hung on teardown)"
+                kill -9 $SCRIPT_PID 2>/dev/null; true
+                break
+              fi
+              sleep 5
+              ELAPSED=$((ELAPSED + 5))
+            done
+          fi
+          wait $SCRIPT_PID 2>/dev/null; SCRIPT_EXIT=$?
+          [ $SCRIPT_EXIT -eq 137 ] && SCRIPT_EXIT=0
           adb -s emulator-5554 emu kill 2>/dev/null; true
           pkill -f 'crashpad[_]handler' 2>/dev/null; true
+          exit $SCRIPT_EXIT
 
     # ── Windows — manual boot (action doesn't support Windows) ──
     # Git Bash needs Unix paths — cygpath converts C:\Android\... to /c/Android/...
@@ -111,7 +132,25 @@ runs:
     - name: Run script (Windows)
       if: runner.os == 'Windows'
       shell: bash
-      run: ${{ inputs.script }}
+      run: |
+        LIMIT=${{ inputs.script-timeout }}
+        bash -c '${{ inputs.script }}' &
+        SCRIPT_PID=$!
+        if [ "$LIMIT" -gt 0 ] 2>/dev/null; then
+          ELAPSED=0
+          while kill -0 $SCRIPT_PID 2>/dev/null; do
+            if [ $ELAPSED -ge $LIMIT ]; then
+              echo "::warning::Script still running after ${LIMIT}s — killing"
+              kill -9 $SCRIPT_PID 2>/dev/null; true
+              break
+            fi
+            sleep 5
+            ELAPSED=$((ELAPSED + 5))
+          done
+        fi
+        wait $SCRIPT_PID 2>/dev/null; SCRIPT_EXIT=$?
+        [ $SCRIPT_EXIT -eq 137 ] && SCRIPT_EXIT=0
+        exit $SCRIPT_EXIT
 
     - name: Kill emulator (Windows)
       if: always() && runner.os == 'Windows'

--- a/.github/actions/capabilities/fvm/action.yml
+++ b/.github/actions/capabilities/fvm/action.yml
@@ -17,8 +17,8 @@ runs:
       uses: actions/cache@v5
       with:
         path: ~/.pub-cache
-        key: pub-${{ runner.os }}-${{ hashFiles('pubspec.yaml', 'example/pubspec.yaml') }}
-        restore-keys: pub-${{ runner.os }}-
+        key: pub-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pubspec.yaml', 'example/pubspec.yaml') }}
+        restore-keys: pub-${{ runner.os }}-${{ runner.arch }}-
 
     - name: Cache Flutter SDK (FVM)
       uses: actions/cache@v5

--- a/.github/actions/capabilities/gradle-cache/action.yml
+++ b/.github/actions/capabilities/gradle-cache/action.yml
@@ -19,8 +19,8 @@ runs:
         path: |
           ~/.gradle/caches
           ~/.gradle/wrapper
-        key: gradle-${{ hashFiles('example/android/build.gradle.kts', 'example/android/app/build.gradle.kts') }}
-        restore-keys: gradle-
+        key: gradle-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('example/android/build.gradle.kts', 'example/android/app/build.gradle.kts') }}
+        restore-keys: gradle-${{ runner.os }}-${{ runner.arch }}-
 
     - name: Stop Gradle daemon
       if: inputs.phase == 'save'
@@ -36,4 +36,4 @@ runs:
         path: |
           ~/.gradle/caches
           ~/.gradle/wrapper
-        key: gradle-${{ hashFiles('example/android/build.gradle.kts', 'example/android/app/build.gradle.kts') }}
+        key: gradle-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('example/android/build.gradle.kts', 'example/android/app/build.gradle.kts') }}

--- a/.github/actions/capabilities/pods-cache/action.yml
+++ b/.github/actions/capabilities/pods-cache/action.yml
@@ -7,5 +7,5 @@ runs:
     - uses: actions/cache@v5
       with:
         path: example/ios/Pods
-        key: pods-${{ hashFiles('example/ios/Podfile') }}
-        restore-keys: pods-
+        key: pods-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('example/ios/Podfile') }}
+        restore-keys: pods-${{ runner.os }}-${{ runner.arch }}-

--- a/.github/actions/capabilities/rust/action.yml
+++ b/.github/actions/capabilities/rust/action.yml
@@ -23,8 +23,8 @@ runs:
         path: |
           ~/.cargo/registry/cache
           ~/.cargo/git/db
-        key: cargo-${{ runner.os }}-${{ steps.sub.outputs.pdf_oxide }}-${{ steps.sub.outputs.office_oxide }}
-        restore-keys: cargo-${{ runner.os }}-
+        key: cargo-${{ runner.os }}-${{ runner.arch }}-${{ steps.sub.outputs.pdf_oxide }}-${{ steps.sub.outputs.office_oxide }}
+        restore-keys: cargo-${{ runner.os }}-${{ runner.arch }}-
 
     - uses: dtolnay/rust-toolchain@stable
       with:

--- a/.github/actions/capabilities/wasm-cache/action.yml
+++ b/.github/actions/capabilities/wasm-cache/action.yml
@@ -8,4 +8,4 @@ runs:
       id: wasm-cache
       with:
         path: web_assets/pdf_oxide_bg.wasm
-        key: wasm-${{ env.SUBMODULE_PDF_OXIDE }}
+        key: wasm-${{ runner.os }}-${{ runner.arch }}-${{ env.SUBMODULE_PDF_OXIDE }}

--- a/.github/actions/capabilities/xcode-cache/action.yml
+++ b/.github/actions/capabilities/xcode-cache/action.yml
@@ -11,5 +11,5 @@ runs:
   steps:
     - uses: irgaly/xcode-cache@v1
       with:
-        key: xcode-${{ inputs.target }}-${{ env.SUBMODULE_PDF_OXIDE }}
-        restore-keys: xcode-${{ inputs.target }}-
+        key: xcode-${{ runner.os }}-${{ runner.arch }}-${{ inputs.target }}-${{ env.SUBMODULE_PDF_OXIDE }}
+        restore-keys: xcode-${{ runner.os }}-${{ runner.arch }}-${{ inputs.target }}-

--- a/.github/workflows/flutter-upgrade.yml
+++ b/.github/workflows/flutter-upgrade.yml
@@ -43,13 +43,16 @@ jobs:
         run: |
           CURRENT=$(sed -n 's/.*"flutter": *"\([^"]*\)".*/\1/p' .fvmrc)
           RELEASES_JSON=$(curl -sS https://storage.googleapis.com/flutter_infra_release/releases/releases_linux.json)
-          STABLE_HASH=$(echo "$RELEASES_JSON" | grep -oE '"stable":"[^"]*"' | head -1 | sed 's/"stable":"//;s/"//')
-          LATEST=$(echo "$RELEASES_JSON" | grep -oE "\"hash\":\"${STABLE_HASH}\"[^}]*\"version\":\"[^\"]*\"" | grep -oE '"version":"[^"]*"' | sed 's/"version":"//;s/"//')
+          STABLE_HASH=$(echo "$RELEASES_JSON" | grep -oE '"stable" *: *"[^"]*"' | head -1 | sed 's/"stable" *: *"//;s/"//')
+          LATEST=$(echo "$RELEASES_JSON" | grep -A5 "\"hash\" *: *\"${STABLE_HASH}\"" | grep -oE '"version" *: *"[^"]*"' | head -1 | sed 's/"version" *: *"//;s/"//')
 
           echo "current=$CURRENT" >> $GITHUB_OUTPUT
           echo "latest=$LATEST" >> $GITHUB_OUTPUT
 
-          if [ "$CURRENT" = "$LATEST" ]; then
+          if [ -z "$LATEST" ]; then
+            echo "needs_upgrade=false" >> $GITHUB_OUTPUT
+            echo "::error::Could not detect latest Flutter stable version"
+          elif [ "$CURRENT" = "$LATEST" ]; then
             echo "needs_upgrade=false" >> $GITHUB_OUTPUT
             echo "Already on latest stable: $CURRENT"
           else

--- a/.github/workflows/full-test.yml
+++ b/.github/workflows/full-test.yml
@@ -159,7 +159,7 @@ jobs:
           # Non-emulator jobs (verify) run fine on ARM.
           - { name: "verify: Android (macos-arm64)", runner: macos-14,         make: verify-android, timeout: 40, java: true, gradle-cache: true }
           - { name: "verify: Android (win-x64)",     runner: windows-2025-vs2026,     make: verify-android, timeout: 60, java: true, gradle-cache: true }
-          - { name: "int: Android (macos-intel)",     runner: macos-15-intel,   make: test-example-android, timeout: 40, java: true, hw-accel: true, gradle-cache: true, emulator: true }
+          - { name: "int: Android (macos-intel)",     runner: macos-15-intel,   make: test-example-android, timeout: 60, java: true, hw-accel: true, gradle-cache: true, emulator: true }
           - { name: "int: Android (win-x64)",        runner: windows-2025-vs2026, make: test-example-android, timeout: 60, java: true, hw-accel: true, gradle-cache: true, emulator: true }
           # Web on other runners
           - { name: "pkg: Web (macos-arm64)",      runner: macos-14,       make: test-ops-web,    timeout: 40, chrome: true, wasm-cache: true, wasm-build: true }

--- a/.github/workflows/full-test.yml
+++ b/.github/workflows/full-test.yml
@@ -1,10 +1,10 @@
 # Full test — maintainer adds "ready-to-test" label to trigger.
 # Label auto-removed on new pushes (stale results = wasted compute).
 #
-# Two matrices: core (one runner per target) and portability
-# (every valid runner combo — proves any developer on any machine
-# can build with this package). Each row declares capabilities —
-# make-target provisions them.
+# Single matrix — core rows run always, portability rows (marked
+# [P]) run when the portability toggle is on. Proves any developer
+# on any machine can build with this package. Each row declares
+# capabilities — make-target provisions them.
 #
 # Runners: per-row in matrix (target-specific). Gate job uses
 # configurable infra runner (default: ubuntu-24.04).
@@ -63,8 +63,7 @@ jobs:
           echo "portability=${{ inputs.portability || env.DEFAULT_PORTABILITY }}" >> $GITHUB_OUTPUT
           echo "filter=${{ inputs.filter || 'all' }}" >> $GITHUB_OUTPUT
 
-  # ── Core ──
-  core:
+  test:
     needs: inputs
     if: >-
       github.event_name == 'workflow_dispatch' ||
@@ -74,106 +73,48 @@ jobs:
       matrix:
         include:
           # ── Package tests ──
-          - { name: "pkg: macOS (macos-arm64)",    runner: macos-14,       make: test-pkg-native,      timeout: 30 }
-          - { name: "pkg: Linux (ubuntu-x64)",     runner: ubuntu-24.04,  make: test-pkg-native,      timeout: 30 }
-          - { name: "pkg: Windows (win-x64)",      runner: windows-2025-vs2026, make: test-pkg-native,      timeout: 40 }
-          - { name: "pkg: Web (ubuntu-x64)",       runner: ubuntu-24.04,  make: test-ops-web,         timeout: 40, chrome: true, headless-display: true, wasm-cache: true, wasm-build: true }
+          - { name: "pkg: Linux (ubuntu-x64)",      runner: ubuntu-24.04,        make: test-pkg-native, timeout: 30 }
+          - { name: "pkg: macOS (macos-arm64)",     runner: macos-14,            make: test-pkg-native, timeout: 30 }
+          - { name: "pkg: Web (ubuntu-x64)",        runner: ubuntu-24.04,        make: test-ops-web,    timeout: 40, chrome: true, headless-display: true, wasm-cache: true, wasm-build: true }
+          - { name: "pkg: Web (macos-arm64) [P]",       runner: macos-14,            make: test-ops-web,    timeout: 40, chrome: true, wasm-cache: true, wasm-build: true, portability: true }
+          - { name: "pkg: Web (win-x64) [P]",           runner: windows-2025-vs2026, make: test-ops-web,    timeout: 40, chrome: true, wasm-cache: true, wasm-build: true, portability: true }
+          - { name: "pkg: Windows (win-x64)",       runner: windows-2025-vs2026, make: test-pkg-native, timeout: 40 }
 
           # ── Integration tests ──
-          - { name: "int: macOS (macos-arm64)",    runner: macos-14,       make: test-example-macos,   timeout: 30, xcode-cache: true, xcode-cache-target: macos }
-          - { name: "int: Linux (ubuntu-x64)",     runner: ubuntu-24.04,  make: test-example-linux,   timeout: 30, headless-display: true }
-          - { name: "int: Windows (win-x64)",      runner: windows-2025-vs2026, make: test-example-windows,  timeout: 40 }
-          - { name: "int: Android (ubuntu-x64)",   runner: ubuntu-24.04,  make: test-example-android,  timeout: 40, java: true, hw-accel: true, gradle-cache: true, emulator: true }
-          - { name: "int: iOS (macos-arm64)",      runner: macos-14,       make: test-example-ios,      timeout: 60, xcode-cache: true, xcode-cache-target: ios, pods-cache: true, simulator: true }
-          - { name: "int: Web (ubuntu-x64)",       runner: ubuntu-24.04,  make: test-example-web,      timeout: 40, chrome: true, headless-display: true, wasm-cache: true, wasm-build: true }
-
-          # ── Verify (release builds) ──
-          - { name: "verify: Android (ubuntu-x64)", runner: ubuntu-24.04,  make: verify-android,       timeout: 40, java: true, gradle-cache: true }
-          - { name: "verify: iOS (macos-arm64)",    runner: macos-14,       make: verify-ios,           timeout: 40, xcode-cache: true, xcode-cache-target: ios, pods-cache: true }
-          - { name: "verify: macOS (macos-arm64)",  runner: macos-14,       make: verify-macos,         timeout: 40, xcode-cache: true, xcode-cache-target: macos }
-          - { name: "verify: Linux (ubuntu-x64)",   runner: ubuntu-24.04,  make: verify-linux,         timeout: 30 }
-          - { name: "verify: Windows (win-x64)",    runner: windows-2025-vs2026, make: verify-windows,       timeout: 40 }
-          - { name: "verify: Web (ubuntu-x64)",     runner: ubuntu-24.04,  make: verify-web,           timeout: 40, wasm-cache: true, wasm-build: true }
-
-    name: ${{ matrix.name }}
-    runs-on: ${{ matrix.runner }}
-    timeout-minutes: ${{ matrix.timeout }}
-    env:
-      FILTER: ${{ needs.inputs.outputs.filter }}
-    steps:
-      - name: Check filter
-        id: filter
-        shell: bash
-        run: |
-          NAME="${{ matrix.name }}"
-          F="$FILTER"
-          if [[ "$F" == "all" || -z "$F" ]]; then
-            echo "match=true" >> $GITHUB_OUTPUT
-          elif echo "$NAME" | grep -qi "$F"; then
-            echo "match=true" >> $GITHUB_OUTPUT
-          else
-            echo "Skipped by filter: $F ∉ $NAME"
-            echo "match=false" >> $GITHUB_OUTPUT
-          fi
-      - uses: actions/checkout@v6
-        if: steps.filter.outputs.match == 'true'
-        with: { submodules: recursive }
-      - uses: ./.github/actions/make-target
-        if: steps.filter.outputs.match == 'true'
-        with:
-          make-target: ${{ matrix.make }}
-          java: ${{ matrix.java || 'false' }}
-          chrome: ${{ matrix.chrome || 'false' }}
-          headless-display: ${{ matrix.headless-display || 'false' }}
-          hw-accel: ${{ matrix.hw-accel || 'false' }}
-          gradle-cache: ${{ matrix.gradle-cache || 'false' }}
-          xcode-cache: ${{ matrix.xcode-cache || 'false' }}
-          xcode-cache-target: ${{ matrix.xcode-cache-target || '' }}
-          pods-cache: ${{ matrix.pods-cache || 'false' }}
-          wasm-cache: ${{ matrix.wasm-cache || 'false' }}
-          wasm-build: ${{ matrix.wasm-build || 'false' }}
-          emulator: ${{ matrix.emulator || 'false' }}
-          simulator: ${{ matrix.simulator || 'false' }}
-      - name: Upload test results
-        if: always() && steps.filter.outputs.match == 'true'
-        uses: actions/upload-artifact@v7
-        with:
-          name: ${{ matrix.make }}-${{ matrix.runner }}
-          path: test-results/
-          if-no-files-found: ignore
-
-  # ── Portability ──
-  portability:
-    needs: inputs
-    if: >-
-      needs.inputs.outputs.portability == 'true' &&
-      (github.event_name == 'workflow_dispatch' ||
-       (github.event.action == 'labeled' && github.event.label.name == 'ready-to-test'))
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          # Android on other runners
           # Emulator needs Intel — macOS ARM runners are M1 VMs that can't virtualize the emulator:
           # https://docs.github.com/en/actions/reference/runners/github-hosted-runners#limitations-for-arm64-macos-runners
-          # Non-emulator jobs (verify) run fine on ARM.
-          - { name: "verify: Android (macos-arm64)", runner: macos-14,         make: verify-android, timeout: 40, java: true, gradle-cache: true }
-          - { name: "verify: Android (win-x64)",     runner: windows-2025-vs2026,     make: verify-android, timeout: 60, java: true, gradle-cache: true }
-          - { name: "int: Android (macos-intel)",     runner: macos-15-intel,   make: test-example-android, timeout: 60, java: true, hw-accel: true, gradle-cache: true, emulator: true }
-          - { name: "int: Android (win-x64)",        runner: windows-2025-vs2026, make: test-example-android, timeout: 60, java: true, hw-accel: true, gradle-cache: true, emulator: true }
-          # Web on other runners
-          - { name: "pkg: Web (macos-arm64)",      runner: macos-14,       make: test-ops-web,    timeout: 40, chrome: true, wasm-cache: true, wasm-build: true }
-          - { name: "pkg: Web (win-x64)",          runner: windows-2025-vs2026, make: test-ops-web,    timeout: 40, chrome: true, wasm-cache: true, wasm-build: true }
-          - { name: "int: Web (macos-arm64)",      runner: macos-14,       make: test-example-web, timeout: 40, chrome: true, wasm-cache: true, wasm-build: true }
-          - { name: "int: Web (win-x64)",          runner: windows-2025-vs2026, make: test-example-web, timeout: 40, chrome: true, wasm-cache: true, wasm-build: true }
-          - { name: "verify: Web (macos-arm64)",   runner: macos-14,       make: verify-web,      timeout: 40, wasm-cache: true, wasm-build: true }
-          - { name: "verify: Web (win-x64)",       runner: windows-2025-vs2026, make: verify-web,      timeout: 40, wasm-cache: true, wasm-build: true }
+          - { name: "int: Android (ubuntu-x64)",    runner: ubuntu-24.04,        make: test-example-android, timeout: 40, java: true, hw-accel: true, gradle-cache: true, emulator: true }
+          # Always hangs: flutter test doesn't exit after tests pass
+          # on Intel macOS — dart VM stuck on teardown. Check logs
+          # for ✅/❌ results manually, ignore the timeout cancel.
+          - { name: "int: Android (macos-intel) [P] ⚠", runner: macos-15-intel,      make: test-example-android, timeout: 60, java: true, hw-accel: true, gradle-cache: true, emulator: true, portability: true }
+          - { name: "int: Android (win-x64) [P]",       runner: windows-2025-vs2026, make: test-example-android, timeout: 60, java: true, hw-accel: true, gradle-cache: true, emulator: true, portability: true }
+          - { name: "int: iOS (macos-arm64)",       runner: macos-14,            make: test-example-ios,     timeout: 60, xcode-cache: true, xcode-cache-target: ios, pods-cache: true, simulator: true }
+          - { name: "int: Linux (ubuntu-x64)",      runner: ubuntu-24.04,        make: test-example-linux,   timeout: 30, headless-display: true }
+          - { name: "int: macOS (macos-arm64)",     runner: macos-14,            make: test-example-macos,   timeout: 30, xcode-cache: true, xcode-cache-target: macos }
+          - { name: "int: Web (ubuntu-x64)",        runner: ubuntu-24.04,        make: test-example-web,     timeout: 40, chrome: true, headless-display: true, wasm-cache: true, wasm-build: true }
+          - { name: "int: Web (macos-arm64) [P]",       runner: macos-14,            make: test-example-web,     timeout: 40, chrome: true, wasm-cache: true, wasm-build: true, portability: true }
+          - { name: "int: Web (win-x64) [P]",           runner: windows-2025-vs2026, make: test-example-web,     timeout: 40, chrome: true, wasm-cache: true, wasm-build: true, portability: true }
+          - { name: "int: Windows (win-x64)",       runner: windows-2025-vs2026, make: test-example-windows, timeout: 40 }
+
+          # ── Verify (release builds) ──
+          - { name: "verify: Android (ubuntu-x64)", runner: ubuntu-24.04,        make: verify-android, timeout: 40, java: true, gradle-cache: true }
+          - { name: "verify: Android (macos-arm64) [P]",runner: macos-14,            make: verify-android, timeout: 40, java: true, gradle-cache: true, portability: true }
+          - { name: "verify: Android (win-x64) [P]",    runner: windows-2025-vs2026, make: verify-android, timeout: 60, java: true, gradle-cache: true, portability: true }
+          - { name: "verify: iOS (macos-arm64)",    runner: macos-14,            make: verify-ios,     timeout: 40, xcode-cache: true, xcode-cache-target: ios, pods-cache: true }
+          - { name: "verify: Linux (ubuntu-x64)",   runner: ubuntu-24.04,        make: verify-linux,   timeout: 30 }
+          - { name: "verify: macOS (macos-arm64)",  runner: macos-14,            make: verify-macos,   timeout: 40, xcode-cache: true, xcode-cache-target: macos }
+          - { name: "verify: Web (ubuntu-x64)",     runner: ubuntu-24.04,        make: verify-web,     timeout: 40, wasm-cache: true, wasm-build: true }
+          - { name: "verify: Web (macos-arm64) [P]",    runner: macos-14,            make: verify-web,     timeout: 40, wasm-cache: true, wasm-build: true, portability: true }
+          - { name: "verify: Web (win-x64) [P]",        runner: windows-2025-vs2026, make: verify-web,     timeout: 40, wasm-cache: true, wasm-build: true, portability: true }
+          - { name: "verify: Windows (win-x64)",    runner: windows-2025-vs2026, make: verify-windows, timeout: 40 }
 
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: ${{ matrix.timeout }}
     env:
       FILTER: ${{ needs.inputs.outputs.filter }}
+      PORTABILITY: ${{ needs.inputs.outputs.portability }}
     steps:
       - name: Check filter
         id: filter
@@ -181,6 +122,13 @@ jobs:
         run: |
           NAME="${{ matrix.name }}"
           F="$FILTER"
+          P="${{ matrix.portability }}"
+          # Skip portability rows when portability is off
+          if [[ "$P" == "true" && "$PORTABILITY" != "true" ]]; then
+            echo "Skipped: portability off"
+            echo "match=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
           if [[ "$F" == "all" || -z "$F" ]]; then
             echo "match=true" >> $GITHUB_OUTPUT
           elif echo "$NAME" | grep -qi "$F"; then
@@ -220,19 +168,14 @@ jobs:
   gate:
     name: Full Test Gate
     if: always()
-    needs: [inputs, core, portability]
+    needs: [inputs, test]
     runs-on: ${{ needs.inputs.outputs.runner }}
     steps:
       - name: Evaluate
         run: |
-          CORE="${{ needs.core.result }}"
-          PORT="${{ needs.portability.result }}"
-          if [[ "$CORE" != "success" && "$CORE" != "skipped" ]]; then
-            echo "FAILED: core returned '$CORE'"
-            exit 1
-          fi
-          if [[ "$PORT" != "success" && "$PORT" != "skipped" ]]; then
-            echo "FAILED: portability returned '$PORT'"
+          RESULT="${{ needs.test.result }}"
+          if [[ "$RESULT" != "success" && "$RESULT" != "skipped" ]]; then
+            echo "FAILED: test returned '$RESULT'"
             exit 1
           fi
           echo "All jobs passed"

--- a/.gitignore
+++ b/.gitignore
@@ -116,6 +116,7 @@ data/samples/cache/
 /debug/
 /logs/
 /projects/
+/test-results/
 *.log
 
 # Output dirs that ARE legitimately runtime data wherever they appear

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 <!-- Stable releases. Add ## heading at top, CI handles the rest. -->
 
+## 1.0.6
+
+- Fixed release build routing for consumer builds ([PR #80](https://github.com/whuppi/pdf_manipulator/pull/80), [@Binary-Parse](https://github.com/Binary-Parse))
+- Fixed Windows NDK linker `.cmd` extension for Android cross-compilation ([PR #81](https://github.com/whuppi/pdf_manipulator/pull/81), [@Binary-Parse](https://github.com/Binary-Parse))
+- Added CI verify tests — release builds now verified on all 6 targets (Android, iOS, macOS, Linux, Windows, Web)
+
 ## 1.0.5
 
 - Fixed README version not stamped on pub.dev

--- a/CHANGELOG.pre.md
+++ b/CHANGELOG.pre.md
@@ -2,6 +2,12 @@
 
 <!-- Prereleases. Add ## heading at top, CI handles the rest. -->
 
+## 1.0.6-dev.0
+
+- Fixed release build routing for consumer builds ([PR #80](https://github.com/whuppi/pdf_manipulator/pull/80), [@Binary-Parse](https://github.com/Binary-Parse))
+- Fixed Windows NDK linker `.cmd` extension for Android cross-compilation ([PR #81](https://github.com/whuppi/pdf_manipulator/pull/81), [@Binary-Parse](https://github.com/Binary-Parse))
+- Added CI verify tests — release builds now verified on all 6 targets (Android, iOS, macOS, Linux, Windows, Web)
+
 ## 1.0.5-dev.0
 
 - Fixed README version not stamped on pub.dev

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@
 DART    ?= fvm dart
 FLUTTER ?= fvm flutter
 TEST_RESULTS_DIR ?= test-results
+TIMEOUT := $(if $(CI),--timeout=30x,)
 
 # ═══════════════════════════════════════════════════════════════════
 # § 1 — Gate
@@ -110,31 +111,31 @@ test-pkg-native: test-unit test-ops-native
 test-unit:
 	@echo "=== Unit: types + transport ==="
 	@mkdir -p $(TEST_RESULTS_DIR)
-	$(DART) test test/types/ test/transport/ -p vm --concurrency=1 --file-reporter json:$(TEST_RESULTS_DIR)/unit.json
+	$(DART) test $(TIMEOUT) test/types/ test/transport/ -p vm --concurrency=1 --file-reporter json:$(TEST_RESULTS_DIR)/unit.json
 
 test-ops: test-ops-native test-ops-web
 
 test-ops-native:
 	@echo "=== Ops: Native ==="
 	@mkdir -p $(TEST_RESULTS_DIR)
-	$(DART) test test/ops/runners/native_runner_test.dart --concurrency=1 --file-reporter json:$(TEST_RESULTS_DIR)/ops-native.json
+	$(DART) test $(TIMEOUT) test/ops/runners/native_runner_test.dart --concurrency=1 --file-reporter json:$(TEST_RESULTS_DIR)/ops-native.json
 
 test-ops-web: test-ops-opfs test-ops-jspi test-ops-atomics
 
 test-ops-opfs:
 	@echo "=== Ops: Web OPFS ==="
 	@mkdir -p $(TEST_RESULTS_DIR)
-	$(DART) test test/ops/runners/web_opfs_runner_test.dart -p chrome --concurrency=1 --file-reporter json:$(TEST_RESULTS_DIR)/ops-opfs.json
+	$(DART) test $(TIMEOUT) test/ops/runners/web_opfs_runner_test.dart -p chrome --concurrency=1 --file-reporter json:$(TEST_RESULTS_DIR)/ops-opfs.json
 
 test-ops-jspi:
 	@echo "=== Ops: Web JSPI ==="
 	@mkdir -p $(TEST_RESULTS_DIR)
-	$(DART) test test/ops/runners/web_jspi_runner_test.dart -p chrome --concurrency=1 --file-reporter json:$(TEST_RESULTS_DIR)/ops-jspi.json
+	$(DART) test $(TIMEOUT) test/ops/runners/web_jspi_runner_test.dart -p chrome --concurrency=1 --file-reporter json:$(TEST_RESULTS_DIR)/ops-jspi.json
 
 test-ops-atomics:
 	@echo "=== Ops: Web Atomics ==="
 	@mkdir -p $(TEST_RESULTS_DIR)
-	$(DART) test test/ops/runners/web_atomics_runner_test.dart -p chrome-coi --concurrency=1 --file-reporter json:$(TEST_RESULTS_DIR)/ops-atomics.json
+	$(DART) test $(TIMEOUT) test/ops/runners/web_atomics_runner_test.dart -p chrome-coi --concurrency=1 --file-reporter json:$(TEST_RESULTS_DIR)/ops-atomics.json
 
 # ═══════════════════════════════════════════════════════════════════
 # § 6 — Integration tests (example app)
@@ -175,34 +176,34 @@ test-example: test-example-macos test-example-web
 test-example-macos:
 	@echo "=== Example: macOS ==="
 	@mkdir -p $(TEST_RESULTS_DIR)
-	cd example && $(FLUTTER) test integration_test/pdf_smoke_test.dart -d macos --file-reporter json:../$(TEST_RESULTS_DIR)/int-macos.json
+	cd example && $(FLUTTER) test $(TIMEOUT) integration_test/pdf_smoke_test.dart -d macos --file-reporter json:../$(TEST_RESULTS_DIR)/int-macos.json
 
 test-example-linux:
 	@echo "=== Example: Linux ==="
 	$(call ensure_gtk)
 	@mkdir -p $(TEST_RESULTS_DIR)
-	cd example && $(FLUTTER) test integration_test/pdf_smoke_test.dart -d linux --file-reporter json:../$(TEST_RESULTS_DIR)/int-linux.json
+	cd example && $(FLUTTER) test $(TIMEOUT) integration_test/pdf_smoke_test.dart -d linux --file-reporter json:../$(TEST_RESULTS_DIR)/int-linux.json
 
 test-example-windows:
 	@echo "=== Example: Windows ==="
 	@mkdir -p $(TEST_RESULTS_DIR)
-	cd example && $(FLUTTER) test integration_test/pdf_smoke_test.dart -d windows --file-reporter json:../$(TEST_RESULTS_DIR)/int-windows.json
+	cd example && $(FLUTTER) test $(TIMEOUT) integration_test/pdf_smoke_test.dart -d windows --file-reporter json:../$(TEST_RESULTS_DIR)/int-windows.json
 
 # Runs on the connected/booted device. CI boots the emulator via setup-android.
 test-example-android:
 	@echo "=== Example: Android ==="
 	@mkdir -p $(TEST_RESULTS_DIR)
-	cd example && $(FLUTTER) test integration_test/pdf_smoke_test.dart --file-reporter json:../$(TEST_RESULTS_DIR)/int-android.json
+	cd example && $(FLUTTER) test $(TIMEOUT) integration_test/pdf_smoke_test.dart --file-reporter json:../$(TEST_RESULTS_DIR)/int-android.json
 
 # Runs on the booted simulator. CI boots the simulator via setup-ios.
 test-example-ios:
 	@echo "=== Example: iOS ==="
 	@mkdir -p $(TEST_RESULTS_DIR)
-	cd example && $(FLUTTER) test integration_test/pdf_smoke_test.dart --file-reporter json:../$(TEST_RESULTS_DIR)/int-ios.json
+	cd example && $(FLUTTER) test $(TIMEOUT) integration_test/pdf_smoke_test.dart --file-reporter json:../$(TEST_RESULTS_DIR)/int-ios.json
 
 test-example-device:
 	@echo "=== Example: device=$(DEVICE) ==="
-	cd example && $(FLUTTER) test integration_test/pdf_smoke_test.dart -d $(DEVICE)
+	cd example && $(FLUTTER) test $(TIMEOUT) integration_test/pdf_smoke_test.dart -d $(DEVICE)
 
 test-example-web:
 	$(call setup_example_web)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -350,7 +350,7 @@ Each capability:
 | Workflow | Trigger | Runner model |
 |---|---|---|
 | `ci.yml` | PR to prod/dev | All jobs on one input runner (default: ubuntu) |
-| `full-test.yml` | `ready-to-test` label or dispatch | Core (one runner/target) + portability (every valid combo) |
+| `full-test.yml` | `ready-to-test` label or dispatch | Single matrix — core + portability [P] rows |
 | `create-release.yml` | Changelog push or dispatch | Infra on input runner, compile on matrix |
 | `pr-lint.yml` | PR to prod/dev | All jobs on one input runner |
 | `triage.yml` | Issues/PRs | All jobs on env runner |
@@ -359,19 +359,18 @@ Each capability:
 
 ### Test matrix (full-test.yml)
 
-**Core** — one runner per target, proves the code works:
+Single matrix with two tiers in one sorted list:
 
-| Category | Entries |
-|---|---|
-| Package tests | macOS, Linux, Windows, Web |
-| Integration tests | macOS, Linux, Windows, Android (emulator), iOS (simulator), Web (Chrome) |
-| Verify (release builds) | Android, iOS, macOS, Linux, Windows, Web |
+- **Core rows** — one runner per target, proves the code works.
+- **Portability rows `[P]`** — extra runners, proves any dev
+  machine can build with this package. Controlled by
+  `DEFAULT_PORTABILITY` env var. Skipped when toggle is off.
 
-**Portability** — adds remaining valid runner combos. Proves a
-developer on any machine can build with this package. Controlled
-by `DEFAULT_PORTABILITY` env var. Android emulator on
-`macos-15-intel` and `windows` (ARM M1 can't nest VMs).
-Android verify and Web (pkg + int + verify) on macos + windows.
+| Category | Core | Portability [P] |
+|---|---|---|
+| Package | macOS, Linux, Windows, Web | Web on macos + win |
+| Integration | macOS, Linux, Windows, Android, iOS, Web | Android on macos-intel ⚠ + win, Web on macos + win |
+| Verify | Android, iOS, macOS, Linux, Windows, Web | Android on macos + win, Web on macos + win |
 
 ### Dependency ownership
 

--- a/test/ops/core/pdf_builder_test.dart
+++ b/test/ops/core/pdf_builder_test.dart
@@ -22,7 +22,7 @@ void registerBuilderTests(Pdf Function() createPdf) {
       final doc = await pdf.open(src(output));
       expect(doc.pageCount, 1);
       expect(String.fromCharCodes(output), contains('Hello World'));
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('create → setMetadata → save → verify metadata', () async {
       final pdf = createPdf();
@@ -41,13 +41,13 @@ void registerBuilderTests(Pdf Function() createPdf) {
       final asString = String.fromCharCodes(output);
       expect(asString, contains('Custom Builder Title'));
       expect(asString, contains('Builder Author'));
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('double dispose is safe', () async {
       final builder = await createPdf().build();
       await builder.dispose();
       await builder.dispose();
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('imagesToPdf creates valid single-page PDF', () async {
       final pdf = createPdf();
@@ -57,7 +57,7 @@ void registerBuilderTests(Pdf Function() createPdf) {
       final doc = await pdf.open(src(output));
       expect(doc.pageCount, 1);
       expect(output.length, greaterThan(minimalPdf.length));
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('multiple pages have correct count', () async {
       final pdf = createPdf();
@@ -72,7 +72,7 @@ void registerBuilderTests(Pdf Function() createPdf) {
       await builder.dispose();
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 3);
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('addA4Page creates correct dimensions', () async {
       final pdf = createPdf();
@@ -87,7 +87,7 @@ void registerBuilderTests(Pdf Function() createPdf) {
       expect(doc.pageCount, 1);
       expect(doc.pages[0].width, closeTo(595, 2));
       expect(doc.pages[0].height, closeTo(842, 2));
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('addLetterPage creates correct dimensions', () async {
       final pdf = createPdf();
@@ -102,7 +102,7 @@ void registerBuilderTests(Pdf Function() createPdf) {
       expect(doc.pageCount, 1);
       expect(doc.pages[0].width, closeTo(612, 2));
       expect(doc.pages[0].height, closeTo(792, 2));
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('addPage custom dimensions', () async {
       final pdf = createPdf();
@@ -116,7 +116,7 @@ void registerBuilderTests(Pdf Function() createPdf) {
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pages[0].width, closeTo(400, 2));
       expect(doc.pages[0].height, closeTo(300, 2));
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('heading + paragraph + space + horizontalRule produce content', () async {
       final pdf = createPdf();
@@ -133,7 +133,7 @@ void registerBuilderTests(Pdf Function() createPdf) {
       final output = sink.takeBytes();
       expect(String.fromCharCodes(output), contains('Test Heading'));
       expect(String.fromCharCodes(output), contains('Test paragraph'));
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('font changes affect output', () async {
       final pdf = createPdf();
@@ -147,7 +147,7 @@ void registerBuilderTests(Pdf Function() createPdf) {
       await builder.dispose();
       final output = String.fromCharCodes(sink.takeBytes());
       expect(output, contains('Courier'));
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('watermark embeds text', () async {
       final pdf = createPdf();
@@ -160,7 +160,7 @@ void registerBuilderTests(Pdf Function() createPdf) {
       await builder.save(sink);
       await builder.dispose();
       expect(String.fromCharCodes(sink.takeBytes()), contains('BUILDERMARK'));
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('image produces output larger than text-only', () async {
       final pdf = createPdf();
@@ -173,7 +173,7 @@ void registerBuilderTests(Pdf Function() createPdf) {
       await builder.save(sink);
       await builder.dispose();
       expect(sink.takeBytes().length, greaterThan(minimalPdf.length));
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('textField embeds field name', () async {
       final pdf = createPdf();
@@ -185,7 +185,7 @@ void registerBuilderTests(Pdf Function() createPdf) {
       await builder.save(sink);
       await builder.dispose();
       expect(String.fromCharCodes(sink.takeBytes()), contains('myfield'));
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('checkbox embeds field name', () async {
       final pdf = createPdf();
@@ -197,7 +197,7 @@ void registerBuilderTests(Pdf Function() createPdf) {
       await builder.save(sink);
       await builder.dispose();
       expect(String.fromCharCodes(sink.takeBytes()), contains('mycheckbox'));
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('comboBox embeds field name and options', () async {
       final pdf = createPdf();
@@ -210,7 +210,7 @@ void registerBuilderTests(Pdf Function() createPdf) {
       await builder.save(sink);
       await builder.dispose();
       expect(String.fromCharCodes(sink.takeBytes()), contains('mycombo'));
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('linkUrl produces valid PDF with annotation', () async {
       final pdf = createPdf();
@@ -227,7 +227,7 @@ void registerBuilderTests(Pdf Function() createPdf) {
       expect(doc.pageCount, 1);
       // URL is in a /URI annotation, verify it's in the raw PDF bytes
       expect(String.fromCharCodes(output), contains('example.com'));
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('footnote embeds note text', () async {
       final pdf = createPdf();
@@ -240,7 +240,7 @@ void registerBuilderTests(Pdf Function() createPdf) {
       await builder.save(sink);
       await builder.dispose();
       expect(String.fromCharCodes(sink.takeBytes()), contains('Footnote content'));
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('columns embeds column text', () async {
       final pdf = createPdf();
@@ -252,7 +252,7 @@ void registerBuilderTests(Pdf Function() createPdf) {
       await builder.save(sink);
       await builder.dispose();
       expect(String.fromCharCodes(sink.takeBytes()), contains('Column text'));
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('newPageSameSize creates two pages', () async {
       final pdf = createPdf();
@@ -267,7 +267,7 @@ void registerBuilderTests(Pdf Function() createPdf) {
       await builder.dispose();
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 2);
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('newline does not crash', () async {
       final pdf = createPdf();
@@ -282,7 +282,7 @@ void registerBuilderTests(Pdf Function() createPdf) {
       await builder.dispose();
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 1);
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('setSubject + setKeywords on builder', () async {
       final pdf = createPdf();
@@ -297,7 +297,7 @@ void registerBuilderTests(Pdf Function() createPdf) {
       await builder.dispose();
       final output = String.fromCharCodes(sink.takeBytes());
       expect(output, contains('Test Subject'));
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('pushButton embeds field name', () async {
       final pdf = createPdf();
@@ -309,7 +309,7 @@ void registerBuilderTests(Pdf Function() createPdf) {
       await builder.save(sink);
       await builder.dispose();
       expect(String.fromCharCodes(sink.takeBytes()), contains('mybtn'));
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('signatureField embeds field name', () async {
       final pdf = createPdf();
@@ -321,7 +321,7 @@ void registerBuilderTests(Pdf Function() createPdf) {
       await builder.save(sink);
       await builder.dispose();
       expect(String.fromCharCodes(sink.takeBytes()), contains('mysig'));
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('fieldKeystroke does not crash', () async {
       final pdf = createPdf();
@@ -334,7 +334,7 @@ void registerBuilderTests(Pdf Function() createPdf) {
       await builder.dispose();
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 1);
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('fieldFormat does not crash', () async {
       final pdf = createPdf();
@@ -347,7 +347,7 @@ void registerBuilderTests(Pdf Function() createPdf) {
       await builder.dispose();
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 1);
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('fieldValidate does not crash', () async {
       final pdf = createPdf();
@@ -360,7 +360,7 @@ void registerBuilderTests(Pdf Function() createPdf) {
       await builder.dispose();
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 1);
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('fieldCalculate does not crash', () async {
       final pdf = createPdf();
@@ -373,7 +373,7 @@ void registerBuilderTests(Pdf Function() createPdf) {
       await builder.dispose();
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 1);
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('linkPage produces valid output', () async {
       final pdf = createPdf();
@@ -390,6 +390,6 @@ void registerBuilderTests(Pdf Function() createPdf) {
       await builder.dispose();
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 2);
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
   });
 }

--- a/test/ops/core/pdf_doc_test.dart
+++ b/test/ops/core/pdf_doc_test.dart
@@ -17,13 +17,13 @@ void registerDocTests(Pdf Function() createPdf) {
       final doc = await createPdf().open(src(minimalPdf));
       expect(doc.pageCount, 1);
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('open returns version containing dot', () async {
       final doc = await createPdf().open(src(minimalPdf));
       expect(doc.version, contains('.'));
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('A4 dimensions are 595×842', () async {
       final doc = await createPdf().open(src(minimalPdf));
@@ -31,20 +31,20 @@ void registerDocTests(Pdf Function() createPdf) {
       expect(doc.pages[0].width, closeTo(595, 1));
       expect(doc.pages[0].height, closeTo(842, 1));
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('Letter dimensions are 612×792', () async {
       final doc = await createPdf().open(src(letterPdf));
       expect(doc.pages[0].width, closeTo(612, 1));
       expect(doc.pages[0].height, closeTo(792, 1));
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('isEncrypted false for unencrypted PDF', () async {
       final doc = await createPdf().open(src(minimalPdf));
       expect(doc.isEncrypted, isFalse);
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('multi-page PDF has correct page count', () async {
       final bytes = await buildTwoPageTextPdf(createPdf);
@@ -75,7 +75,7 @@ void registerDocTests(Pdf Function() createPdf) {
       final text = await doc.extract(pages: const PdfPages.single(0));
       expect(text.trim(), isEmpty);
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('extract all pages returns text from both pages', () async {
       final bytes = await buildTwoPageTextPdf(createPdf);
@@ -116,7 +116,7 @@ void registerDocTests(Pdf Function() createPdf) {
       );
       expect(md, contains('Application'));
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('extract HTML format returns content', () async {
       final bytes = await buildFormPdf(createPdf);
@@ -127,7 +127,7 @@ void registerDocTests(Pdf Function() createPdf) {
       );
       expect(html, isNotEmpty);
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     // ── Search ────────────────────────────────────────────────────
 
@@ -145,7 +145,7 @@ void registerDocTests(Pdf Function() createPdf) {
         expect(r.rect.width, greaterThan(0));
       }
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('search for nonexistent term returns empty', () async {
       final doc = await createPdf().open(src(minimalPdf));
@@ -155,7 +155,7 @@ void registerDocTests(Pdf Function() createPdf) {
       );
       expect(results, isEmpty);
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     // This test catches the search page-filtering bug:
     // if pages param is ignored, both searches return the same count.
@@ -174,16 +174,6 @@ void registerDocTests(Pdf Function() createPdf) {
 
     // ── Render ────────────────────────────────────────────────────
 
-    // Warmup: first render call pays a one-time init cost for the
-    // rasterizer. On slow Windows CI VMs this exceeds any reasonable
-    // per-test timeout. Running it once untimed in setUp lets the
-    // actual tests measure render performance, not init.
-    test('render warmup', () async {
-      final doc = await createPdf().open(src(minimalPdf));
-      await for (final _ in doc.render(pages: const PdfPages.single(0))) {}
-      await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 30)));
-
     test('render single page yields one image with dimensions', () async {
       final doc = await createPdf().open(src(minimalPdf));
       final pages = <RenderedPage>[];
@@ -195,7 +185,7 @@ void registerDocTests(Pdf Function() createPdf) {
       expect(pages[0].height, greaterThan(0));
       expect(pages[0].data.length, greaterThan(0));
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('render all pages of 2-page PDF yields 2 results', () async {
       final pdf = createPdf();
@@ -207,7 +197,7 @@ void registerDocTests(Pdf Function() createPdf) {
       }
       expect(pages, hasLength(2));
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     // ── Extract images ────────────────────────────────────────────
 
@@ -219,7 +209,7 @@ void registerDocTests(Pdf Function() createPdf) {
       }
       expect(images, isEmpty);
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     // Builder creates proper XObject images (/Im1 in /Resources/XObject,
     // referenced by Do in content stream). The extractor should find them.
@@ -243,13 +233,13 @@ void registerDocTests(Pdf Function() createPdf) {
       expect(result.compliant, isFalse);
       expect(result.errors, greaterThan(0));
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('validatePdfUa on minimal returns false', () async {
       final doc = await createPdf().open(src(minimalPdf));
       expect(await doc.validatePdfUa(), isFalse);
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     // ── Classify ──────────────────────────────────────────────────
 
@@ -260,7 +250,7 @@ void registerDocTests(Pdf Function() createPdf) {
       expect(result.confidence, greaterThanOrEqualTo(0.0));
       expect(result.confidence, lessThanOrEqualTo(1.0));
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('classifyDocument returns type and confidence in range', () async {
       final doc = await createPdf().open(src(minimalPdf));
@@ -269,7 +259,7 @@ void registerDocTests(Pdf Function() createPdf) {
       expect(result.confidence, greaterThanOrEqualTo(0.0));
       expect(result.confidence, lessThanOrEqualTo(1.0));
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     // ── Signatures ────────────────────────────────────────────────
 
@@ -277,13 +267,13 @@ void registerDocTests(Pdf Function() createPdf) {
       final doc = await createPdf().open(src(minimalPdf));
       expect(await doc.getSignatures(), isEmpty);
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('verifySignatures false for unsigned PDF', () async {
       final doc = await createPdf().open(src(minimalPdf));
       expect(await doc.verifySignatures(), isFalse);
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     // ── Bookmarks ─────────────────────────────────────────────────
 
@@ -295,7 +285,7 @@ void registerDocTests(Pdf Function() createPdf) {
       expect(splits[1].title, contains('Chapter 2'));
       expect(splits[0].startPage, greaterThanOrEqualTo(0));
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     // ── Convert ───────────────────────────────────────────────────
 
@@ -335,6 +325,6 @@ void registerDocTests(Pdf Function() createPdf) {
       await pdf.convertToPdf(src(docxSink.takeBytes()), pdfSink, format: PdfDocumentFormat.docx);
       final pdfBytes = pdfSink.takeBytes();
       expect(String.fromCharCodes(pdfBytes.sublist(0, 5)), startsWith('%PDF'));
-    }, timeout: Timeout(Duration(seconds: 5)));
+    }, timeout: Timeout(Duration(seconds: 1)));
   });
 }

--- a/test/ops/core/pdf_editor_test.dart
+++ b/test/ops/core/pdf_editor_test.dart
@@ -18,13 +18,13 @@ void registerEditorTests(Pdf Function() createPdf) {
       final editor = await createPdf().edit(src(minimalPdf));
       expect(await editor.pageCount, 1);
       await editor.dispose();
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('double dispose is safe', () async {
       final editor = await createPdf().edit(src(minimalPdf));
       await editor.dispose();
       await editor.dispose();
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('isModified false before mutation, true after', () async {
       final editor = await createPdf().edit(src(minimalPdf));
@@ -34,7 +34,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       final sink = TestSink();
       await editor.save(sink);
       await editor.dispose();
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     // ── Metadata ──
 
@@ -49,7 +49,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       final doc = await pdf.open(src(output));
       expect(doc.pageCount, 1);
       expect(String.fromCharCodes(output), contains('Behavioral Test Title'));
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('scrubMetadata removes title and author', () async {
       final pdf = createPdf();
@@ -69,7 +69,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       final scrubbed = String.fromCharCodes(output);
       expect(scrubbed, isNot(contains('ScrubMeTitle')));
       expect(scrubbed, isNot(contains('ScrubMeAuthor')));
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('setAuthor + getAuthor roundtrips', () async {
       final editor = await createPdf().edit(src(minimalPdf));
@@ -77,7 +77,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       final author = await editor.getAuthor();
       expect(author, contains('Test Author'));
       await editor.dispose();
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('setSubject + getSubject roundtrips', () async {
       final editor = await createPdf().edit(src(minimalPdf));
@@ -85,7 +85,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       final subject = await editor.getSubject();
       expect(subject, contains('Test Subject'));
       await editor.dispose();
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('setKeywords + getKeywords roundtrips', () async {
       final editor = await createPdf().edit(src(minimalPdf));
@@ -93,7 +93,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       final kw = await editor.getKeywords();
       expect(kw, contains('dart'));
       await editor.dispose();
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     // ── Pages ──
 
@@ -110,7 +110,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       await editor.dispose();
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 1);
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('getPageMediaBox returns correct A4 dimensions', () async {
       final editor = await createPdf().edit(src(minimalPdf));
@@ -118,7 +118,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       expect(box.width, closeTo(595, 1));
       expect(box.height, closeTo(842, 1));
       await editor.dispose();
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('mergeFrom increases page count', () async {
       final pdf = createPdf();
@@ -131,7 +131,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       await editor.dispose();
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 2);
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('selectPages reduces to selected set', () async {
       final pdf = createPdf();
@@ -146,7 +146,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       await editor.dispose();
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 2);
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('movePage changes page order verified by dimensions', () async {
       final pdf = createPdf();
@@ -162,7 +162,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       await editor.dispose();
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pages[0].width, isNot(closeTo(boxBefore.width, 1)));
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     // ── Redaction ──
 
@@ -177,7 +177,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       await editor.addRedaction(0, const PdfRect(x: 50, y: 100, width: 100, height: 20));
       expect(await editor.redactionCount(0), 2);
       await editor.dispose();
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('addRedaction + applyRedactions produces valid PDF', () async {
       final pdf = createPdf();
@@ -189,7 +189,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       await editor.dispose();
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 1);
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     // ── Encryption ──
 
@@ -204,7 +204,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       await editor.dispose();
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.isEncrypted, isTrue);
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('save with encryption remove strips encryption', () async {
       final pdf = createPdf();
@@ -227,7 +227,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       await editor2.dispose();
       final doc = await pdf.open(src(decSink.takeBytes()));
       expect(doc.isEncrypted, isFalse);
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     // ── Optimization ──
 
@@ -236,7 +236,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       final count = await editor.optimizeImages(quality: 75);
       expect(count, 0);
       await editor.dispose();
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('optimizeImages returns non-zero on image PDF', () async {
       final pdf = createPdf();
@@ -245,7 +245,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       final count = await editor.optimizeImages(quality: 50);
       expect(count, greaterThan(0));
       await editor.dispose();
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('unembedStandardFonts returns count', () async {
       final editor = await createPdf().edit(src(minimalPdf));
@@ -253,7 +253,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       expect(count, isA<int>());
       expect(count, greaterThanOrEqualTo(0));
       await editor.dispose();
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     // ── Content ──
 
@@ -266,7 +266,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       await editor.dispose();
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 1);
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('cropMargins produces valid PDF', () async {
       final pdf = createPdf();
@@ -279,7 +279,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       await editor.dispose();
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 1);
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('convertToPdfA produces valid PDF', () async {
       final pdf = createPdf();
@@ -295,7 +295,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       final validation = await doc.validatePdfA();
       expect(validation.errors, 0);
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     // ── Watermark ──
 
@@ -312,7 +312,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       expect(doc.pageCount, 1);
       expect(output.length, greaterThan(minimalPdf.length));
       expect(String.fromCharCodes(output), contains('TILED'));
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('addWatermark with background layer', () async {
       final pdf = createPdf();
@@ -325,7 +325,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       final doc = await pdf.open(src(output));
       expect(doc.pageCount, 1);
       expect(String.fromCharCodes(output), contains('BG'));
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     // ── Form fields ──
 
@@ -341,7 +341,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       final doc = await pdf.open(src(output));
       expect(doc.pageCount, 1);
       expect(String.fromCharCodes(output), contains('John Doe'));
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     // ── Rotation ──
 
@@ -354,7 +354,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       await editor.dispose();
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pages[0].rotation, 90);
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('rotateAllPages sets rotation on every page', () async {
       final pdf = createPdf();
@@ -368,7 +368,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pages[0].rotation, 180);
       expect(doc.pages[1].rotation, 180);
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     // ── Stamps ──
 
@@ -385,7 +385,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       expect(output.length, greaterThan(minimalPdf.length));
       final doc = await pdf.open(src(output));
       expect(doc.pageCount, 1);
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('addImageStamp embeds image data', () async {
       final pdf = createPdf();
@@ -397,7 +397,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       await editor.dispose();
       final output = sink.takeBytes();
       expect(output.length, greaterThan(minimalPdf.length));
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     // ── Content ──
 
@@ -410,7 +410,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       await editor.save(sink);
       await editor.dispose();
       expect(sink.takeBytes().length, greaterThan(minimalPdf.length));
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('eraseRegions produces valid output', () async {
       final pdf = createPdf();
@@ -422,7 +422,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       await editor.dispose();
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 1);
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('flattenForms preserves page count', () async {
       final pdf = createPdf();
@@ -434,7 +434,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       await editor.dispose();
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 1);
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     // ── Save options ──
 
@@ -447,7 +447,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       await editor.dispose();
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 1);
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('fullRewrite with compress + GC produces smaller output', () async {
       final pdf = createPdf();
@@ -459,7 +459,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       await editor.dispose();
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 1);
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     // ── Getters ──
 
@@ -468,14 +468,14 @@ void registerEditorTests(Pdf Function() createPdf) {
       final v = await editor.version;
       expect(v, contains('.'));
       await editor.dispose();
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('getTitle roundtrips with setTitle', () async {
       final editor = await createPdf().edit(src(minimalPdf));
       await editor.setTitle('RoundtripTitle');
       expect(await editor.getTitle(), contains('RoundtripTitle'));
       await editor.dispose();
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     // ── ResizeImage ──
 
@@ -493,6 +493,6 @@ void registerEditorTests(Pdf Function() createPdf) {
       await editor.save(sink);
       await editor.dispose();
       expect(sink.takeBytes().length, greaterThan(0));
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: Timeout(Duration(seconds: 1)));
   });
 }

--- a/test/ops/core/pdf_instance_test.dart
+++ b/test/ops/core/pdf_instance_test.dart
@@ -19,7 +19,7 @@ void registerInstanceTests(Pdf Function() createPdf) {
       expect(doc1.pageCount, 1);
       expect(doc2.pageCount, 1);
       await pdf.dispose();
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('dispose cascades to open editors', () async {
       final pdf = createPdf();
@@ -28,7 +28,7 @@ void registerInstanceTests(Pdf Function() createPdf) {
       expect(await ed1.pageCount, 1);
       expect(await ed2.pageCount, 1);
       await pdf.dispose();
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('dispose cascades to open builders', () async {
       final pdf = createPdf();
@@ -37,7 +37,7 @@ void registerInstanceTests(Pdf Function() createPdf) {
       await pdf.dispose();
       // No error — both builders freed by cascade
       expect(true, isTrue);
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('dispose cascades to mix of doc+editor+builder', () async {
       final pdf = createPdf();
@@ -47,7 +47,7 @@ void registerInstanceTests(Pdf Function() createPdf) {
       expect(doc.pageCount, 1);
       expect(await ed.pageCount, 1);
       await pdf.dispose();
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     // ── Double dispose ──
 
@@ -55,7 +55,7 @@ void registerInstanceTests(Pdf Function() createPdf) {
       final pdf = createPdf();
       await pdf.dispose();
       await pdf.dispose();
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('doc double dispose is safe', () async {
       final pdf = createPdf();
@@ -63,7 +63,7 @@ void registerInstanceTests(Pdf Function() createPdf) {
       await doc.dispose();
       await doc.dispose();
       await pdf.dispose();
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('editor double dispose is safe', () async {
       final pdf = createPdf();
@@ -71,7 +71,7 @@ void registerInstanceTests(Pdf Function() createPdf) {
       await ed.dispose();
       await ed.dispose();
       await pdf.dispose();
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('builder double dispose is safe', () async {
       final pdf = createPdf();
@@ -79,7 +79,7 @@ void registerInstanceTests(Pdf Function() createPdf) {
       await b.dispose();
       await b.dispose();
       await pdf.dispose();
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     // ── Operations after dispose throw ──
 
@@ -87,7 +87,7 @@ void registerInstanceTests(Pdf Function() createPdf) {
       final pdf = createPdf();
       await pdf.dispose();
       expect(() => pdf.open(src(minimalPdf)), throwsStateError);
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     // ── Dispose returns quickly ──
 
@@ -100,7 +100,7 @@ void registerInstanceTests(Pdf Function() createPdf) {
       await pdf.dispose();
       sw.stop();
       expect(sw.elapsedMilliseconds, lessThan(2000));
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     // ── Sequential reuse ──
 
@@ -119,7 +119,7 @@ void registerInstanceTests(Pdf Function() createPdf) {
       await doc2.dispose();
 
       await pdf.dispose();
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('doc dispose frees one doc, others survive', () async {
       final pdf = createPdf();
@@ -129,7 +129,7 @@ void registerInstanceTests(Pdf Function() createPdf) {
       expect(doc2.pageCount, 1);
       await doc2.dispose();
       await pdf.dispose();
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     // ── Multi-instance isolation ──
 
@@ -147,7 +147,7 @@ void registerInstanceTests(Pdf Function() createPdf) {
       expect(docB.pageCount, 1);
       await docB.dispose();
       await pdfB.dispose();
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('disposing one instance does not affect another', () async {
       final pdfA = createPdf();
@@ -160,7 +160,7 @@ void registerInstanceTests(Pdf Function() createPdf) {
       expect(doc.pageCount, 1);
       await doc.dispose();
       await pdfB.dispose();
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     // ── Parallel ops on single instance ──
 
@@ -210,7 +210,7 @@ void registerInstanceTests(Pdf Function() createPdf) {
         errors.add(e);
       });
       expect(errors, isEmpty, reason: 'dispose mid-flight should not leak errors');
-    }, timeout: Timeout(Duration(seconds: 5)));
+    }, timeout: Timeout(Duration(seconds: 3)));
 
     test('dispose mid-open produces no unhandled errors', () async {
       final errors = <Object>[];
@@ -224,7 +224,7 @@ void registerInstanceTests(Pdf Function() createPdf) {
         errors.add(e);
       });
       expect(errors, isEmpty, reason: 'dispose mid-flight should not leak errors');
-    }, timeout: Timeout(Duration(seconds: 5)));
+    }, timeout: Timeout(Duration(seconds: 3)));
 
     test('dispose mid-edit produces no unhandled errors', () async {
       final errors = <Object>[];
@@ -238,7 +238,7 @@ void registerInstanceTests(Pdf Function() createPdf) {
         errors.add(e);
       });
       expect(errors, isEmpty, reason: 'dispose mid-flight should not leak errors');
-    }, timeout: Timeout(Duration(seconds: 5)));
+    }, timeout: Timeout(Duration(seconds: 3)));
 
     test('fresh instance works after abrupt dispose of another', () async {
       final pdf1 = createPdf();
@@ -255,6 +255,6 @@ void registerInstanceTests(Pdf Function() createPdf) {
       expect(doc.pageCount, 1);
       await doc.dispose();
       await pdf2.dispose();
-    }, timeout: Timeout(Duration(seconds: 5)));
+    }, timeout: Timeout(Duration(seconds: 3)));
   });
 }

--- a/test/ops/core/pdf_lifecycle_test.dart
+++ b/test/ops/core/pdf_lifecycle_test.dart
@@ -18,14 +18,14 @@ void registerLifecycleTests(Pdf Function() createPdf) {
         () => createPdf().open(TestSource(Uint8List.fromList([1, 2, 3, 4]))),
         throwsA(anything),
       );
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('open empty bytes throws', () async {
       expect(
         () => createPdf().open(TestSource(Uint8List(0))),
         throwsA(anything),
       );
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('recover after error — next op works', () async {
       final pdf = createPdf();
@@ -43,7 +43,7 @@ void registerLifecycleTests(Pdf Function() createPdf) {
             .codeUnits,
       )));
       expect(doc.pageCount, 1);
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     // ── Instance dispose ──
 
@@ -52,19 +52,19 @@ void registerLifecycleTests(Pdf Function() createPdf) {
       final doc = await pdf.open(src(minimalPdf));
       expect(doc.pageCount, 1);
       await pdf.dispose();
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('instance double dispose is safe', () async {
       final pdf = createPdf();
       await pdf.dispose();
       await pdf.dispose();
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('operations after instance dispose throw', () async {
       final pdf = createPdf();
       await pdf.dispose();
       expect(() => pdf.open(src(minimalPdf)), throwsStateError);
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('instance dispose returns quickly', () async {
       final pdf = createPdf();
@@ -73,7 +73,7 @@ void registerLifecycleTests(Pdf Function() createPdf) {
       await pdf.dispose();
       sw.stop();
       expect(sw.elapsedMilliseconds, lessThan(2000));
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     // ── Doc handle dispose ──
 
@@ -83,7 +83,7 @@ void registerLifecycleTests(Pdf Function() createPdf) {
       expect(doc.pageCount, 1);
       await doc.dispose();
       await pdf.dispose();
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('doc double dispose is safe', () async {
       final pdf = createPdf();
@@ -91,6 +91,6 @@ void registerLifecycleTests(Pdf Function() createPdf) {
       await doc.dispose();
       await doc.dispose();
       await pdf.dispose();
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
   });
 }

--- a/test/ops/core/pdf_standalone_test.dart
+++ b/test/ops/core/pdf_standalone_test.dart
@@ -27,7 +27,7 @@ void registerStandaloneTests(Pdf Function() createPdf) {
       expect(sigs.first.signerName, isNotNull);
       expect(sigs.first.signerName, isNotEmpty);
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('sign with PEM adds a retrievable signature', () async {
       final pdf = createPdf();
@@ -41,7 +41,7 @@ void registerStandaloneTests(Pdf Function() createPdf) {
       expect(sigs, isNotEmpty);
       expect(sigs.first.signerName, isNotNull);
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('sign with invalid cert throws', () async {
       final pdf = createPdf();
@@ -52,7 +52,7 @@ void registerStandaloneTests(Pdf Function() createPdf) {
                 Uint8List.fromList([1, 2, 3, 4]), 'wrong')),
         throwsA(anything),
       );
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     // ── Extract pages ──
 
@@ -66,7 +66,7 @@ void registerStandaloneTests(Pdf Function() createPdf) {
       await pdf.extractPages(src(threePage), sink, pages: [0]);
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 1);
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     // ── Convert ──
 
@@ -77,7 +77,7 @@ void registerStandaloneTests(Pdf Function() createPdf) {
       final bytes = sink.takeBytes();
       expect(bytes[0], 0x50); // PK header
       expect(bytes[1], 0x4B);
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('convertTo PPTX produces valid ZIP', () async {
       final pdf = createPdf();
@@ -86,7 +86,7 @@ void registerStandaloneTests(Pdf Function() createPdf) {
       final bytes = sink.takeBytes();
       expect(bytes[0], 0x50);
       expect(bytes[1], 0x4B);
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('convertTo XLSX produces valid ZIP', () async {
       final pdf = createPdf();
@@ -95,7 +95,7 @@ void registerStandaloneTests(Pdf Function() createPdf) {
       final bytes = sink.takeBytes();
       expect(bytes[0], 0x50);
       expect(bytes[1], 0x4B);
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('convertToPdf from DOCX produces valid PDF', () async {
       final pdf = createPdf();
@@ -105,6 +105,6 @@ void registerStandaloneTests(Pdf Function() createPdf) {
       await pdf.convertToPdf(src(docxSink.takeBytes()), pdfSink, format: PdfDocumentFormat.docx);
       final pdfBytes = pdfSink.takeBytes();
       expect(String.fromCharCodes(pdfBytes.sublist(0, 5)), startsWith('%PDF'));
-    }, timeout: Timeout(Duration(seconds: 5)));
+    }, timeout: Timeout(Duration(seconds: 1)));
   });
 }

--- a/test/ops/core/pdf_sugar_test.dart
+++ b/test/ops/core/pdf_sugar_test.dart
@@ -20,7 +20,7 @@ void registerSugarTests(Pdf Function() createPdf) {
       await pdf.merge([src(minimalPdf), src(minimalPdf)], sink);
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 2);
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('merge three PDFs → 3 pages', () async {
       final pdf = createPdf();
@@ -28,7 +28,7 @@ void registerSugarTests(Pdf Function() createPdf) {
       await pdf.merge([src(minimalPdf), src(minimalPdf), src(minimalPdf)], sink);
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 3);
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('merge different sized PDFs', () async {
       final pdf = createPdf();
@@ -36,7 +36,7 @@ void registerSugarTests(Pdf Function() createPdf) {
       await pdf.merge([src(minimalPdf), src(letterPdf)], sink);
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 2);
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('merged output is valid PDF', () async {
       final pdf = createPdf();
@@ -47,7 +47,7 @@ void registerSugarTests(Pdf Function() createPdf) {
       expect(bytes[1], 0x50);
       expect(bytes[2], 0x44);
       expect(bytes[3], 0x46);
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     // ── Rotate ──
 
@@ -57,7 +57,7 @@ void registerSugarTests(Pdf Function() createPdf) {
       await pdf.rotateAllPages(src(minimalPdf), sink, degrees: 90);
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pages[0].rotation, 90);
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('rotatePages rotates specific pages', () async {
       final pdf = createPdf();
@@ -65,7 +65,7 @@ void registerSugarTests(Pdf Function() createPdf) {
       await pdf.rotatePages(src(minimalPdf), sink, pages: {0: 90});
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pages[0].rotation, 90);
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     // ── Flatten ──
 
@@ -78,7 +78,7 @@ void registerSugarTests(Pdf Function() createPdf) {
       final doc = await pdf.open(src(output));
       expect(doc.pageCount, 1);
       expect(output.length, greaterThan(formBytes.length ~/ 2));
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     // ── Compress ──
 
@@ -91,7 +91,7 @@ void registerSugarTests(Pdf Function() createPdf) {
       final doc = await pdf.open(src(output));
       expect(doc.pageCount, 3);
       expect(output.length, lessThanOrEqualTo(multiPage.length * 2));
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     // ── Delete ──
 
@@ -104,7 +104,7 @@ void registerSugarTests(Pdf Function() createPdf) {
       await pdf.deletePages(src(twoPage), deleteSink, pages: [0]);
       final doc = await pdf.open(src(deleteSink.takeBytes()));
       expect(doc.pageCount, 1);
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     // ── Reorder ──
 
@@ -115,7 +115,7 @@ void registerSugarTests(Pdf Function() createPdf) {
       await pdf.reorderPages(src(multiPage), sink, order: [2, 1, 0]);
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 3);
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     // ── Move ──
 
@@ -135,7 +135,7 @@ void registerSugarTests(Pdf Function() createPdf) {
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 3);
       expect(doc.pages[0].width, closeTo(letterWidth, 1.0));
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     // ── Split ──
 
@@ -153,7 +153,7 @@ void registerSugarTests(Pdf Function() createPdf) {
         final doc = await pdf.open(src(s.takeBytes()));
         expect(doc.pageCount, 1);
       }
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('splitBySize total pages equals original', () async {
       final pdf = createPdf();
@@ -172,7 +172,7 @@ void registerSugarTests(Pdf Function() createPdf) {
         totalPages += doc.pageCount;
       }
       expect(totalPages, 3);
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     // ── Split by bookmarks ──
 
@@ -189,7 +189,7 @@ void registerSugarTests(Pdf Function() createPdf) {
         final doc = await pdf.open(src(s.takeBytes()));
         expect(doc.pageCount, 1);
       }
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     // ── Redaction ──
 
@@ -199,7 +199,7 @@ void registerSugarTests(Pdf Function() createPdf) {
       await pdf.applyRedactions(src(bookmarkedPdf), sink);
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 2);
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     // ── Embed file ──
 
@@ -214,7 +214,7 @@ void registerSugarTests(Pdf Function() createPdf) {
       expect(doc.pageCount, 1);
       expect(output.length, greaterThan(minimalPdf.length));
       expect(String.fromCharCodes(output), contains('test.txt'));
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     // ── Erase ──
 
@@ -227,7 +227,7 @@ void registerSugarTests(Pdf Function() createPdf) {
       final doc = await pdf.open(src(output));
       expect(doc.pageCount, 1);
       expect(output.length, greaterThan(minimalPdf.length));
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     // ── Stamps ──
 
@@ -242,7 +242,7 @@ void registerSugarTests(Pdf Function() createPdf) {
       expect(doc.pageCount, 1);
       expect(output.length, greaterThan(minimalPdf.length));
       expect(String.fromCharCodes(output).toLowerCase(), contains('approved'));
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('addImageStamp embeds image data', () async {
       final pdf = createPdf();
@@ -254,7 +254,7 @@ void registerSugarTests(Pdf Function() createPdf) {
       final doc = await pdf.open(src(output));
       expect(doc.pageCount, 1);
       expect(output.length, greaterThan(minimalPdf.length));
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     // ── Watermark ──
 
@@ -269,7 +269,7 @@ void registerSugarTests(Pdf Function() createPdf) {
       await doc.dispose();
       expect(output.length, greaterThan(input.length));
       expect(String.fromCharCodes(output), contains('CONFIDENTIAL'));
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('watermark position variants produce valid output', () async {
       final pdf = createPdf();
@@ -290,7 +290,7 @@ void registerSugarTests(Pdf Function() createPdf) {
         expect(output.length, greaterThan(input.length),
             reason: '${entry.key}: watermark increases file size');
       }
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     test('watermark layers produce valid output', () async {
       final pdf = createPdf();
@@ -305,7 +305,7 @@ void registerSugarTests(Pdf Function() createPdf) {
         expect(output.length, greaterThan(input.length));
         expect(String.fromCharCodes(output), contains('LAYER'));
       }
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     // ── Encrypt / Decrypt ──
 
@@ -326,7 +326,7 @@ void registerSugarTests(Pdf Function() createPdf) {
       final decDoc = await pdf.open(src(decrypted));
       expect(decDoc.pageCount, 1);
       await decDoc.dispose();
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     // ── ConvertToPdfA ──
 
@@ -337,7 +337,7 @@ void registerSugarTests(Pdf Function() createPdf) {
       await pdf.convertToPdfA(src(formBytes), sink);
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 1);
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     // ── ExtractPages ──
 
@@ -348,7 +348,7 @@ void registerSugarTests(Pdf Function() createPdf) {
       await pdf.extractPages(src(threePage), sink, pages: [0, 2]);
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 2);
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
 
     // ── ImagesToPdf ──
 
@@ -358,7 +358,7 @@ void registerSugarTests(Pdf Function() createPdf) {
       await pdf.imagesToPdf([src(minimalPng)], sink);
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 1);
-    }, timeout: Timeout(Duration(seconds: 2)));
+    }, timeout: Timeout(Duration(seconds: 1)));
   });
 }
 

--- a/test/ops/native/native_finalizer_test.dart
+++ b/test/ops/native/native_finalizer_test.dart
@@ -38,5 +38,5 @@ void registerNativeFinalizerTests() {
             ? 'Process hung — dispose() did not shut down cleanly.'
             : 'Process crashed (exit $exitCode) — dangling NativeCallable.\n'
                 'stderr: ${await process.stderr.transform(const SystemEncoding().decoder).join()}');
-  }, timeout: Timeout(Duration(seconds: 45)));
+  }, timeout: Timeout(Duration(seconds: 5)));
 }

--- a/test/ops/runners/native_runner_test.dart
+++ b/test/ops/runners/native_runner_test.dart
@@ -30,13 +30,13 @@ void main() {
 
   test('engine init', () {
     pdf = Pdf();
-  }, timeout: Timeout(Duration(seconds: 5)));
+  }, timeout: Timeout(Duration(seconds: 3)));
 
   test('verify I/O mode is native', () async {
     final doc = await pdf.open(src(minimalPdf));
     await doc.dispose();
     expect(pdf.ioMode, PdfIoMode.native);
-  }, timeout: Timeout(Duration(seconds: 2)));
+  }, timeout: Timeout(Duration(seconds: 1)));
 
   tearDownAll(() => pdf.dispose());
 

--- a/test/ops/runners/web_atomics_runner_test.dart
+++ b/test/ops/runners/web_atomics_runner_test.dart
@@ -39,13 +39,13 @@ void main() {
       webWorkerUrl: 'http://localhost:$serverPort/web_assets/worker.js',
       webIoMode: PdfIoMode.atomics,
     ));
-  }, timeout: Timeout(Duration(seconds: 10)));
+  }, timeout: Timeout(Duration(seconds: 3)));
 
   test('verify I/O mode is atomics', () async {
     final doc = await pdf.open(src(minimalPdf));
     await doc.dispose();
     expect(pdf.ioMode, PdfIoMode.atomics);
-  }, timeout: Timeout(Duration(seconds: 5)));
+  }, timeout: Timeout(Duration(seconds: 3)));
 
   tearDownAll(() => pdf.dispose());
 

--- a/test/ops/runners/web_jspi_runner_test.dart
+++ b/test/ops/runners/web_jspi_runner_test.dart
@@ -39,13 +39,13 @@ void main() {
       webWorkerUrl: 'http://localhost:$serverPort/web_assets/worker.js',
       webIoMode: PdfIoMode.jspi,
     ));
-  }, timeout: Timeout(Duration(seconds: 10)));
+  }, timeout: Timeout(Duration(seconds: 3)));
 
   test('verify I/O mode is jspi', () async {
     final doc = await pdf.open(src(minimalPdf));
     await doc.dispose();
     expect(pdf.ioMode, PdfIoMode.jspi);
-  }, timeout: Timeout(Duration(seconds: 5)));
+  }, timeout: Timeout(Duration(seconds: 3)));
 
   tearDownAll(() => pdf.dispose());
 

--- a/test/ops/runners/web_opfs_runner_test.dart
+++ b/test/ops/runners/web_opfs_runner_test.dart
@@ -39,13 +39,13 @@ void main() {
       webWorkerUrl: 'http://localhost:$serverPort/web_assets/worker.js',
       webIoMode: PdfIoMode.opfs,
     ));
-  }, timeout: Timeout(Duration(seconds: 10)));
+  }, timeout: Timeout(Duration(seconds: 3)));
 
   test('verify I/O mode is opfs', () async {
     final doc = await pdf.open(src(minimalPdf));
     await doc.dispose();
     expect(pdf.ioMode, PdfIoMode.opfs);
-  }, timeout: Timeout(Duration(seconds: 5)));
+  }, timeout: Timeout(Duration(seconds: 3)));
 
   tearDownAll(() => pdf.dispose());
 

--- a/test/ops/stress/pdf_builder_stress_test.dart
+++ b/test/ops/stress/pdf_builder_stress_test.dart
@@ -13,6 +13,6 @@ void registerBuilderStressTests(Pdf Function() createPdf) {
       final imagePdf = await buildImagePdf(createPdf, pageCount: 10);
       final doc = await pdf.open(src(imagePdf));
       expect(doc.pageCount, 10);
-    }, timeout: Timeout(Duration(seconds: 10)));
+    }, timeout: Timeout(Duration(seconds: 3)));
   });
 }

--- a/test/ops/stress/pdf_doc_stress_test.dart
+++ b/test/ops/stress/pdf_doc_stress_test.dart
@@ -15,12 +15,12 @@ void registerDocStressTests(Pdf Function() createPdf) {
     test('build 1000-page PDF', () async {
       largePdf = await buildLargePdf(createPdf, pageCount: 1000);
       expect(largePdf.length, greaterThan(0));
-    }, timeout: Timeout(Duration(seconds: 10)));
+    }, timeout: Timeout(Duration(seconds: 3)));
 
     test('open 1000-page PDF', () async {
       final doc = await createPdf().open(src(largePdf));
       expect(doc.pageCount, 1000);
-    }, timeout: Timeout(Duration(seconds: 10)));
+    }, timeout: Timeout(Duration(seconds: 3)));
 
     test('extract text from 1000-page PDF', () async {
       final doc = await createPdf().open(src(largePdf));
@@ -28,21 +28,21 @@ void registerDocStressTests(Pdf Function() createPdf) {
       expect(text.length, greaterThan(1000));
       expect(text, contains('Lorem ipsum'));
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 10)));
+    }, timeout: Timeout(Duration(seconds: 3)));
 
     test('extract single page from middle', () async {
       final doc = await createPdf().open(src(largePdf));
       final text = await doc.extract(pages: const PdfPages.single(100));
       expect(text.length, greaterThan(0));
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 10)));
+    }, timeout: Timeout(Duration(seconds: 3)));
 
     test('search across 1000-page PDF', () async {
       final doc = await createPdf().open(src(largePdf));
       final results = await doc.search(query: 'Lorem', pages: const PdfPages.all());
       expect(results.length, greaterThanOrEqualTo(1000));
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 10)));
+    }, timeout: Timeout(Duration(seconds: 3)));
 
     test('render first page', () async {
       final doc = await createPdf().open(src(largePdf));
@@ -53,7 +53,7 @@ void registerDocStressTests(Pdf Function() createPdf) {
       }
       expect(count, 1);
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 10)));
+    }, timeout: Timeout(Duration(seconds: 3)));
 
     test('render pages 100-109', () async {
       final doc = await createPdf().open(src(largePdf));
@@ -64,13 +64,13 @@ void registerDocStressTests(Pdf Function() createPdf) {
       }
       expect(count, 10);
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 10)));
+    }, timeout: Timeout(Duration(seconds: 3)));
 
     test('convertTo DOCX', () async {
       final pdf = createPdf();
       final sink = TestSink();
       await pdf.convertTo(src(largePdf), sink, format: PdfDocumentFormat.docx);
       expect(sink.takeBytes().length, greaterThan(0));
-    }, timeout: Timeout(Duration(seconds: 10)));
+    }, timeout: Timeout(Duration(seconds: 3)));
   });
 }

--- a/test/ops/stress/pdf_editor_stress_test.dart
+++ b/test/ops/stress/pdf_editor_stress_test.dart
@@ -15,14 +15,14 @@ void registerEditorStressTests(Pdf Function() createPdf) {
     test('build 1000-page PDF', () async {
       largePdf = await buildLargePdf(createPdf, pageCount: 1000);
       expect(largePdf.length, greaterThan(0));
-    }, timeout: Timeout(Duration(seconds: 10)));
+    }, timeout: Timeout(Duration(seconds: 3)));
 
     test('watermark 1000 pages', () async {
       final pdf = createPdf();
       final sink = TestSink();
       await pdf.watermark(src(largePdf), sink, text: 'CONFIDENTIAL');
       expect(sink.takeBytes().length, greaterThan(largePdf.length));
-    }, timeout: Timeout(Duration(seconds: 10)));
+    }, timeout: Timeout(Duration(seconds: 3)));
 
     test('encrypt then decrypt 1000-page PDF', () async {
       final pdf = createPdf();
@@ -35,7 +35,7 @@ void registerEditorStressTests(Pdf Function() createPdf) {
       final doc = await pdf.open(src(decSink.takeBytes()));
       expect(doc.pageCount, 1000);
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 10)));
+    }, timeout: Timeout(Duration(seconds: 3)));
 
     test('editor watermark first 10 pages', () async {
       final pdf = createPdf();
@@ -48,14 +48,14 @@ void registerEditorStressTests(Pdf Function() createPdf) {
       await editor.dispose();
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 1000);
-    }, timeout: Timeout(Duration(seconds: 10)));
+    }, timeout: Timeout(Duration(seconds: 3)));
 
     test('compress 1000-page PDF', () async {
       final pdf = createPdf();
       final sink = TestSink();
       await pdf.compress(src(largePdf), sink);
       expect(sink.takeBytes().length, greaterThan(0));
-    }, timeout: Timeout(Duration(seconds: 10)));
+    }, timeout: Timeout(Duration(seconds: 3)));
 
     test('flattenForms on form PDF', () async {
       final pdf = createPdf();
@@ -63,6 +63,6 @@ void registerEditorStressTests(Pdf Function() createPdf) {
       final sink = TestSink();
       await pdf.flattenForms(src(formPdf), sink);
       expect(sink.takeBytes().length, greaterThan(0));
-    }, timeout: Timeout(Duration(seconds: 10)));
+    }, timeout: Timeout(Duration(seconds: 3)));
   });
 }

--- a/test/ops/stress/pdf_instance_stress_test.dart
+++ b/test/ops/stress/pdf_instance_stress_test.dart
@@ -17,7 +17,7 @@ void registerInstanceStressTests(Pdf Function() createPdf) {
         await doc.dispose();
       }
       await pdf.dispose();
-    }, timeout: Timeout(Duration(seconds: 10)));
+    }, timeout: Timeout(Duration(seconds: 3)));
 
     test('100x rapid editor open/dispose cycles', () async {
       final pdf = createPdf();
@@ -27,7 +27,7 @@ void registerInstanceStressTests(Pdf Function() createPdf) {
         await ed.dispose();
       }
       await pdf.dispose();
-    }, timeout: Timeout(Duration(seconds: 10)));
+    }, timeout: Timeout(Duration(seconds: 3)));
 
     test('50x parallel open across 5 instances', () async {
       final instances = List.generate(5, (_) => createPdf());
@@ -43,7 +43,7 @@ void registerInstanceStressTests(Pdf Function() createPdf) {
       for (final pdf in instances) {
         await pdf.dispose();
       }
-    }, timeout: Timeout(Duration(seconds: 10)));
+    }, timeout: Timeout(Duration(seconds: 3)));
 
     test('interleaved doc+editor+sugar on same instance', () async {
       final pdf = createPdf();
@@ -62,7 +62,7 @@ void registerInstanceStressTests(Pdf Function() createPdf) {
         await pdf.merge([src(minimalPdf), src(minimalPdf)], sink2);
       }
       await pdf.dispose();
-    }, timeout: Timeout(Duration(seconds: 10)));
+    }, timeout: Timeout(Duration(seconds: 3)));
 
     test('dispose under load — open 10 docs then kill', () async {
       final pdf = createPdf();
@@ -74,7 +74,7 @@ void registerInstanceStressTests(Pdf Function() createPdf) {
       await pdf.dispose();
       sw.stop();
       expect(sw.elapsedMilliseconds, lessThan(2000));
-    }, timeout: Timeout(Duration(seconds: 10)));
+    }, timeout: Timeout(Duration(seconds: 3)));
 
     test('splitBySize on varied-size pages', () async {
       final pdf = createPdf();
@@ -95,6 +95,6 @@ void registerInstanceStressTests(Pdf Function() createPdf) {
       }
       expect(totalPages, 50);
       await pdf.dispose();
-    }, timeout: Timeout(Duration(seconds: 10)));
+    }, timeout: Timeout(Duration(seconds: 3)));
   });
 }

--- a/test/ops/stress/pdf_standalone_stress_test.dart
+++ b/test/ops/stress/pdf_standalone_stress_test.dart
@@ -15,7 +15,7 @@ void registerStandaloneStressTests(Pdf Function() createPdf) {
     test('build 1000-page PDF', () async {
       largePdf = await buildLargePdf(createPdf, pageCount: 1000);
       expect(largePdf.length, greaterThan(0));
-    }, timeout: Timeout(Duration(seconds: 10)));
+    }, timeout: Timeout(Duration(seconds: 3)));
 
     test('extractPages first 10 from 1000-page', () async {
       final pdf = createPdf();
@@ -24,6 +24,6 @@ void registerStandaloneStressTests(Pdf Function() createPdf) {
           pages: List.generate(10, (i) => i));
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 10);
-    }, timeout: Timeout(Duration(seconds: 10)));
+    }, timeout: Timeout(Duration(seconds: 3)));
   });
 }

--- a/test/ops/stress/pdf_sugar_stress_test.dart
+++ b/test/ops/stress/pdf_sugar_stress_test.dart
@@ -15,7 +15,7 @@ void registerSugarStressTests(Pdf Function() createPdf) {
     test('build 1000-page PDF', () async {
       largePdf = await buildLargePdf(createPdf, pageCount: 1000);
       expect(largePdf.length, greaterThan(0));
-    }, timeout: Timeout(Duration(seconds: 20)));
+    }, timeout: Timeout(Duration(seconds: 3)));
 
     test('split every 100 pages', () async {
       final pdf = createPdf();
@@ -32,7 +32,7 @@ void registerSugarStressTests(Pdf Function() createPdf) {
         final doc = await pdf.open(src(bytes));
         expect(doc.pageCount, 100);
       }
-    }, timeout: Timeout(Duration(seconds: 20)));
+    }, timeout: Timeout(Duration(seconds: 3)));
 
     test('splitBySize generous limit', () async {
       final pdf = createPdf();
@@ -50,7 +50,7 @@ void registerSugarStressTests(Pdf Function() createPdf) {
         totalPages += doc.pageCount;
       }
       expect(totalPages, 100);
-    }, timeout: Timeout(Duration(seconds: 20)));
+    }, timeout: Timeout(Duration(seconds: 3)));
 
     test('splitBySize tight limit', () async {
       final pdf = createPdf();
@@ -65,7 +65,7 @@ void registerSugarStressTests(Pdf Function() createPdf) {
       for (final s in sinks) {
         expect(s.takeBytes().length, greaterThan(0));
       }
-    }, timeout: Timeout(Duration(seconds: 20)));
+    }, timeout: Timeout(Duration(seconds: 3)));
 
     test('splitBySize smaller than single page', () async {
       final pdf = createPdf();
@@ -83,7 +83,7 @@ void registerSugarStressTests(Pdf Function() createPdf) {
         final doc = await pdf.open(src(bytes));
         expect(doc.pageCount, greaterThanOrEqualTo(1));
       }
-    }, timeout: Timeout(Duration(seconds: 20)));
+    }, timeout: Timeout(Duration(seconds: 3)));
 
     test('splitBySize equal to full PDF → 1 chunk', () async {
       final pdf = createPdf();
@@ -97,7 +97,7 @@ void registerSugarStressTests(Pdf Function() createPdf) {
       expect(sinks.length, 1);
       final doc = await pdf.open(src(sinks.first.takeBytes()));
       expect(doc.pageCount, 100);
-    }, timeout: Timeout(Duration(seconds: 20)));
+    }, timeout: Timeout(Duration(seconds: 3)));
 
     test('splitBySize returns chunk byte sizes', () async {
       final pdf = createPdf();
@@ -113,7 +113,7 @@ void registerSugarStressTests(Pdf Function() createPdf) {
         expect(chunkSizes[i], greaterThan(0));
         expect(chunkSizes[i], sinks[i].takeBytes().length);
       }
-    }, timeout: Timeout(Duration(seconds: 20)));
+    }, timeout: Timeout(Duration(seconds: 3)));
 
     test('extract first 10 pages', () async {
       final pdf = createPdf();
@@ -122,7 +122,7 @@ void registerSugarStressTests(Pdf Function() createPdf) {
           pages: List.generate(10, (i) => i));
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 10);
-    }, timeout: Timeout(Duration(seconds: 20)));
+    }, timeout: Timeout(Duration(seconds: 3)));
 
     test('delete 990 pages', () async {
       final pdf = createPdf();
@@ -131,7 +131,7 @@ void registerSugarStressTests(Pdf Function() createPdf) {
           pages: List.generate(990, (i) => i));
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 10);
-    }, timeout: Timeout(Duration(seconds: 20)));
+    }, timeout: Timeout(Duration(seconds: 3)));
 
     test('merge two 1000-page PDFs → 2000 pages', () async {
       final pdf = createPdf();
@@ -139,7 +139,7 @@ void registerSugarStressTests(Pdf Function() createPdf) {
       await pdf.merge([src(largePdf), src(largePdf)], sink);
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 2000);
-    }, timeout: Timeout(Duration(seconds: 20)));
+    }, timeout: Timeout(Duration(seconds: 3)));
 
     test('splitBySize on varied-size pages', () async {
       final pdf = createPdf();
@@ -156,6 +156,6 @@ void registerSugarStressTests(Pdf Function() createPdf) {
         totalPages += doc.pageCount;
       }
       expect(totalPages, 50);
-    }, timeout: Timeout(Duration(seconds: 20)));
+    }, timeout: Timeout(Duration(seconds: 3)));
   });
 }

--- a/tool/compile_rust.sh
+++ b/tool/compile_rust.sh
@@ -286,9 +286,11 @@ do_wasm() {
         || { echo "Error: failed to download binaryen $BINARYEN_VER"; exit 1; }
       tar xzf "$tmp/binaryen.tar.gz" -C "$tmp"
       local cargo_bin="$HOME/.cargo/bin"
-      mkdir -p "$cargo_bin"
+      local cargo_lib="$HOME/.cargo/lib"
+      mkdir -p "$cargo_bin" "$cargo_lib"
       cp "$tmp/binaryen-$BINARYEN_VER/bin/wasm-opt"* "$cargo_bin/" \
         || { echo "Error: could not copy wasm-opt to $cargo_bin"; exit 1; }
+      cp "$tmp/binaryen-$BINARYEN_VER/lib/"* "$cargo_lib/" 2>/dev/null || true
       rm -rf "$tmp/binaryen.tar.gz" "$tmp/binaryen-$BINARYEN_VER"
     else
       echo "Error: wasm-opt not found. Install binaryen:"


### PR DESCRIPTION
## Summary

- Release build routing fix ([PR #80](https://github.com/whuppi/pdf_manipulator/pull/80), @Binary-Parse)
- Windows NDK `.cmd` extension fix ([PR #81](https://github.com/whuppi/pdf_manipulator/pull/81), @Binary-Parse)
- CI verify tests — release builds verified on all 6 targets

## Test plan

- [ ] Merging triggers release pipeline gate
- [ ] Gate detects `1.0.6` / `1.0.6-dev.0` as new versions