### PR TITLE
fix(ci): WASM release assets + binary verification gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 <!-- Stable releases. Add ## heading at top, CI handles the rest. -->
 
+## 1.0.7
+
+- Fixed missing WASM binaries in 1.0.6 release (web consumers couldn't download pre-built assets)
+- Added binary verification gate — releases now fail if any of the 15 expected binaries are missing
+
 ## 1.0.6
 
 - Fixed release build routing for consumer builds ([PR #80](https://github.com/whuppi/pdf_manipulator/pull/80), [@Binary-Parse](https://github.com/Binary-Parse))

--- a/CHANGELOG.pre.md
+++ b/CHANGELOG.pre.md
@@ -2,6 +2,11 @@
 
 <!-- Prereleases. Add ## heading at top, CI handles the rest. -->
 
+## 1.0.7-dev.0
+
+- Fixed missing WASM binaries in 1.0.6 release (web consumers couldn't download pre-built assets)
+- Added binary verification gate — releases now fail if any of the 15 expected binaries are missing
+
 ## 1.0.6-dev.0
 
 - Fixed release build routing for consumer builds ([PR #80](https://github.com/whuppi/pdf_manipulator/pull/80), [@Binary-Parse](https://github.com/Binary-Parse))

--- a/test/helpers/timeouts.dart
+++ b/test/helpers/timeouts.dart
@@ -1,0 +1,11 @@
+import 'package:test/test.dart';
+
+/// Per-test timeout that respects the `--timeout` CLI multiplier.
+///
+/// Locally: `t(3)` = 3 seconds (tight, catches perf regressions).
+/// CI with `--timeout=30x`: `t(3)` = 90 seconds (absorbs runner variance).
+///
+/// Uses `Timeout.factor()` because `Timeout(Duration())` ignores the
+/// CLI multiplier entirely — the Dart test framework only multiplies
+/// factor-based timeouts.
+Timeout t(int seconds) => Timeout.factor(seconds / 30);

--- a/test/ops/core/pdf_builder_test.dart
+++ b/test/ops/core/pdf_builder_test.dart
@@ -6,6 +6,7 @@ import 'package:test/test.dart';
 
 import '../../helpers/fixtures.dart';
 import '../../helpers/test_source_sink.dart';
+import '../../helpers/timeouts.dart';
 
 void registerBuilderTests(Pdf Function() createPdf) {
   group('builder', () {
@@ -22,7 +23,7 @@ void registerBuilderTests(Pdf Function() createPdf) {
       final doc = await pdf.open(src(output));
       expect(doc.pageCount, 1);
       expect(String.fromCharCodes(output), contains('Hello World'));
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('create → setMetadata → save → verify metadata', () async {
       final pdf = createPdf();
@@ -41,13 +42,13 @@ void registerBuilderTests(Pdf Function() createPdf) {
       final asString = String.fromCharCodes(output);
       expect(asString, contains('Custom Builder Title'));
       expect(asString, contains('Builder Author'));
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('double dispose is safe', () async {
       final builder = await createPdf().build();
       await builder.dispose();
       await builder.dispose();
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('imagesToPdf creates valid single-page PDF', () async {
       final pdf = createPdf();
@@ -57,7 +58,7 @@ void registerBuilderTests(Pdf Function() createPdf) {
       final doc = await pdf.open(src(output));
       expect(doc.pageCount, 1);
       expect(output.length, greaterThan(minimalPdf.length));
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('multiple pages have correct count', () async {
       final pdf = createPdf();
@@ -72,7 +73,7 @@ void registerBuilderTests(Pdf Function() createPdf) {
       await builder.dispose();
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 3);
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('addA4Page creates correct dimensions', () async {
       final pdf = createPdf();
@@ -87,7 +88,7 @@ void registerBuilderTests(Pdf Function() createPdf) {
       expect(doc.pageCount, 1);
       expect(doc.pages[0].width, closeTo(595, 2));
       expect(doc.pages[0].height, closeTo(842, 2));
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('addLetterPage creates correct dimensions', () async {
       final pdf = createPdf();
@@ -102,7 +103,7 @@ void registerBuilderTests(Pdf Function() createPdf) {
       expect(doc.pageCount, 1);
       expect(doc.pages[0].width, closeTo(612, 2));
       expect(doc.pages[0].height, closeTo(792, 2));
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('addPage custom dimensions', () async {
       final pdf = createPdf();
@@ -116,7 +117,7 @@ void registerBuilderTests(Pdf Function() createPdf) {
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pages[0].width, closeTo(400, 2));
       expect(doc.pages[0].height, closeTo(300, 2));
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('heading + paragraph + space + horizontalRule produce content', () async {
       final pdf = createPdf();
@@ -133,7 +134,7 @@ void registerBuilderTests(Pdf Function() createPdf) {
       final output = sink.takeBytes();
       expect(String.fromCharCodes(output), contains('Test Heading'));
       expect(String.fromCharCodes(output), contains('Test paragraph'));
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('font changes affect output', () async {
       final pdf = createPdf();
@@ -147,7 +148,7 @@ void registerBuilderTests(Pdf Function() createPdf) {
       await builder.dispose();
       final output = String.fromCharCodes(sink.takeBytes());
       expect(output, contains('Courier'));
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('watermark embeds text', () async {
       final pdf = createPdf();
@@ -160,7 +161,7 @@ void registerBuilderTests(Pdf Function() createPdf) {
       await builder.save(sink);
       await builder.dispose();
       expect(String.fromCharCodes(sink.takeBytes()), contains('BUILDERMARK'));
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('image produces output larger than text-only', () async {
       final pdf = createPdf();
@@ -173,7 +174,7 @@ void registerBuilderTests(Pdf Function() createPdf) {
       await builder.save(sink);
       await builder.dispose();
       expect(sink.takeBytes().length, greaterThan(minimalPdf.length));
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('textField embeds field name', () async {
       final pdf = createPdf();
@@ -185,7 +186,7 @@ void registerBuilderTests(Pdf Function() createPdf) {
       await builder.save(sink);
       await builder.dispose();
       expect(String.fromCharCodes(sink.takeBytes()), contains('myfield'));
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('checkbox embeds field name', () async {
       final pdf = createPdf();
@@ -197,7 +198,7 @@ void registerBuilderTests(Pdf Function() createPdf) {
       await builder.save(sink);
       await builder.dispose();
       expect(String.fromCharCodes(sink.takeBytes()), contains('mycheckbox'));
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('comboBox embeds field name and options', () async {
       final pdf = createPdf();
@@ -210,7 +211,7 @@ void registerBuilderTests(Pdf Function() createPdf) {
       await builder.save(sink);
       await builder.dispose();
       expect(String.fromCharCodes(sink.takeBytes()), contains('mycombo'));
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('linkUrl produces valid PDF with annotation', () async {
       final pdf = createPdf();
@@ -227,7 +228,7 @@ void registerBuilderTests(Pdf Function() createPdf) {
       expect(doc.pageCount, 1);
       // URL is in a /URI annotation, verify it's in the raw PDF bytes
       expect(String.fromCharCodes(output), contains('example.com'));
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('footnote embeds note text', () async {
       final pdf = createPdf();
@@ -240,7 +241,7 @@ void registerBuilderTests(Pdf Function() createPdf) {
       await builder.save(sink);
       await builder.dispose();
       expect(String.fromCharCodes(sink.takeBytes()), contains('Footnote content'));
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('columns embeds column text', () async {
       final pdf = createPdf();
@@ -252,7 +253,7 @@ void registerBuilderTests(Pdf Function() createPdf) {
       await builder.save(sink);
       await builder.dispose();
       expect(String.fromCharCodes(sink.takeBytes()), contains('Column text'));
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('newPageSameSize creates two pages', () async {
       final pdf = createPdf();
@@ -267,7 +268,7 @@ void registerBuilderTests(Pdf Function() createPdf) {
       await builder.dispose();
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 2);
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('newline does not crash', () async {
       final pdf = createPdf();
@@ -282,7 +283,7 @@ void registerBuilderTests(Pdf Function() createPdf) {
       await builder.dispose();
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 1);
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('setSubject + setKeywords on builder', () async {
       final pdf = createPdf();
@@ -297,7 +298,7 @@ void registerBuilderTests(Pdf Function() createPdf) {
       await builder.dispose();
       final output = String.fromCharCodes(sink.takeBytes());
       expect(output, contains('Test Subject'));
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('pushButton embeds field name', () async {
       final pdf = createPdf();
@@ -309,7 +310,7 @@ void registerBuilderTests(Pdf Function() createPdf) {
       await builder.save(sink);
       await builder.dispose();
       expect(String.fromCharCodes(sink.takeBytes()), contains('mybtn'));
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('signatureField embeds field name', () async {
       final pdf = createPdf();
@@ -321,7 +322,7 @@ void registerBuilderTests(Pdf Function() createPdf) {
       await builder.save(sink);
       await builder.dispose();
       expect(String.fromCharCodes(sink.takeBytes()), contains('mysig'));
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('fieldKeystroke does not crash', () async {
       final pdf = createPdf();
@@ -334,7 +335,7 @@ void registerBuilderTests(Pdf Function() createPdf) {
       await builder.dispose();
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 1);
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('fieldFormat does not crash', () async {
       final pdf = createPdf();
@@ -347,7 +348,7 @@ void registerBuilderTests(Pdf Function() createPdf) {
       await builder.dispose();
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 1);
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('fieldValidate does not crash', () async {
       final pdf = createPdf();
@@ -360,7 +361,7 @@ void registerBuilderTests(Pdf Function() createPdf) {
       await builder.dispose();
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 1);
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('fieldCalculate does not crash', () async {
       final pdf = createPdf();
@@ -373,7 +374,7 @@ void registerBuilderTests(Pdf Function() createPdf) {
       await builder.dispose();
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 1);
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('linkPage produces valid output', () async {
       final pdf = createPdf();
@@ -390,6 +391,6 @@ void registerBuilderTests(Pdf Function() createPdf) {
       await builder.dispose();
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 2);
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
   });
 }

--- a/test/ops/core/pdf_doc_test.dart
+++ b/test/ops/core/pdf_doc_test.dart
@@ -8,6 +8,7 @@ import 'package:test/test.dart';
 import '../../helpers/fixtures.dart';
 import '../../helpers/generators.dart';
 import '../../helpers/test_source_sink.dart';
+import '../../helpers/timeouts.dart';
 
 void registerDocTests(Pdf Function() createPdf) {
   group('doc', () {
@@ -17,13 +18,13 @@ void registerDocTests(Pdf Function() createPdf) {
       final doc = await createPdf().open(src(minimalPdf));
       expect(doc.pageCount, 1);
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('open returns version containing dot', () async {
       final doc = await createPdf().open(src(minimalPdf));
       expect(doc.version, contains('.'));
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('A4 dimensions are 595×842', () async {
       final doc = await createPdf().open(src(minimalPdf));
@@ -31,27 +32,27 @@ void registerDocTests(Pdf Function() createPdf) {
       expect(doc.pages[0].width, closeTo(595, 1));
       expect(doc.pages[0].height, closeTo(842, 1));
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('Letter dimensions are 612×792', () async {
       final doc = await createPdf().open(src(letterPdf));
       expect(doc.pages[0].width, closeTo(612, 1));
       expect(doc.pages[0].height, closeTo(792, 1));
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('isEncrypted false for unencrypted PDF', () async {
       final doc = await createPdf().open(src(minimalPdf));
       expect(doc.isEncrypted, isFalse);
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('multi-page PDF has correct page count', () async {
       final bytes = await buildTwoPageTextPdf(createPdf);
       final doc = await createPdf().open(src(bytes));
       expect(doc.pageCount, 2);
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: t(3));
 
     // ── Open with password ────────────────────────────────────────
 
@@ -66,7 +67,7 @@ void registerDocTests(Pdf Function() createPdf) {
       expect(doc.isEncrypted, isTrue);
       expect(doc.pageCount, 1);
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: t(3));
 
     // ── Extract text ──────────────────────────────────────────────
 
@@ -75,7 +76,7 @@ void registerDocTests(Pdf Function() createPdf) {
       final text = await doc.extract(pages: const PdfPages.single(0));
       expect(text.trim(), isEmpty);
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('extract all pages returns text from both pages', () async {
       final bytes = await buildTwoPageTextPdf(createPdf);
@@ -84,7 +85,7 @@ void registerDocTests(Pdf Function() createPdf) {
       expect(text, contains('ALPHA'));
       expect(text, contains('BRAVO'));
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: t(3));
 
     test('extract single page returns only that page text', () async {
       final bytes = await buildTwoPageTextPdf(createPdf);
@@ -96,7 +97,7 @@ void registerDocTests(Pdf Function() createPdf) {
       expect(page1, contains('BRAVO'));
       expect(page1, isNot(contains('ALPHA')));
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: t(3));
 
     test('extract range returns subset', () async {
       final bytes = await buildTwoPageTextPdf(createPdf);
@@ -105,7 +106,7 @@ void registerDocTests(Pdf Function() createPdf) {
       expect(range, contains('ALPHA'));
       expect(range, isNot(contains('BRAVO')));
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: t(3));
 
     test('extract markdown format returns content', () async {
       final bytes = await buildFormPdf(createPdf);
@@ -116,7 +117,7 @@ void registerDocTests(Pdf Function() createPdf) {
       );
       expect(md, contains('Application'));
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('extract HTML format returns content', () async {
       final bytes = await buildFormPdf(createPdf);
@@ -127,7 +128,7 @@ void registerDocTests(Pdf Function() createPdf) {
       );
       expect(html, isNotEmpty);
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     // ── Search ────────────────────────────────────────────────────
 
@@ -145,7 +146,7 @@ void registerDocTests(Pdf Function() createPdf) {
         expect(r.rect.width, greaterThan(0));
       }
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('search for nonexistent term returns empty', () async {
       final doc = await createPdf().open(src(minimalPdf));
@@ -155,7 +156,7 @@ void registerDocTests(Pdf Function() createPdf) {
       );
       expect(results, isEmpty);
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     // This test catches the search page-filtering bug:
     // if pages param is ignored, both searches return the same count.
@@ -170,7 +171,7 @@ void registerDocTests(Pdf Function() createPdf) {
       expect(page0Hits, isNotEmpty, reason: 'ALPHA should be on page 0');
       expect(page1Hits, isEmpty, reason: 'ALPHA should NOT be on page 1');
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: t(3));
 
     // ── Render ────────────────────────────────────────────────────
 
@@ -185,7 +186,7 @@ void registerDocTests(Pdf Function() createPdf) {
       expect(pages[0].height, greaterThan(0));
       expect(pages[0].data.length, greaterThan(0));
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('render all pages of 2-page PDF yields 2 results', () async {
       final pdf = createPdf();
@@ -197,7 +198,7 @@ void registerDocTests(Pdf Function() createPdf) {
       }
       expect(pages, hasLength(2));
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     // ── Extract images ────────────────────────────────────────────
 
@@ -209,7 +210,7 @@ void registerDocTests(Pdf Function() createPdf) {
       }
       expect(images, isEmpty);
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     // Builder creates proper XObject images (/Im1 in /Resources/XObject,
     // referenced by Do in content stream). The extractor should find them.
@@ -223,7 +224,7 @@ void registerDocTests(Pdf Function() createPdf) {
       }
       expect(images, isNotEmpty, reason: 'Builder XObject image should be extractable');
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: t(3));
 
     // ── Validate ──────────────────────────────────────────────────
 
@@ -233,13 +234,13 @@ void registerDocTests(Pdf Function() createPdf) {
       expect(result.compliant, isFalse);
       expect(result.errors, greaterThan(0));
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('validatePdfUa on minimal returns false', () async {
       final doc = await createPdf().open(src(minimalPdf));
       expect(await doc.validatePdfUa(), isFalse);
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     // ── Classify ──────────────────────────────────────────────────
 
@@ -250,7 +251,7 @@ void registerDocTests(Pdf Function() createPdf) {
       expect(result.confidence, greaterThanOrEqualTo(0.0));
       expect(result.confidence, lessThanOrEqualTo(1.0));
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('classifyDocument returns type and confidence in range', () async {
       final doc = await createPdf().open(src(minimalPdf));
@@ -259,7 +260,7 @@ void registerDocTests(Pdf Function() createPdf) {
       expect(result.confidence, greaterThanOrEqualTo(0.0));
       expect(result.confidence, lessThanOrEqualTo(1.0));
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     // ── Signatures ────────────────────────────────────────────────
 
@@ -267,13 +268,13 @@ void registerDocTests(Pdf Function() createPdf) {
       final doc = await createPdf().open(src(minimalPdf));
       expect(await doc.getSignatures(), isEmpty);
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('verifySignatures false for unsigned PDF', () async {
       final doc = await createPdf().open(src(minimalPdf));
       expect(await doc.verifySignatures(), isFalse);
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     // ── Bookmarks ─────────────────────────────────────────────────
 
@@ -285,7 +286,7 @@ void registerDocTests(Pdf Function() createPdf) {
       expect(splits[1].title, contains('Chapter 2'));
       expect(splits[0].startPage, greaterThanOrEqualTo(0));
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     // ── Convert ───────────────────────────────────────────────────
 
@@ -297,7 +298,7 @@ void registerDocTests(Pdf Function() createPdf) {
       expect(bytes.length, greaterThan(4));
       expect(bytes[0], 0x50); // PK ZIP header
       expect(bytes[1], 0x4B);
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: t(3));
 
     test('convertTo PPTX produces valid ZIP', () async {
       final pdf = createPdf();
@@ -306,7 +307,7 @@ void registerDocTests(Pdf Function() createPdf) {
       final bytes = sink.takeBytes();
       expect(bytes[0], 0x50);
       expect(bytes[1], 0x4B);
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: t(3));
 
     test('convertTo XLSX produces valid ZIP', () async {
       final pdf = createPdf();
@@ -315,7 +316,7 @@ void registerDocTests(Pdf Function() createPdf) {
       final bytes = sink.takeBytes();
       expect(bytes[0], 0x50);
       expect(bytes[1], 0x4B);
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: t(3));
 
     test('convertToPdf from DOCX produces valid PDF', () async {
       final pdf = createPdf();
@@ -325,6 +326,6 @@ void registerDocTests(Pdf Function() createPdf) {
       await pdf.convertToPdf(src(docxSink.takeBytes()), pdfSink, format: PdfDocumentFormat.docx);
       final pdfBytes = pdfSink.takeBytes();
       expect(String.fromCharCodes(pdfBytes.sublist(0, 5)), startsWith('%PDF'));
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
   });
 }

--- a/test/ops/core/pdf_editor_test.dart
+++ b/test/ops/core/pdf_editor_test.dart
@@ -9,6 +9,7 @@ import 'package:test/test.dart';
 import '../../helpers/fixtures.dart';
 import '../../helpers/generators.dart';
 import '../../helpers/test_source_sink.dart';
+import '../../helpers/timeouts.dart';
 
 void registerEditorTests(Pdf Function() createPdf) {
   group('editor', () {
@@ -18,13 +19,13 @@ void registerEditorTests(Pdf Function() createPdf) {
       final editor = await createPdf().edit(src(minimalPdf));
       expect(await editor.pageCount, 1);
       await editor.dispose();
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('double dispose is safe', () async {
       final editor = await createPdf().edit(src(minimalPdf));
       await editor.dispose();
       await editor.dispose();
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('isModified false before mutation, true after', () async {
       final editor = await createPdf().edit(src(minimalPdf));
@@ -34,7 +35,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       final sink = TestSink();
       await editor.save(sink);
       await editor.dispose();
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     // ── Metadata ──
 
@@ -49,7 +50,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       final doc = await pdf.open(src(output));
       expect(doc.pageCount, 1);
       expect(String.fromCharCodes(output), contains('Behavioral Test Title'));
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('scrubMetadata removes title and author', () async {
       final pdf = createPdf();
@@ -69,7 +70,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       final scrubbed = String.fromCharCodes(output);
       expect(scrubbed, isNot(contains('ScrubMeTitle')));
       expect(scrubbed, isNot(contains('ScrubMeAuthor')));
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('setAuthor + getAuthor roundtrips', () async {
       final editor = await createPdf().edit(src(minimalPdf));
@@ -77,7 +78,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       final author = await editor.getAuthor();
       expect(author, contains('Test Author'));
       await editor.dispose();
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('setSubject + getSubject roundtrips', () async {
       final editor = await createPdf().edit(src(minimalPdf));
@@ -85,7 +86,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       final subject = await editor.getSubject();
       expect(subject, contains('Test Subject'));
       await editor.dispose();
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('setKeywords + getKeywords roundtrips', () async {
       final editor = await createPdf().edit(src(minimalPdf));
@@ -93,7 +94,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       final kw = await editor.getKeywords();
       expect(kw, contains('dart'));
       await editor.dispose();
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     // ── Pages ──
 
@@ -110,7 +111,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       await editor.dispose();
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 1);
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('getPageMediaBox returns correct A4 dimensions', () async {
       final editor = await createPdf().edit(src(minimalPdf));
@@ -118,7 +119,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       expect(box.width, closeTo(595, 1));
       expect(box.height, closeTo(842, 1));
       await editor.dispose();
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('mergeFrom increases page count', () async {
       final pdf = createPdf();
@@ -131,7 +132,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       await editor.dispose();
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 2);
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('selectPages reduces to selected set', () async {
       final pdf = createPdf();
@@ -146,7 +147,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       await editor.dispose();
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 2);
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('movePage changes page order verified by dimensions', () async {
       final pdf = createPdf();
@@ -162,7 +163,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       await editor.dispose();
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pages[0].width, isNot(closeTo(boxBefore.width, 1)));
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     // ── Redaction ──
 
@@ -177,7 +178,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       await editor.addRedaction(0, const PdfRect(x: 50, y: 100, width: 100, height: 20));
       expect(await editor.redactionCount(0), 2);
       await editor.dispose();
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('addRedaction + applyRedactions produces valid PDF', () async {
       final pdf = createPdf();
@@ -189,7 +190,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       await editor.dispose();
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 1);
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     // ── Encryption ──
 
@@ -204,7 +205,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       await editor.dispose();
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.isEncrypted, isTrue);
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('save with encryption remove strips encryption', () async {
       final pdf = createPdf();
@@ -227,7 +228,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       await editor2.dispose();
       final doc = await pdf.open(src(decSink.takeBytes()));
       expect(doc.isEncrypted, isFalse);
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     // ── Optimization ──
 
@@ -236,7 +237,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       final count = await editor.optimizeImages(quality: 75);
       expect(count, 0);
       await editor.dispose();
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('optimizeImages returns non-zero on image PDF', () async {
       final pdf = createPdf();
@@ -245,7 +246,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       final count = await editor.optimizeImages(quality: 50);
       expect(count, greaterThan(0));
       await editor.dispose();
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('unembedStandardFonts returns count', () async {
       final editor = await createPdf().edit(src(minimalPdf));
@@ -253,7 +254,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       expect(count, isA<int>());
       expect(count, greaterThanOrEqualTo(0));
       await editor.dispose();
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     // ── Content ──
 
@@ -266,7 +267,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       await editor.dispose();
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 1);
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('cropMargins produces valid PDF', () async {
       final pdf = createPdf();
@@ -279,7 +280,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       await editor.dispose();
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 1);
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('convertToPdfA produces valid PDF', () async {
       final pdf = createPdf();
@@ -295,7 +296,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       final validation = await doc.validatePdfA();
       expect(validation.errors, 0);
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     // ── Watermark ──
 
@@ -312,7 +313,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       expect(doc.pageCount, 1);
       expect(output.length, greaterThan(minimalPdf.length));
       expect(String.fromCharCodes(output), contains('TILED'));
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('addWatermark with background layer', () async {
       final pdf = createPdf();
@@ -325,7 +326,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       final doc = await pdf.open(src(output));
       expect(doc.pageCount, 1);
       expect(String.fromCharCodes(output), contains('BG'));
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     // ── Form fields ──
 
@@ -341,7 +342,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       final doc = await pdf.open(src(output));
       expect(doc.pageCount, 1);
       expect(String.fromCharCodes(output), contains('John Doe'));
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     // ── Rotation ──
 
@@ -354,7 +355,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       await editor.dispose();
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pages[0].rotation, 90);
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('rotateAllPages sets rotation on every page', () async {
       final pdf = createPdf();
@@ -368,7 +369,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pages[0].rotation, 180);
       expect(doc.pages[1].rotation, 180);
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     // ── Stamps ──
 
@@ -385,7 +386,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       expect(output.length, greaterThan(minimalPdf.length));
       final doc = await pdf.open(src(output));
       expect(doc.pageCount, 1);
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('addImageStamp embeds image data', () async {
       final pdf = createPdf();
@@ -397,7 +398,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       await editor.dispose();
       final output = sink.takeBytes();
       expect(output.length, greaterThan(minimalPdf.length));
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     // ── Content ──
 
@@ -410,7 +411,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       await editor.save(sink);
       await editor.dispose();
       expect(sink.takeBytes().length, greaterThan(minimalPdf.length));
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('eraseRegions produces valid output', () async {
       final pdf = createPdf();
@@ -422,7 +423,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       await editor.dispose();
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 1);
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('flattenForms preserves page count', () async {
       final pdf = createPdf();
@@ -434,7 +435,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       await editor.dispose();
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 1);
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     // ── Save options ──
 
@@ -447,7 +448,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       await editor.dispose();
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 1);
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('fullRewrite with compress + GC produces smaller output', () async {
       final pdf = createPdf();
@@ -459,7 +460,7 @@ void registerEditorTests(Pdf Function() createPdf) {
       await editor.dispose();
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 1);
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     // ── Getters ──
 
@@ -468,14 +469,14 @@ void registerEditorTests(Pdf Function() createPdf) {
       final v = await editor.version;
       expect(v, contains('.'));
       await editor.dispose();
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('getTitle roundtrips with setTitle', () async {
       final editor = await createPdf().edit(src(minimalPdf));
       await editor.setTitle('RoundtripTitle');
       expect(await editor.getTitle(), contains('RoundtripTitle'));
       await editor.dispose();
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     // ── ResizeImage ──
 
@@ -493,6 +494,6 @@ void registerEditorTests(Pdf Function() createPdf) {
       await editor.save(sink);
       await editor.dispose();
       expect(sink.takeBytes().length, greaterThan(0));
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
   });
 }

--- a/test/ops/core/pdf_instance_test.dart
+++ b/test/ops/core/pdf_instance_test.dart
@@ -7,6 +7,7 @@ import 'package:test/test.dart';
 
 import '../../helpers/fixtures.dart';
 import '../../helpers/test_source_sink.dart';
+import '../../helpers/timeouts.dart';
 
 void registerInstanceTests(Pdf Function() createPdf) {
   group('instance', () {
@@ -19,7 +20,7 @@ void registerInstanceTests(Pdf Function() createPdf) {
       expect(doc1.pageCount, 1);
       expect(doc2.pageCount, 1);
       await pdf.dispose();
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('dispose cascades to open editors', () async {
       final pdf = createPdf();
@@ -28,7 +29,7 @@ void registerInstanceTests(Pdf Function() createPdf) {
       expect(await ed1.pageCount, 1);
       expect(await ed2.pageCount, 1);
       await pdf.dispose();
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('dispose cascades to open builders', () async {
       final pdf = createPdf();
@@ -37,7 +38,7 @@ void registerInstanceTests(Pdf Function() createPdf) {
       await pdf.dispose();
       // No error — both builders freed by cascade
       expect(true, isTrue);
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('dispose cascades to mix of doc+editor+builder', () async {
       final pdf = createPdf();
@@ -47,7 +48,7 @@ void registerInstanceTests(Pdf Function() createPdf) {
       expect(doc.pageCount, 1);
       expect(await ed.pageCount, 1);
       await pdf.dispose();
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     // ── Double dispose ──
 
@@ -55,7 +56,7 @@ void registerInstanceTests(Pdf Function() createPdf) {
       final pdf = createPdf();
       await pdf.dispose();
       await pdf.dispose();
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('doc double dispose is safe', () async {
       final pdf = createPdf();
@@ -63,7 +64,7 @@ void registerInstanceTests(Pdf Function() createPdf) {
       await doc.dispose();
       await doc.dispose();
       await pdf.dispose();
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('editor double dispose is safe', () async {
       final pdf = createPdf();
@@ -71,7 +72,7 @@ void registerInstanceTests(Pdf Function() createPdf) {
       await ed.dispose();
       await ed.dispose();
       await pdf.dispose();
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('builder double dispose is safe', () async {
       final pdf = createPdf();
@@ -79,7 +80,7 @@ void registerInstanceTests(Pdf Function() createPdf) {
       await b.dispose();
       await b.dispose();
       await pdf.dispose();
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     // ── Operations after dispose throw ──
 
@@ -87,7 +88,7 @@ void registerInstanceTests(Pdf Function() createPdf) {
       final pdf = createPdf();
       await pdf.dispose();
       expect(() => pdf.open(src(minimalPdf)), throwsStateError);
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     // ── Dispose returns quickly ──
 
@@ -100,7 +101,7 @@ void registerInstanceTests(Pdf Function() createPdf) {
       await pdf.dispose();
       sw.stop();
       expect(sw.elapsedMilliseconds, lessThan(2000));
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     // ── Sequential reuse ──
 
@@ -119,7 +120,7 @@ void registerInstanceTests(Pdf Function() createPdf) {
       await doc2.dispose();
 
       await pdf.dispose();
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('doc dispose frees one doc, others survive', () async {
       final pdf = createPdf();
@@ -129,7 +130,7 @@ void registerInstanceTests(Pdf Function() createPdf) {
       expect(doc2.pageCount, 1);
       await doc2.dispose();
       await pdf.dispose();
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     // ── Multi-instance isolation ──
 
@@ -147,7 +148,7 @@ void registerInstanceTests(Pdf Function() createPdf) {
       expect(docB.pageCount, 1);
       await docB.dispose();
       await pdfB.dispose();
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('disposing one instance does not affect another', () async {
       final pdfA = createPdf();
@@ -160,7 +161,7 @@ void registerInstanceTests(Pdf Function() createPdf) {
       expect(doc.pageCount, 1);
       await doc.dispose();
       await pdfB.dispose();
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     // ── Parallel ops on single instance ──
 
@@ -175,7 +176,7 @@ void registerInstanceTests(Pdf Function() createPdf) {
         expect(doc.pageCount, 1);
       }
       await pdf.dispose();
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: t(3));
 
     test('parallel mix of doc+editor+builder', () async {
       final pdf = createPdf();
@@ -190,7 +191,7 @@ void registerInstanceTests(Pdf Function() createPdf) {
       expect(doc.pageCount, 1);
       expect(await ed.pageCount, 1);
       await pdf.dispose();
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: t(3));
 
     // ── Abrupt dispose (kill mid-flight) ──
 
@@ -210,7 +211,7 @@ void registerInstanceTests(Pdf Function() createPdf) {
         errors.add(e);
       });
       expect(errors, isEmpty, reason: 'dispose mid-flight should not leak errors');
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: t(3));
 
     test('dispose mid-open produces no unhandled errors', () async {
       final errors = <Object>[];
@@ -224,7 +225,7 @@ void registerInstanceTests(Pdf Function() createPdf) {
         errors.add(e);
       });
       expect(errors, isEmpty, reason: 'dispose mid-flight should not leak errors');
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: t(3));
 
     test('dispose mid-edit produces no unhandled errors', () async {
       final errors = <Object>[];
@@ -238,7 +239,7 @@ void registerInstanceTests(Pdf Function() createPdf) {
         errors.add(e);
       });
       expect(errors, isEmpty, reason: 'dispose mid-flight should not leak errors');
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: t(3));
 
     test('fresh instance works after abrupt dispose of another', () async {
       final pdf1 = createPdf();
@@ -255,6 +256,6 @@ void registerInstanceTests(Pdf Function() createPdf) {
       expect(doc.pageCount, 1);
       await doc.dispose();
       await pdf2.dispose();
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: t(3));
   });
 }

--- a/test/ops/core/pdf_lifecycle_test.dart
+++ b/test/ops/core/pdf_lifecycle_test.dart
@@ -8,6 +8,7 @@ import 'package:test/test.dart';
 
 import '../../helpers/fixtures.dart';
 import '../../helpers/test_source_sink.dart';
+import '../../helpers/timeouts.dart';
 
 void registerLifecycleTests(Pdf Function() createPdf) {
   group('lifecycle', () {
@@ -18,14 +19,14 @@ void registerLifecycleTests(Pdf Function() createPdf) {
         () => createPdf().open(TestSource(Uint8List.fromList([1, 2, 3, 4]))),
         throwsA(anything),
       );
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('open empty bytes throws', () async {
       expect(
         () => createPdf().open(TestSource(Uint8List(0))),
         throwsA(anything),
       );
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('recover after error — next op works', () async {
       final pdf = createPdf();
@@ -43,7 +44,7 @@ void registerLifecycleTests(Pdf Function() createPdf) {
             .codeUnits,
       )));
       expect(doc.pageCount, 1);
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     // ── Instance dispose ──
 
@@ -52,19 +53,19 @@ void registerLifecycleTests(Pdf Function() createPdf) {
       final doc = await pdf.open(src(minimalPdf));
       expect(doc.pageCount, 1);
       await pdf.dispose();
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('instance double dispose is safe', () async {
       final pdf = createPdf();
       await pdf.dispose();
       await pdf.dispose();
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('operations after instance dispose throw', () async {
       final pdf = createPdf();
       await pdf.dispose();
       expect(() => pdf.open(src(minimalPdf)), throwsStateError);
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('instance dispose returns quickly', () async {
       final pdf = createPdf();
@@ -73,7 +74,7 @@ void registerLifecycleTests(Pdf Function() createPdf) {
       await pdf.dispose();
       sw.stop();
       expect(sw.elapsedMilliseconds, lessThan(2000));
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     // ── Doc handle dispose ──
 
@@ -83,7 +84,7 @@ void registerLifecycleTests(Pdf Function() createPdf) {
       expect(doc.pageCount, 1);
       await doc.dispose();
       await pdf.dispose();
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('doc double dispose is safe', () async {
       final pdf = createPdf();
@@ -91,6 +92,6 @@ void registerLifecycleTests(Pdf Function() createPdf) {
       await doc.dispose();
       await doc.dispose();
       await pdf.dispose();
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
   });
 }

--- a/test/ops/core/pdf_standalone_test.dart
+++ b/test/ops/core/pdf_standalone_test.dart
@@ -8,6 +8,7 @@ import 'package:test/test.dart';
 
 import '../../helpers/fixtures.dart';
 import '../../helpers/test_source_sink.dart';
+import '../../helpers/timeouts.dart';
 
 void registerStandaloneTests(Pdf Function() createPdf) {
   group('standalone', () {
@@ -27,7 +28,7 @@ void registerStandaloneTests(Pdf Function() createPdf) {
       expect(sigs.first.signerName, isNotNull);
       expect(sigs.first.signerName, isNotEmpty);
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('sign with PEM adds a retrievable signature', () async {
       final pdf = createPdf();
@@ -41,7 +42,7 @@ void registerStandaloneTests(Pdf Function() createPdf) {
       expect(sigs, isNotEmpty);
       expect(sigs.first.signerName, isNotNull);
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('sign with invalid cert throws', () async {
       final pdf = createPdf();
@@ -52,7 +53,7 @@ void registerStandaloneTests(Pdf Function() createPdf) {
                 Uint8List.fromList([1, 2, 3, 4]), 'wrong')),
         throwsA(anything),
       );
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     // ── Extract pages ──
 
@@ -66,7 +67,7 @@ void registerStandaloneTests(Pdf Function() createPdf) {
       await pdf.extractPages(src(threePage), sink, pages: [0]);
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 1);
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     // ── Convert ──
 
@@ -77,7 +78,7 @@ void registerStandaloneTests(Pdf Function() createPdf) {
       final bytes = sink.takeBytes();
       expect(bytes[0], 0x50); // PK header
       expect(bytes[1], 0x4B);
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('convertTo PPTX produces valid ZIP', () async {
       final pdf = createPdf();
@@ -86,7 +87,7 @@ void registerStandaloneTests(Pdf Function() createPdf) {
       final bytes = sink.takeBytes();
       expect(bytes[0], 0x50);
       expect(bytes[1], 0x4B);
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('convertTo XLSX produces valid ZIP', () async {
       final pdf = createPdf();
@@ -95,7 +96,7 @@ void registerStandaloneTests(Pdf Function() createPdf) {
       final bytes = sink.takeBytes();
       expect(bytes[0], 0x50);
       expect(bytes[1], 0x4B);
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('convertToPdf from DOCX produces valid PDF', () async {
       final pdf = createPdf();
@@ -105,6 +106,6 @@ void registerStandaloneTests(Pdf Function() createPdf) {
       await pdf.convertToPdf(src(docxSink.takeBytes()), pdfSink, format: PdfDocumentFormat.docx);
       final pdfBytes = pdfSink.takeBytes();
       expect(String.fromCharCodes(pdfBytes.sublist(0, 5)), startsWith('%PDF'));
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
   });
 }

--- a/test/ops/core/pdf_sugar_test.dart
+++ b/test/ops/core/pdf_sugar_test.dart
@@ -9,6 +9,7 @@ import 'package:test/test.dart';
 import '../../helpers/fixtures.dart';
 import '../../helpers/generators.dart';
 import '../../helpers/test_source_sink.dart';
+import '../../helpers/timeouts.dart';
 
 void registerSugarTests(Pdf Function() createPdf) {
   group('sugar', () {
@@ -20,7 +21,7 @@ void registerSugarTests(Pdf Function() createPdf) {
       await pdf.merge([src(minimalPdf), src(minimalPdf)], sink);
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 2);
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('merge three PDFs → 3 pages', () async {
       final pdf = createPdf();
@@ -28,7 +29,7 @@ void registerSugarTests(Pdf Function() createPdf) {
       await pdf.merge([src(minimalPdf), src(minimalPdf), src(minimalPdf)], sink);
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 3);
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('merge different sized PDFs', () async {
       final pdf = createPdf();
@@ -36,7 +37,7 @@ void registerSugarTests(Pdf Function() createPdf) {
       await pdf.merge([src(minimalPdf), src(letterPdf)], sink);
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 2);
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('merged output is valid PDF', () async {
       final pdf = createPdf();
@@ -47,7 +48,7 @@ void registerSugarTests(Pdf Function() createPdf) {
       expect(bytes[1], 0x50);
       expect(bytes[2], 0x44);
       expect(bytes[3], 0x46);
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     // ── Rotate ──
 
@@ -57,7 +58,7 @@ void registerSugarTests(Pdf Function() createPdf) {
       await pdf.rotateAllPages(src(minimalPdf), sink, degrees: 90);
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pages[0].rotation, 90);
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('rotatePages rotates specific pages', () async {
       final pdf = createPdf();
@@ -65,7 +66,7 @@ void registerSugarTests(Pdf Function() createPdf) {
       await pdf.rotatePages(src(minimalPdf), sink, pages: {0: 90});
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pages[0].rotation, 90);
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     // ── Flatten ──
 
@@ -78,7 +79,7 @@ void registerSugarTests(Pdf Function() createPdf) {
       final doc = await pdf.open(src(output));
       expect(doc.pageCount, 1);
       expect(output.length, greaterThan(formBytes.length ~/ 2));
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     // ── Compress ──
 
@@ -91,7 +92,7 @@ void registerSugarTests(Pdf Function() createPdf) {
       final doc = await pdf.open(src(output));
       expect(doc.pageCount, 3);
       expect(output.length, lessThanOrEqualTo(multiPage.length * 2));
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     // ── Delete ──
 
@@ -104,7 +105,7 @@ void registerSugarTests(Pdf Function() createPdf) {
       await pdf.deletePages(src(twoPage), deleteSink, pages: [0]);
       final doc = await pdf.open(src(deleteSink.takeBytes()));
       expect(doc.pageCount, 1);
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     // ── Reorder ──
 
@@ -115,7 +116,7 @@ void registerSugarTests(Pdf Function() createPdf) {
       await pdf.reorderPages(src(multiPage), sink, order: [2, 1, 0]);
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 3);
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     // ── Move ──
 
@@ -135,7 +136,7 @@ void registerSugarTests(Pdf Function() createPdf) {
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 3);
       expect(doc.pages[0].width, closeTo(letterWidth, 1.0));
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     // ── Split ──
 
@@ -153,7 +154,7 @@ void registerSugarTests(Pdf Function() createPdf) {
         final doc = await pdf.open(src(s.takeBytes()));
         expect(doc.pageCount, 1);
       }
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('splitBySize total pages equals original', () async {
       final pdf = createPdf();
@@ -172,7 +173,7 @@ void registerSugarTests(Pdf Function() createPdf) {
         totalPages += doc.pageCount;
       }
       expect(totalPages, 3);
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     // ── Split by bookmarks ──
 
@@ -189,7 +190,7 @@ void registerSugarTests(Pdf Function() createPdf) {
         final doc = await pdf.open(src(s.takeBytes()));
         expect(doc.pageCount, 1);
       }
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     // ── Redaction ──
 
@@ -199,7 +200,7 @@ void registerSugarTests(Pdf Function() createPdf) {
       await pdf.applyRedactions(src(bookmarkedPdf), sink);
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 2);
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     // ── Embed file ──
 
@@ -214,7 +215,7 @@ void registerSugarTests(Pdf Function() createPdf) {
       expect(doc.pageCount, 1);
       expect(output.length, greaterThan(minimalPdf.length));
       expect(String.fromCharCodes(output), contains('test.txt'));
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     // ── Erase ──
 
@@ -227,7 +228,7 @@ void registerSugarTests(Pdf Function() createPdf) {
       final doc = await pdf.open(src(output));
       expect(doc.pageCount, 1);
       expect(output.length, greaterThan(minimalPdf.length));
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     // ── Stamps ──
 
@@ -242,7 +243,7 @@ void registerSugarTests(Pdf Function() createPdf) {
       expect(doc.pageCount, 1);
       expect(output.length, greaterThan(minimalPdf.length));
       expect(String.fromCharCodes(output).toLowerCase(), contains('approved'));
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('addImageStamp embeds image data', () async {
       final pdf = createPdf();
@@ -254,7 +255,7 @@ void registerSugarTests(Pdf Function() createPdf) {
       final doc = await pdf.open(src(output));
       expect(doc.pageCount, 1);
       expect(output.length, greaterThan(minimalPdf.length));
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     // ── Watermark ──
 
@@ -269,7 +270,7 @@ void registerSugarTests(Pdf Function() createPdf) {
       await doc.dispose();
       expect(output.length, greaterThan(input.length));
       expect(String.fromCharCodes(output), contains('CONFIDENTIAL'));
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('watermark position variants produce valid output', () async {
       final pdf = createPdf();
@@ -290,7 +291,7 @@ void registerSugarTests(Pdf Function() createPdf) {
         expect(output.length, greaterThan(input.length),
             reason: '${entry.key}: watermark increases file size');
       }
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     test('watermark layers produce valid output', () async {
       final pdf = createPdf();
@@ -305,7 +306,7 @@ void registerSugarTests(Pdf Function() createPdf) {
         expect(output.length, greaterThan(input.length));
         expect(String.fromCharCodes(output), contains('LAYER'));
       }
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     // ── Encrypt / Decrypt ──
 
@@ -326,7 +327,7 @@ void registerSugarTests(Pdf Function() createPdf) {
       final decDoc = await pdf.open(src(decrypted));
       expect(decDoc.pageCount, 1);
       await decDoc.dispose();
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     // ── ConvertToPdfA ──
 
@@ -337,7 +338,7 @@ void registerSugarTests(Pdf Function() createPdf) {
       await pdf.convertToPdfA(src(formBytes), sink);
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 1);
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     // ── ExtractPages ──
 
@@ -348,7 +349,7 @@ void registerSugarTests(Pdf Function() createPdf) {
       await pdf.extractPages(src(threePage), sink, pages: [0, 2]);
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 2);
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
 
     // ── ImagesToPdf ──
 
@@ -358,7 +359,7 @@ void registerSugarTests(Pdf Function() createPdf) {
       await pdf.imagesToPdf([src(minimalPng)], sink);
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 1);
-    }, timeout: Timeout(Duration(seconds: 1)));
+    }, timeout: t(1));
   });
 }
 

--- a/test/ops/native/native_finalizer_test.dart
+++ b/test/ops/native/native_finalizer_test.dart
@@ -14,6 +14,7 @@
 import 'dart:io';
 
 import 'package:test/test.dart';
+import '../../helpers/timeouts.dart';
 
 void registerNativeFinalizerTests() {
   test('dispose exits cleanly (no dangling NativeCallable)',
@@ -38,5 +39,5 @@ void registerNativeFinalizerTests() {
             ? 'Process hung — dispose() did not shut down cleanly.'
             : 'Process crashed (exit $exitCode) — dangling NativeCallable.\n'
                 'stderr: ${await process.stderr.transform(const SystemEncoding().decoder).join()}');
-  }, timeout: Timeout(Duration(seconds: 5)));
+  }, timeout: t(5));
 }

--- a/test/ops/runners/native_runner_test.dart
+++ b/test/ops/runners/native_runner_test.dart
@@ -24,19 +24,20 @@ import '../stress/pdf_standalone_stress_test.dart';
 import '../stress/pdf_builder_stress_test.dart';
 import '../stress/pdf_instance_stress_test.dart';
 import '../native/native_finalizer_test.dart';
+import '../../helpers/timeouts.dart';
 
 void main() {
   late Pdf pdf;
 
   test('engine init', () {
     pdf = Pdf();
-  }, timeout: Timeout(Duration(seconds: 3)));
+  }, timeout: t(3));
 
   test('verify I/O mode is native', () async {
     final doc = await pdf.open(src(minimalPdf));
     await doc.dispose();
     expect(pdf.ioMode, PdfIoMode.native);
-  }, timeout: Timeout(Duration(seconds: 1)));
+  }, timeout: t(1));
 
   tearDownAll(() => pdf.dispose());
 

--- a/test/ops/runners/web_atomics_runner_test.dart
+++ b/test/ops/runners/web_atomics_runner_test.dart
@@ -22,6 +22,7 @@ import '../stress/pdf_sugar_stress_test.dart';
 import '../stress/pdf_standalone_stress_test.dart';
 import '../stress/pdf_builder_stress_test.dart';
 import '../stress/pdf_instance_stress_test.dart';
+import '../../helpers/timeouts.dart';
 
 void main() {
   late Pdf pdf;
@@ -39,13 +40,13 @@ void main() {
       webWorkerUrl: 'http://localhost:$serverPort/web_assets/worker.js',
       webIoMode: PdfIoMode.atomics,
     ));
-  }, timeout: Timeout(Duration(seconds: 3)));
+  }, timeout: t(3));
 
   test('verify I/O mode is atomics', () async {
     final doc = await pdf.open(src(minimalPdf));
     await doc.dispose();
     expect(pdf.ioMode, PdfIoMode.atomics);
-  }, timeout: Timeout(Duration(seconds: 3)));
+  }, timeout: t(3));
 
   tearDownAll(() => pdf.dispose());
 

--- a/test/ops/runners/web_jspi_runner_test.dart
+++ b/test/ops/runners/web_jspi_runner_test.dart
@@ -22,6 +22,7 @@ import '../stress/pdf_sugar_stress_test.dart';
 import '../stress/pdf_standalone_stress_test.dart';
 import '../stress/pdf_builder_stress_test.dart';
 import '../stress/pdf_instance_stress_test.dart';
+import '../../helpers/timeouts.dart';
 
 void main() {
   late Pdf pdf;
@@ -39,13 +40,13 @@ void main() {
       webWorkerUrl: 'http://localhost:$serverPort/web_assets/worker.js',
       webIoMode: PdfIoMode.jspi,
     ));
-  }, timeout: Timeout(Duration(seconds: 3)));
+  }, timeout: t(3));
 
   test('verify I/O mode is jspi', () async {
     final doc = await pdf.open(src(minimalPdf));
     await doc.dispose();
     expect(pdf.ioMode, PdfIoMode.jspi);
-  }, timeout: Timeout(Duration(seconds: 3)));
+  }, timeout: t(3));
 
   tearDownAll(() => pdf.dispose());
 

--- a/test/ops/runners/web_opfs_runner_test.dart
+++ b/test/ops/runners/web_opfs_runner_test.dart
@@ -22,6 +22,7 @@ import '../stress/pdf_sugar_stress_test.dart';
 import '../stress/pdf_standalone_stress_test.dart';
 import '../stress/pdf_builder_stress_test.dart';
 import '../stress/pdf_instance_stress_test.dart';
+import '../../helpers/timeouts.dart';
 
 void main() {
   late Pdf pdf;
@@ -39,13 +40,13 @@ void main() {
       webWorkerUrl: 'http://localhost:$serverPort/web_assets/worker.js',
       webIoMode: PdfIoMode.opfs,
     ));
-  }, timeout: Timeout(Duration(seconds: 3)));
+  }, timeout: t(3));
 
   test('verify I/O mode is opfs', () async {
     final doc = await pdf.open(src(minimalPdf));
     await doc.dispose();
     expect(pdf.ioMode, PdfIoMode.opfs);
-  }, timeout: Timeout(Duration(seconds: 3)));
+  }, timeout: t(3));
 
   tearDownAll(() => pdf.dispose());
 

--- a/test/ops/stress/pdf_builder_stress_test.dart
+++ b/test/ops/stress/pdf_builder_stress_test.dart
@@ -5,6 +5,7 @@ import 'package:test/test.dart';
 
 import '../../helpers/generators.dart';
 import '../../helpers/test_source_sink.dart';
+import '../../helpers/timeouts.dart';
 
 void registerBuilderStressTests(Pdf Function() createPdf) {
   group('stress builder', tags: 'stress', () {
@@ -13,6 +14,6 @@ void registerBuilderStressTests(Pdf Function() createPdf) {
       final imagePdf = await buildImagePdf(createPdf, pageCount: 10);
       final doc = await pdf.open(src(imagePdf));
       expect(doc.pageCount, 10);
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: t(3));
   });
 }

--- a/test/ops/stress/pdf_doc_stress_test.dart
+++ b/test/ops/stress/pdf_doc_stress_test.dart
@@ -7,6 +7,7 @@ import 'package:test/test.dart';
 
 import '../../helpers/generators.dart';
 import '../../helpers/test_source_sink.dart';
+import '../../helpers/timeouts.dart';
 
 void registerDocStressTests(Pdf Function() createPdf) {
   group('stress doc', tags: 'stress', () {
@@ -15,12 +16,12 @@ void registerDocStressTests(Pdf Function() createPdf) {
     test('build 1000-page PDF', () async {
       largePdf = await buildLargePdf(createPdf, pageCount: 1000);
       expect(largePdf.length, greaterThan(0));
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: t(3));
 
     test('open 1000-page PDF', () async {
       final doc = await createPdf().open(src(largePdf));
       expect(doc.pageCount, 1000);
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: t(3));
 
     test('extract text from 1000-page PDF', () async {
       final doc = await createPdf().open(src(largePdf));
@@ -28,21 +29,21 @@ void registerDocStressTests(Pdf Function() createPdf) {
       expect(text.length, greaterThan(1000));
       expect(text, contains('Lorem ipsum'));
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: t(3));
 
     test('extract single page from middle', () async {
       final doc = await createPdf().open(src(largePdf));
       final text = await doc.extract(pages: const PdfPages.single(100));
       expect(text.length, greaterThan(0));
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: t(3));
 
     test('search across 1000-page PDF', () async {
       final doc = await createPdf().open(src(largePdf));
       final results = await doc.search(query: 'Lorem', pages: const PdfPages.all());
       expect(results.length, greaterThanOrEqualTo(1000));
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: t(3));
 
     test('render first page', () async {
       final doc = await createPdf().open(src(largePdf));
@@ -53,7 +54,7 @@ void registerDocStressTests(Pdf Function() createPdf) {
       }
       expect(count, 1);
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: t(3));
 
     test('render pages 100-109', () async {
       final doc = await createPdf().open(src(largePdf));
@@ -64,13 +65,13 @@ void registerDocStressTests(Pdf Function() createPdf) {
       }
       expect(count, 10);
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: t(3));
 
     test('convertTo DOCX', () async {
       final pdf = createPdf();
       final sink = TestSink();
       await pdf.convertTo(src(largePdf), sink, format: PdfDocumentFormat.docx);
       expect(sink.takeBytes().length, greaterThan(0));
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: t(3));
   });
 }

--- a/test/ops/stress/pdf_editor_stress_test.dart
+++ b/test/ops/stress/pdf_editor_stress_test.dart
@@ -7,6 +7,7 @@ import 'package:test/test.dart';
 
 import '../../helpers/generators.dart';
 import '../../helpers/test_source_sink.dart';
+import '../../helpers/timeouts.dart';
 
 void registerEditorStressTests(Pdf Function() createPdf) {
   group('stress editor', tags: 'stress', () {
@@ -15,14 +16,14 @@ void registerEditorStressTests(Pdf Function() createPdf) {
     test('build 1000-page PDF', () async {
       largePdf = await buildLargePdf(createPdf, pageCount: 1000);
       expect(largePdf.length, greaterThan(0));
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: t(3));
 
     test('watermark 1000 pages', () async {
       final pdf = createPdf();
       final sink = TestSink();
       await pdf.watermark(src(largePdf), sink, text: 'CONFIDENTIAL');
       expect(sink.takeBytes().length, greaterThan(largePdf.length));
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: t(3));
 
     test('encrypt then decrypt 1000-page PDF', () async {
       final pdf = createPdf();
@@ -35,7 +36,7 @@ void registerEditorStressTests(Pdf Function() createPdf) {
       final doc = await pdf.open(src(decSink.takeBytes()));
       expect(doc.pageCount, 1000);
       await doc.dispose();
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: t(3));
 
     test('editor watermark first 10 pages', () async {
       final pdf = createPdf();
@@ -48,14 +49,14 @@ void registerEditorStressTests(Pdf Function() createPdf) {
       await editor.dispose();
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 1000);
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: t(3));
 
     test('compress 1000-page PDF', () async {
       final pdf = createPdf();
       final sink = TestSink();
       await pdf.compress(src(largePdf), sink);
       expect(sink.takeBytes().length, greaterThan(0));
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: t(3));
 
     test('flattenForms on form PDF', () async {
       final pdf = createPdf();
@@ -63,6 +64,6 @@ void registerEditorStressTests(Pdf Function() createPdf) {
       final sink = TestSink();
       await pdf.flattenForms(src(formPdf), sink);
       expect(sink.takeBytes().length, greaterThan(0));
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: t(3));
   });
 }

--- a/test/ops/stress/pdf_instance_stress_test.dart
+++ b/test/ops/stress/pdf_instance_stress_test.dart
@@ -6,6 +6,7 @@ import 'package:test/test.dart';
 import '../../helpers/fixtures.dart';
 import '../../helpers/generators.dart';
 import '../../helpers/test_source_sink.dart';
+import '../../helpers/timeouts.dart';
 
 void registerInstanceStressTests(Pdf Function() createPdf) {
   group('instance stress', tags: 'stress', () {
@@ -17,7 +18,7 @@ void registerInstanceStressTests(Pdf Function() createPdf) {
         await doc.dispose();
       }
       await pdf.dispose();
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: t(3));
 
     test('100x rapid editor open/dispose cycles', () async {
       final pdf = createPdf();
@@ -27,7 +28,7 @@ void registerInstanceStressTests(Pdf Function() createPdf) {
         await ed.dispose();
       }
       await pdf.dispose();
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: t(3));
 
     test('50x parallel open across 5 instances', () async {
       final instances = List.generate(5, (_) => createPdf());
@@ -43,7 +44,7 @@ void registerInstanceStressTests(Pdf Function() createPdf) {
       for (final pdf in instances) {
         await pdf.dispose();
       }
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: t(3));
 
     test('interleaved doc+editor+sugar on same instance', () async {
       final pdf = createPdf();
@@ -62,7 +63,7 @@ void registerInstanceStressTests(Pdf Function() createPdf) {
         await pdf.merge([src(minimalPdf), src(minimalPdf)], sink2);
       }
       await pdf.dispose();
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: t(3));
 
     test('dispose under load — open 10 docs then kill', () async {
       final pdf = createPdf();
@@ -74,7 +75,7 @@ void registerInstanceStressTests(Pdf Function() createPdf) {
       await pdf.dispose();
       sw.stop();
       expect(sw.elapsedMilliseconds, lessThan(2000));
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: t(3));
 
     test('splitBySize on varied-size pages', () async {
       final pdf = createPdf();
@@ -95,6 +96,6 @@ void registerInstanceStressTests(Pdf Function() createPdf) {
       }
       expect(totalPages, 50);
       await pdf.dispose();
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: t(3));
   });
 }

--- a/test/ops/stress/pdf_standalone_stress_test.dart
+++ b/test/ops/stress/pdf_standalone_stress_test.dart
@@ -7,6 +7,7 @@ import 'package:test/test.dart';
 
 import '../../helpers/generators.dart';
 import '../../helpers/test_source_sink.dart';
+import '../../helpers/timeouts.dart';
 
 void registerStandaloneStressTests(Pdf Function() createPdf) {
   group('stress standalone', tags: 'stress', () {
@@ -15,7 +16,7 @@ void registerStandaloneStressTests(Pdf Function() createPdf) {
     test('build 1000-page PDF', () async {
       largePdf = await buildLargePdf(createPdf, pageCount: 1000);
       expect(largePdf.length, greaterThan(0));
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: t(3));
 
     test('extractPages first 10 from 1000-page', () async {
       final pdf = createPdf();
@@ -24,6 +25,6 @@ void registerStandaloneStressTests(Pdf Function() createPdf) {
           pages: List.generate(10, (i) => i));
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 10);
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: t(3));
   });
 }

--- a/test/ops/stress/pdf_sugar_stress_test.dart
+++ b/test/ops/stress/pdf_sugar_stress_test.dart
@@ -7,6 +7,7 @@ import 'package:test/test.dart';
 
 import '../../helpers/generators.dart';
 import '../../helpers/test_source_sink.dart';
+import '../../helpers/timeouts.dart';
 
 void registerSugarStressTests(Pdf Function() createPdf) {
   group('stress sugar', tags: 'stress', () {
@@ -15,7 +16,7 @@ void registerSugarStressTests(Pdf Function() createPdf) {
     test('build 1000-page PDF', () async {
       largePdf = await buildLargePdf(createPdf, pageCount: 1000);
       expect(largePdf.length, greaterThan(0));
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: t(3));
 
     test('split every 100 pages', () async {
       final pdf = createPdf();
@@ -32,7 +33,7 @@ void registerSugarStressTests(Pdf Function() createPdf) {
         final doc = await pdf.open(src(bytes));
         expect(doc.pageCount, 100);
       }
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: t(3));
 
     test('splitBySize generous limit', () async {
       final pdf = createPdf();
@@ -50,7 +51,7 @@ void registerSugarStressTests(Pdf Function() createPdf) {
         totalPages += doc.pageCount;
       }
       expect(totalPages, 100);
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: t(3));
 
     test('splitBySize tight limit', () async {
       final pdf = createPdf();
@@ -65,7 +66,7 @@ void registerSugarStressTests(Pdf Function() createPdf) {
       for (final s in sinks) {
         expect(s.takeBytes().length, greaterThan(0));
       }
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: t(3));
 
     test('splitBySize smaller than single page', () async {
       final pdf = createPdf();
@@ -83,7 +84,7 @@ void registerSugarStressTests(Pdf Function() createPdf) {
         final doc = await pdf.open(src(bytes));
         expect(doc.pageCount, greaterThanOrEqualTo(1));
       }
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: t(3));
 
     test('splitBySize equal to full PDF → 1 chunk', () async {
       final pdf = createPdf();
@@ -97,7 +98,7 @@ void registerSugarStressTests(Pdf Function() createPdf) {
       expect(sinks.length, 1);
       final doc = await pdf.open(src(sinks.first.takeBytes()));
       expect(doc.pageCount, 100);
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: t(3));
 
     test('splitBySize returns chunk byte sizes', () async {
       final pdf = createPdf();
@@ -113,7 +114,7 @@ void registerSugarStressTests(Pdf Function() createPdf) {
         expect(chunkSizes[i], greaterThan(0));
         expect(chunkSizes[i], sinks[i].takeBytes().length);
       }
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: t(3));
 
     test('extract first 10 pages', () async {
       final pdf = createPdf();
@@ -122,7 +123,7 @@ void registerSugarStressTests(Pdf Function() createPdf) {
           pages: List.generate(10, (i) => i));
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 10);
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: t(3));
 
     test('delete 990 pages', () async {
       final pdf = createPdf();
@@ -131,7 +132,7 @@ void registerSugarStressTests(Pdf Function() createPdf) {
           pages: List.generate(990, (i) => i));
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 10);
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: t(3));
 
     test('merge two 1000-page PDFs → 2000 pages', () async {
       final pdf = createPdf();
@@ -139,7 +140,7 @@ void registerSugarStressTests(Pdf Function() createPdf) {
       await pdf.merge([src(largePdf), src(largePdf)], sink);
       final doc = await pdf.open(src(sink.takeBytes()));
       expect(doc.pageCount, 2000);
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: t(3));
 
     test('splitBySize on varied-size pages', () async {
       final pdf = createPdf();
@@ -156,6 +157,6 @@ void registerSugarStressTests(Pdf Function() createPdf) {
         totalPages += doc.pageCount;
       }
       expect(totalPages, 50);
-    }, timeout: Timeout(Duration(seconds: 3)));
+    }, timeout: t(3));
   });
 }


### PR DESCRIPTION
## Summary

- **WASM binaries missing from 1.0.6 releases.** `cd` into `vendor/` made relative `COMPILE_OUTPUT_DIR=out` resolve to `vendor/pdf_oxide/out/` instead of repo root `out/`. Resolved to absolute path before `cd`.
- **Binary verification gate.** All 15 expected binaries must exist before upload to GitHub Release. Incomplete releases now fail the job instead of silently publishing.
- Changelog entries for 1.0.7 / 1.0.7-dev.0.

## Test plan

- [ ] `COMPILE_OUTPUT_DIR=out bash tool/compile_rust.sh wasm` creates `out/wasm/` at repo root
- [ ] Release pipeline uploads all 15 binaries including WASM
- [ ] Missing binary fails the upload-assets job