### PR TITLE
ci: debug watchdog v2 — deep descendant search + probes

### DIFF
--- a/.github/actions/capabilities/android-emulator/action.yml
+++ b/.github/actions/capabilities/android-emulator/action.yml
@@ -117,10 +117,16 @@ runs:
             # Search for stuck teardown adb commands (force-stop OR uninstall).
             # Both go through Binder IPC to system_server and hang when
             # the emulator is CPU-starved.
+            # Note: pgrep -f "a\|b" doesn't work on macOS. Search separately.
             echo "-- teardown adb search --"
-            for apid in $(pgrep -f "force-stop\|uninstall" 2>/dev/null); do
+            TEARDOWN_PIDS=""
+            for pattern in "force-stop" "uninstall"; do
+              for apid in $(pgrep -f "$pattern" 2>/dev/null); do
+                TEARDOWN_PIDS="$TEARDOWN_PIDS $apid"
+              done
+            done
+            for apid in $TEARDOWN_PIDS; do
               ACMD=$(ps -p "$apid" -o args= 2>/dev/null || true)
-              # Only match adb commands, not random processes.
               echo "$ACMD" | grep -q "adb" || continue
               ACPU=$(ps -p "$apid" -o %cpu= 2>/dev/null | tr -d ' ' || true)
               echo "  FOUND: PID=$apid CPU=${ACPU}% CMD=$ACMD"

--- a/.github/actions/capabilities/android-emulator/action.yml
+++ b/.github/actions/capabilities/android-emulator/action.yml
@@ -74,31 +74,68 @@ runs:
         # Watchdog: detect and kill stuck `adb shell am force-stop`.
         # Only kills adb processes whose command line contains "force-stop".
         # Other adb commands (install, uninstall, shell getprop) are left alone.
+        # Searches all descendants of dartvm, not just direct children.
         (
           KILLED=false
+          TICK=0
           while kill -0 $CMD_PID 2>/dev/null; do
             sleep 30
-            # Walk every dartvm's children looking for a stuck force-stop.
+            TICK=$((TICK + 1))
+            echo ""
+            echo "=== WATCHDOG PROBE ${TICK} (${TICK}x30s) ==="
+
+            # Find all adb processes system-wide and show their parent chain.
+            echo "-- all adb processes --"
+            for apid in $(pgrep -f adb 2>/dev/null); do
+              ACMD=$(ps -p "$apid" -o args= 2>/dev/null || true)
+              APPID=$(ps -p "$apid" -o ppid= 2>/dev/null | tr -d ' ' || true)
+              ACPU=$(ps -p "$apid" -o %cpu= 2>/dev/null | tr -d ' ' || true)
+              echo "  PID=$apid PPID=$APPID CPU=${ACPU}% CMD=$ACMD"
+            done
+
+            # Find all dartvm processes and their full descendant trees.
+            echo "-- dartvm descendant trees --"
             for dvmpid in $(pgrep -f dartvm 2>/dev/null); do
+              echo "  dartvm $dvmpid:"
+              # Direct children.
               for cpid in $(pgrep -P "$dvmpid" 2>/dev/null); do
-                CNAME=$(ps -p "$cpid" -o comm= 2>/dev/null || true)
-                # Only check adb processes.
-                echo "$CNAME" | grep -q adb || continue
-                [ "$KILLED" = "true" ] && continue
-                # Read the full command line to identify force-stop specifically.
-                CMDLINE=$(ps -p "$cpid" -o args= 2>/dev/null || true)
-                echo "$CMDLINE" | grep -q "force-stop" || continue
-                # Confirmed: this is `adb shell am force-stop`. Kill it.
-                CCPU=$(ps -p "$cpid" -o %cpu= 2>/dev/null | tr -d ' ' || true)
+                CCMD=$(ps -p "$cpid" -o args= 2>/dev/null || true)
+                echo "    L1 $cpid: $CCMD"
+                # Grandchildren.
+                for gcpid in $(pgrep -P "$cpid" 2>/dev/null); do
+                  GCCMD=$(ps -p "$gcpid" -o args= 2>/dev/null || true)
+                  echo "      L2 $gcpid: $GCCMD"
+                  # Great-grandchildren.
+                  for ggcpid in $(pgrep -P "$gcpid" 2>/dev/null); do
+                    GGCCMD=$(ps -p "$ggcpid" -o args= 2>/dev/null || true)
+                    echo "        L3 $ggcpid: $GGCCMD"
+                  done
+                done
+              done
+            done
+
+            # Search for stuck force-stop at any depth under any dartvm.
+            echo "-- force-stop search --"
+            for apid in $(pgrep -f "force-stop" 2>/dev/null); do
+              ACMD=$(ps -p "$apid" -o args= 2>/dev/null || true)
+              ACPU=$(ps -p "$apid" -o %cpu= 2>/dev/null | tr -d ' ' || true)
+              echo "  FOUND: PID=$apid CPU=${ACPU}% CMD=$ACMD"
+              if [ "$KILLED" = "false" ]; then
                 echo ""
-                echo "=== WATCHDOG: stuck adb force-stop detected (PID $cpid, child of dartvm $dvmpid, cpu=${CCPU}%) ==="
-                echo "    cmd: $CMDLINE"
+                echo "=== WATCHDOG: stuck adb force-stop detected (PID $apid, cpu=${ACPU}%) ==="
+                echo "    cmd: $ACMD"
                 echo "    Flutter stopApp() has no timeout — killing to unblock teardown."
                 echo "    Only happens on macOS Intel (SwiftShader CPU starvation)."
-                kill -9 "$cpid" 2>/dev/null || true
+                kill -9 "$apid" 2>/dev/null || true
                 KILLED=true
                 echo "=== WATCHDOG: killed. Flutter test should exit shortly. ==="
                 echo ""
+              fi
+            done
+            if [ "$KILLED" = "false" ]; then
+              echo "  (no force-stop process found)"
+            fi
+            echo "=== END PROBE ==="
               done
             done
           done

--- a/.github/actions/capabilities/android-emulator/action.yml
+++ b/.github/actions/capabilities/android-emulator/action.yml
@@ -35,30 +35,25 @@ runs:
         $ANDROID_HOME/platform-tools/adb start-server
         $ANDROID_HOME/platform-tools/adb devices
 
-    # Watchdog for the flutter test teardown hang on macOS Intel.
+    # Watchdog for flutter test teardown hang on macOS Intel.
     #
     # Only affects: macOS Intel + SwiftShader (no hardware GPU).
     # Does NOT affect: Linux with KVM, Windows, macOS ARM, local dev.
     #
-    # Root cause: Flutter's stopApp() calls `adb shell am force-stop`
-    # with no timeout (android_device.dart → _processUtils.stream()).
-    # On SwiftShader emulators, qemu uses ~200% CPU on 4 cores,
-    # starving the guest's ActivityManagerService. The `am force-stop`
-    # command never gets CPU time to execute. The dartvm waits for
-    # this adb child forever → flutter test never exits.
+    # Root cause: Flutter's teardown calls adb commands (force-stop,
+    # uninstall) that go through Binder IPC to the emulator's
+    # system_server. On SwiftShader emulators qemu uses ~200% CPU,
+    # starving system_server. The adb commands hang forever because
+    # Flutter's stopApp() and uninstallApp() have no timeout.
+    # https://github.com/flutter/flutter/issues/187785
     #
-    # Fix: detect the stuck adb child of dartvm (0% CPU) and kill it.
-    # stopApp() receives an error return, continues to uninstallApp()
-    # which also fails with "adb uninstall failed: exit code -9" —
-    # that error in the logs is expected and harmless. Teardown then
-    # completes and flutter test prints the summary and exits cleanly.
+    # Fix: after all tests pass, any adb child of dartvm sitting at
+    # 0% CPU is a stuck teardown command. Kill it. Flutter handles the
+    # error gracefully and continues to exit. The "adb ... failed:
+    # exit code -9" error in logs after the kill is expected.
     #
     # Harmless on runners where the hang doesn't occur — the watchdog
-    # simply never finds a stuck adb process and exits with the
-    # user's command.
-    #
-    # Remove this watchdog when Flutter adds a timeout to stopApp():
-    # https://github.com/flutter/flutter/blob/master/packages/flutter_tools/lib/src/android/android_device.dart
+    # never finds a stuck adb and exits with the user's command.
     - name: Write emulator scripts
       if: runner.os != 'Windows'
       shell: bash
@@ -67,94 +62,40 @@ runs:
         #!/usr/bin/env bash
         set -euo pipefail
 
-        # Run the user's command in background.
         bash -c "$1" &
         CMD_PID=$!
 
-        # Watchdog: detect and kill stuck `adb shell am force-stop`.
-        # Only kills adb processes whose command line contains "force-stop".
-        # Other adb commands (install, uninstall, shell getprop) are left alone.
-        # Searches all descendants of dartvm, not just direct children.
+        # Watchdog: kill any adb child of dartvm stuck at 0% CPU.
+        # Checks every 30s. No pattern matching on command names —
+        # any adb process parented to dartvm that's idle is stuck.
         (
-          KILLED=false
-          TICK=0
           while kill -0 $CMD_PID 2>/dev/null; do
             sleep 30
-            TICK=$((TICK + 1))
-            echo ""
-            echo "=== WATCHDOG PROBE ${TICK} (${TICK}x30s) ==="
-
-            # Find all adb processes system-wide and show their parent chain.
-            echo "-- all adb processes --"
-            for apid in $(pgrep -f adb 2>/dev/null); do
-              ACMD=$(ps -p "$apid" -o args= 2>/dev/null || true)
-              APPID=$(ps -p "$apid" -o ppid= 2>/dev/null | tr -d ' ' || true)
-              ACPU=$(ps -p "$apid" -o %cpu= 2>/dev/null | tr -d ' ' || true)
-              echo "  PID=$apid PPID=$APPID CPU=${ACPU}% CMD=$ACMD"
-            done
-
-            # Find all dartvm processes and their full descendant trees.
-            echo "-- dartvm descendant trees --"
             for dvmpid in $(pgrep -f dartvm 2>/dev/null); do
-              echo "  dartvm $dvmpid:"
-              # Direct children.
               for cpid in $(pgrep -P "$dvmpid" 2>/dev/null); do
-                CCMD=$(ps -p "$cpid" -o args= 2>/dev/null || true)
-                echo "    L1 $cpid: $CCMD"
-                # Grandchildren.
-                for gcpid in $(pgrep -P "$cpid" 2>/dev/null); do
-                  GCCMD=$(ps -p "$gcpid" -o args= 2>/dev/null || true)
-                  echo "      L2 $gcpid: $GCCMD"
-                  # Great-grandchildren.
-                  for ggcpid in $(pgrep -P "$gcpid" 2>/dev/null); do
-                    GGCCMD=$(ps -p "$ggcpid" -o args= 2>/dev/null || true)
-                    echo "        L3 $ggcpid: $GGCCMD"
-                  done
-                done
+                CNAME=$(ps -p "$cpid" -o comm= 2>/dev/null || true)
+                echo "$CNAME" | grep -q adb || continue
+                CCPU=$(ps -p "$cpid" -o %cpu= 2>/dev/null | tr -d ' ' || true)
+                # 0% CPU = stuck on Binder IPC to CPU-starved emulator.
+                if echo "$CCPU" | awk '{ exit ($1 > 0.1) }'; then
+                  CCMD=$(ps -p "$cpid" -o args= 2>/dev/null || true)
+                  echo ""
+                  echo "=== WATCHDOG: stuck adb detected (PID $cpid, cpu=${CCPU}%) ==="
+                  echo "    cmd: $CCMD"
+                  echo "    Killing to unblock flutter test teardown."
+                  kill -9 "$cpid" 2>/dev/null || true
+                  echo "=== WATCHDOG: killed. Flutter test should exit shortly. ==="
+                  echo ""
+                fi
               done
             done
-
-            # Search for stuck teardown adb commands (force-stop OR uninstall).
-            # Both go through Binder IPC to system_server and hang when
-            # the emulator is CPU-starved.
-            # Note: pgrep -f "a\|b" doesn't work on macOS. Search separately.
-            echo "-- teardown adb search --"
-            TEARDOWN_PIDS=""
-            for pattern in "force-stop" "uninstall"; do
-              for apid in $(pgrep -f "$pattern" 2>/dev/null); do
-                TEARDOWN_PIDS="$TEARDOWN_PIDS $apid"
-              done
-            done
-            for apid in $TEARDOWN_PIDS; do
-              ACMD=$(ps -p "$apid" -o args= 2>/dev/null || true)
-              echo "$ACMD" | grep -q "adb" || continue
-              ACPU=$(ps -p "$apid" -o %cpu= 2>/dev/null | tr -d ' ' || true)
-              echo "  FOUND: PID=$apid CPU=${ACPU}% CMD=$ACMD"
-              if [ "$KILLED" = "false" ]; then
-                echo ""
-                echo "=== WATCHDOG: stuck adb teardown detected (PID $apid, cpu=${ACPU}%) ==="
-                echo "    cmd: $ACMD"
-                echo "    Flutter teardown has no timeout — killing to unblock."
-                echo "    Only happens on macOS Intel (SwiftShader CPU starvation)."
-                kill -9 "$apid" 2>/dev/null || true
-                KILLED=true
-                echo "=== WATCHDOG: killed. Flutter test should exit shortly. ==="
-                echo ""
-              fi
-            done
-            if [ "$KILLED" = "false" ]; then
-              echo "  (no stuck teardown adb found)"
-            fi
-            echo "=== END PROBE ==="
           done
         ) &
         WATCHDOG_PID=$!
 
-        # Wait for the user's command to finish.
         wait $CMD_PID 2>/dev/null
         EXIT=$?
 
-        # Stop the watchdog.
         kill $WATCHDOG_PID 2>/dev/null || true
         wait $WATCHDOG_PID 2>/dev/null || true
 

--- a/.github/actions/capabilities/android-emulator/action.yml
+++ b/.github/actions/capabilities/android-emulator/action.yml
@@ -97,6 +97,14 @@ runs:
         wait $CMD_PID 2>/dev/null
         EXIT=$?
 
+        # DEBUG: show sccache diagnostics from build hook.
+        # Remove once sccache is confirmed working.
+        if [ -f /tmp/sccache-hook.txt ]; then
+          echo ""
+          cat /tmp/sccache-hook.txt
+          echo ""
+        fi
+
         kill $WATCHDOG_PID 2>/dev/null || true
         wait $WATCHDOG_PID 2>/dev/null || true
 

--- a/.github/actions/capabilities/android-emulator/action.yml
+++ b/.github/actions/capabilities/android-emulator/action.yml
@@ -136,8 +136,6 @@ runs:
               echo "  (no force-stop process found)"
             fi
             echo "=== END PROBE ==="
-              done
-            done
           done
         ) &
         WATCHDOG_PID=$!

--- a/.github/actions/capabilities/android-emulator/action.yml
+++ b/.github/actions/capabilities/android-emulator/action.yml
@@ -97,14 +97,6 @@ runs:
         wait $CMD_PID 2>/dev/null
         EXIT=$?
 
-        # DEBUG: show sccache diagnostics from build hook.
-        # Remove once sccache is confirmed working.
-        if [ -f /tmp/sccache-hook.txt ]; then
-          echo ""
-          cat /tmp/sccache-hook.txt
-          echo ""
-        fi
-
         kill $WATCHDOG_PID 2>/dev/null || true
         wait $WATCHDOG_PID 2>/dev/null || true
 

--- a/.github/actions/capabilities/android-emulator/action.yml
+++ b/.github/actions/capabilities/android-emulator/action.yml
@@ -35,25 +35,25 @@ runs:
         $ANDROID_HOME/platform-tools/adb start-server
         $ANDROID_HOME/platform-tools/adb devices
 
-    # Watchdog for flutter test teardown hang on macOS Intel.
+    # Watchdog for the flutter test teardown hang on macOS Intel.
     #
     # Only affects: macOS Intel + SwiftShader (no hardware GPU).
     # Does NOT affect: Linux with KVM, Windows, macOS ARM, local dev.
     #
-    # Root cause: Flutter's teardown calls adb commands (force-stop,
-    # uninstall) that go through Binder IPC to the emulator's
-    # system_server. On SwiftShader emulators qemu uses ~200% CPU,
-    # starving system_server. The adb commands hang forever because
-    # Flutter's stopApp() and uninstallApp() have no timeout.
-    # https://github.com/flutter/flutter/issues/187785
+    # Root cause: Flutter's stopApp() calls `adb shell am force-stop`
+    # with no timeout (android_device.dart → _processUtils.stream()).
+    # On SwiftShader emulators, qemu uses ~200% CPU on 4 cores,
+    # starving the guest's ActivityManagerService. The `am force-stop`
+    # command never gets CPU time to execute. The dartvm waits for
+    # this adb child forever → flutter test never exits.
     #
-    # Fix: after all tests pass, any adb child of dartvm sitting at
-    # 0% CPU is a stuck teardown command. Kill it. Flutter handles the
-    # error gracefully and continues to exit. The "adb ... failed:
-    # exit code -9" error in logs after the kill is expected.
+    # Fix: detect the stuck adb child of dartvm (0% CPU) and kill it.
+    # stopApp() receives an error, continues teardown, flutter test
+    # prints the summary and exits cleanly.
     #
     # Harmless on runners where the hang doesn't occur — the watchdog
-    # never finds a stuck adb and exits with the user's command.
+    # simply never finds a stuck adb process and exits with the
+    # user's command.
     - name: Write emulator scripts
       if: runner.os != 'Windows'
       shell: bash
@@ -65,28 +65,29 @@ runs:
         bash -c "$1" &
         CMD_PID=$!
 
-        # Watchdog: kill any adb child of dartvm stuck at 0% CPU.
-        # Checks every 30s. No pattern matching on command names —
-        # any adb process parented to dartvm that's idle is stuck.
+        # Watchdog: kill the two adb commands Flutter runs in teardown.
+        #
+        # Flutter's kill() in integration_test_device.dart runs:
+        #   1. stopApp()     -> adb shell am force-stop <package>
+        #   2. uninstallApp() -> adb uninstall <package>
+        # Both have no timeout and hang on CPU-starved emulators.
+        # Both are direct children of the dartvm process.
+        #
+        # pgrep -f "a|b" doesn't work on macOS BSD — search separately.
         (
           while kill -0 $CMD_PID 2>/dev/null; do
             sleep 30
-            for dvmpid in $(pgrep -f dartvm 2>/dev/null); do
-              for cpid in $(pgrep -P "$dvmpid" 2>/dev/null); do
-                CNAME=$(ps -p "$cpid" -o comm= 2>/dev/null || true)
-                echo "$CNAME" | grep -q adb || continue
-                CCPU=$(ps -p "$cpid" -o %cpu= 2>/dev/null | tr -d ' ' || true)
-                # 0% CPU = stuck on Binder IPC to CPU-starved emulator.
-                if echo "$CCPU" | awk '{ exit ($1 > 0.1) }'; then
-                  CCMD=$(ps -p "$cpid" -o args= 2>/dev/null || true)
-                  echo ""
-                  echo "=== WATCHDOG: stuck adb detected (PID $cpid, cpu=${CCPU}%) ==="
-                  echo "    cmd: $CCMD"
-                  echo "    Killing to unblock flutter test teardown."
-                  kill -9 "$cpid" 2>/dev/null || true
-                  echo "=== WATCHDOG: killed. Flutter test should exit shortly. ==="
-                  echo ""
-                fi
+            for pattern in force-stop uninstall; do
+              for pid in $(pgrep -f "$pattern" 2>/dev/null); do
+                PCMD=$(ps -p "$pid" -o args= 2>/dev/null || true)
+                echo "$PCMD" | grep -q adb || continue
+                echo ""
+                echo "=== WATCHDOG: stuck adb $pattern (PID $pid) ==="
+                echo "    cmd: $PCMD"
+                echo "    Killing to unblock flutter test teardown."
+                kill -9 "$pid" 2>/dev/null || true
+                echo "=== WATCHDOG: killed. ==="
+                echo ""
               done
             done
           done

--- a/.github/actions/capabilities/android-emulator/action.yml
+++ b/.github/actions/capabilities/android-emulator/action.yml
@@ -114,17 +114,21 @@ runs:
               done
             done
 
-            # Search for stuck force-stop at any depth under any dartvm.
-            echo "-- force-stop search --"
-            for apid in $(pgrep -f "force-stop" 2>/dev/null); do
+            # Search for stuck teardown adb commands (force-stop OR uninstall).
+            # Both go through Binder IPC to system_server and hang when
+            # the emulator is CPU-starved.
+            echo "-- teardown adb search --"
+            for apid in $(pgrep -f "force-stop\|uninstall" 2>/dev/null); do
               ACMD=$(ps -p "$apid" -o args= 2>/dev/null || true)
+              # Only match adb commands, not random processes.
+              echo "$ACMD" | grep -q "adb" || continue
               ACPU=$(ps -p "$apid" -o %cpu= 2>/dev/null | tr -d ' ' || true)
               echo "  FOUND: PID=$apid CPU=${ACPU}% CMD=$ACMD"
               if [ "$KILLED" = "false" ]; then
                 echo ""
-                echo "=== WATCHDOG: stuck adb force-stop detected (PID $apid, cpu=${ACPU}%) ==="
+                echo "=== WATCHDOG: stuck adb teardown detected (PID $apid, cpu=${ACPU}%) ==="
                 echo "    cmd: $ACMD"
-                echo "    Flutter stopApp() has no timeout — killing to unblock teardown."
+                echo "    Flutter teardown has no timeout — killing to unblock."
                 echo "    Only happens on macOS Intel (SwiftShader CPU starvation)."
                 kill -9 "$apid" 2>/dev/null || true
                 KILLED=true
@@ -133,7 +137,7 @@ runs:
               fi
             done
             if [ "$KILLED" = "false" ]; then
-              echo "  (no force-stop process found)"
+              echo "  (no stuck teardown adb found)"
             fi
             echo "=== END PROBE ==="
           done

--- a/.github/actions/capabilities/rust/action.yml
+++ b/.github/actions/capabilities/rust/action.yml
@@ -38,24 +38,13 @@ runs:
         echo "SUBMODULE_PDF_OXIDE=${{ steps.sub.outputs.pdf_oxide }}" >> $GITHUB_ENV
         echo "SUBMODULE_OFFICE_OXIDE=${{ steps.sub.outputs.office_oxide }}" >> $GITHUB_ENV
 
-    # hooks_runner strips SCCACHE_* and ACTIONS_* env vars
-    # (dart-lang/native#3396). Write a wrapper that re-injects them
-    # so build.dart can use sccache with GHA cache backend.
-    # sccache (via opendal) reads: ACTIONS_RESULTS_URL (v2 cache URL),
-    # ACTIONS_RUNTIME_TOKEN, ACTIONS_CACHE_SERVICE_V2, SCCACHE_GHA_ENABLED.
-    # Source: apache/opendal core/src/services/ghac/core.rs
-    - name: Write sccache wrapper for build hooks
+    # Start the sccache server while SCCACHE_GHA_ENABLED and ACTIONS_*
+    # vars are in the environment. The server reads config at startup
+    # and persists as a daemon. Later, hooks_runner strips these vars
+    # (dart-lang/native#3396) before spawning build hooks, so
+    # build.dart's sccache client can't configure the GHA backend
+    # itself. By pre-starting the server here, every client connects
+    # to this already-configured server regardless of their env.
+    - name: Start sccache server
       shell: bash
-      run: |
-        WRAPPER="/tmp/sccache-wrapper.sh"
-        SCCACHE_BIN="$(which sccache)"
-        cat > "$WRAPPER" <<WRAPEOF
-        #!/usr/bin/env bash
-        export SCCACHE_GHA_ENABLED=true
-        export ACTIONS_CACHE_SERVICE_V2="${ACTIONS_CACHE_SERVICE_V2}"
-        export ACTIONS_RESULTS_URL="${ACTIONS_RESULTS_URL}"
-        export ACTIONS_RUNTIME_TOKEN="${ACTIONS_RUNTIME_TOKEN}"
-        exec "${SCCACHE_BIN}" "\$@"
-        WRAPEOF
-        chmod +x "$WRAPPER"
-        echo "sccache wrapper: $WRAPPER -> $SCCACHE_BIN"
+      run: sccache --start-server || true

--- a/.github/actions/capabilities/rust/action.yml
+++ b/.github/actions/capabilities/rust/action.yml
@@ -37,3 +37,28 @@ runs:
         echo "CARGO_INCREMENTAL=0" >> $GITHUB_ENV
         echo "SUBMODULE_PDF_OXIDE=${{ steps.sub.outputs.pdf_oxide }}" >> $GITHUB_ENV
         echo "SUBMODULE_OFFICE_OXIDE=${{ steps.sub.outputs.office_oxide }}" >> $GITHUB_ENV
+
+    # Flutter's hooks_runner strips SCCACHE_* and ACTIONS_* env vars
+    # before spawning build hooks (dart-lang/native allowlist doesn't
+    # include them). Our build.dart can find sccache on PATH but
+    # sccache falls back to local disk cache without these vars.
+    #
+    # Workaround: write a wrapper script that re-injects the vars.
+    # build.dart uses this as RUSTC_WRAPPER instead of raw sccache.
+    # The wrapper calls sccache with the GHA cache env restored.
+    #
+    # Upstream tracking: dart-lang/native#3396
+    - name: Write sccache wrapper for build hooks
+      shell: bash
+      run: |
+        WRAPPER="/tmp/sccache-wrapper.sh"
+        SCCACHE_BIN=$(which sccache)
+        cat > "$WRAPPER" << EOF
+        #!/usr/bin/env bash
+        export SCCACHE_GHA_ENABLED=true
+        export ACTIONS_CACHE_URL="$ACTIONS_CACHE_URL"
+        export ACTIONS_RUNTIME_TOKEN="$ACTIONS_RUNTIME_TOKEN"
+        exec "$SCCACHE_BIN" "\$@"
+        EOF
+        chmod +x "$WRAPPER"
+        echo "sccache wrapper: $WRAPPER -> $SCCACHE_BIN"

--- a/.github/actions/capabilities/rust/action.yml
+++ b/.github/actions/capabilities/rust/action.yml
@@ -38,27 +38,7 @@ runs:
         echo "SUBMODULE_PDF_OXIDE=${{ steps.sub.outputs.pdf_oxide }}" >> $GITHUB_ENV
         echo "SUBMODULE_OFFICE_OXIDE=${{ steps.sub.outputs.office_oxide }}" >> $GITHUB_ENV
 
-    # Flutter's hooks_runner strips SCCACHE_* and ACTIONS_* env vars
-    # before spawning build hooks (dart-lang/native allowlist doesn't
-    # include them). Our build.dart can find sccache on PATH but
-    # sccache falls back to local disk cache without these vars.
-    #
-    # Workaround: write a wrapper script that re-injects the vars.
-    # build.dart uses this as RUSTC_WRAPPER instead of raw sccache.
-    # The wrapper calls sccache with the GHA cache env restored.
-    #
-    # Upstream tracking: dart-lang/native#3396
-    - name: Write sccache wrapper for build hooks
-      shell: bash
-      run: |
-        WRAPPER="/tmp/sccache-wrapper.sh"
-        SCCACHE_BIN=$(which sccache)
-        cat > "$WRAPPER" << EOF
-        #!/usr/bin/env bash
-        export SCCACHE_GHA_ENABLED=true
-        export ACTIONS_CACHE_URL="$ACTIONS_CACHE_URL"
-        export ACTIONS_RUNTIME_TOKEN="$ACTIONS_RUNTIME_TOKEN"
-        exec "$SCCACHE_BIN" "\$@"
-        EOF
-        chmod +x "$WRAPPER"
-        echo "sccache wrapper: $WRAPPER -> $SCCACHE_BIN"
+    # hooks_runner strips SCCACHE_* env vars (dart-lang/native#3396).
+    # sccache still works for direct cargo calls (compile_rust.sh)
+    # but build hooks only get local-disk sccache until upstream
+    # adds SCCACHE_ to the env allowlist.

--- a/.github/actions/capabilities/rust/action.yml
+++ b/.github/actions/capabilities/rust/action.yml
@@ -38,7 +38,24 @@ runs:
         echo "SUBMODULE_PDF_OXIDE=${{ steps.sub.outputs.pdf_oxide }}" >> $GITHUB_ENV
         echo "SUBMODULE_OFFICE_OXIDE=${{ steps.sub.outputs.office_oxide }}" >> $GITHUB_ENV
 
-    # hooks_runner strips SCCACHE_* env vars (dart-lang/native#3396).
-    # sccache still works for direct cargo calls (compile_rust.sh)
-    # but build hooks only get local-disk sccache until upstream
-    # adds SCCACHE_ to the env allowlist.
+    # hooks_runner strips SCCACHE_* and ACTIONS_* env vars
+    # (dart-lang/native#3396). Write a wrapper that re-injects them
+    # so build.dart can use sccache with GHA cache backend.
+    # sccache (via opendal) reads: ACTIONS_RESULTS_URL (v2 cache URL),
+    # ACTIONS_RUNTIME_TOKEN, ACTIONS_CACHE_SERVICE_V2, SCCACHE_GHA_ENABLED.
+    # Source: apache/opendal core/src/services/ghac/core.rs
+    - name: Write sccache wrapper for build hooks
+      shell: bash
+      run: |
+        WRAPPER="/tmp/sccache-wrapper.sh"
+        SCCACHE_BIN="$(which sccache)"
+        cat > "$WRAPPER" <<WRAPEOF
+        #!/usr/bin/env bash
+        export SCCACHE_GHA_ENABLED=true
+        export ACTIONS_CACHE_SERVICE_V2="${ACTIONS_CACHE_SERVICE_V2}"
+        export ACTIONS_RESULTS_URL="${ACTIONS_RESULTS_URL}"
+        export ACTIONS_RUNTIME_TOKEN="${ACTIONS_RUNTIME_TOKEN}"
+        exec "${SCCACHE_BIN}" "\$@"
+        WRAPEOF
+        chmod +x "$WRAPPER"
+        echo "sccache wrapper: $WRAPPER -> $SCCACHE_BIN"

--- a/.github/workflows/full-test.yml
+++ b/.github/workflows/full-test.yml
@@ -72,39 +72,34 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # ── Package tests ──
-          - { name: "pkg: Linux (ubuntu-x64)",      runner: ubuntu-24.04,        make: test-pkg-native, timeout: 30 }
-          - { name: "pkg: macOS (macos-arm64)",     runner: macos-14,            make: test-pkg-native, timeout: 30 }
-          - { name: "pkg: Web (ubuntu-x64)",        runner: ubuntu-24.04,        make: test-ops-web,    timeout: 40, chrome: true, headless-display: true, wasm-cache: true, wasm-build: true }
-          - { name: "pkg: Web (macos-arm64) [P]",       runner: macos-14,            make: test-ops-web,    timeout: 40, chrome: true, wasm-cache: true, wasm-build: true, portability: true }
-          - { name: "pkg: Web (win-x64) [P]",           runner: windows-2025-vs2026, make: test-ops-web,    timeout: 40, chrome: true, wasm-cache: true, wasm-build: true, portability: true }
-          - { name: "pkg: Windows (win-x64)",       runner: windows-2025-vs2026, make: test-pkg-native, timeout: 40 }
-
-          # ── Integration tests ──
-          # Emulator needs Intel — macOS ARM runners are M1 VMs that can't virtualize the emulator:
-          # https://docs.github.com/en/actions/reference/runners/github-hosted-runners#limitations-for-arm64-macos-runners
-          - { name: "int: Android (ubuntu-x64)",    runner: ubuntu-24.04,        make: test-example-android, timeout: 40, java: true, hw-accel: true, gradle-cache: true, emulator: true }
-          - { name: "int: Android (macos-intel) [P]", runner: macos-15-intel,      make: test-example-android, timeout: 60, java: true, hw-accel: true, gradle-cache: true, emulator: true, portability: true }
-          - { name: "int: Android (win-x64) [P]",       runner: windows-2025-vs2026, make: test-example-android, timeout: 60, java: true, hw-accel: true, gradle-cache: true, emulator: true, portability: true }
-          - { name: "int: iOS (macos-arm64)",       runner: macos-14,            make: test-example-ios,     timeout: 60, xcode-cache: true, xcode-cache-target: ios, pods-cache: true, simulator: true }
-          - { name: "int: Linux (ubuntu-x64)",      runner: ubuntu-24.04,        make: test-example-linux,   timeout: 30, headless-display: true }
-          - { name: "int: macOS (macos-arm64)",     runner: macos-14,            make: test-example-macos,   timeout: 30, xcode-cache: true, xcode-cache-target: macos }
-          - { name: "int: Web (ubuntu-x64)",        runner: ubuntu-24.04,        make: test-example-web,     timeout: 40, chrome: true, headless-display: true, wasm-cache: true, wasm-build: true }
-          - { name: "int: Web (macos-arm64) [P]",       runner: macos-14,            make: test-example-web,     timeout: 40, chrome: true, wasm-cache: true, wasm-build: true, portability: true }
-          - { name: "int: Web (win-x64) [P]",           runner: windows-2025-vs2026, make: test-example-web,     timeout: 40, chrome: true, wasm-cache: true, wasm-build: true, portability: true }
-          - { name: "int: Windows (win-x64)",       runner: windows-2025-vs2026, make: test-example-windows, timeout: 40 }
-
-          # ── Verify (release builds) ──
-          - { name: "verify: Android (ubuntu-x64)", runner: ubuntu-24.04,        make: verify-android, timeout: 40, java: true, gradle-cache: true }
-          - { name: "verify: Android (macos-arm64) [P]",runner: macos-14,            make: verify-android, timeout: 40, java: true, gradle-cache: true, portability: true }
-          - { name: "verify: Android (win-x64) [P]",    runner: windows-2025-vs2026, make: verify-android, timeout: 60, java: true, gradle-cache: true, portability: true }
-          - { name: "verify: iOS (macos-arm64)",    runner: macos-14,            make: verify-ios,     timeout: 40, xcode-cache: true, xcode-cache-target: ios, pods-cache: true }
-          - { name: "verify: Linux (ubuntu-x64)",   runner: ubuntu-24.04,        make: verify-linux,   timeout: 30 }
-          - { name: "verify: macOS (macos-arm64)",  runner: macos-14,            make: verify-macos,   timeout: 40, xcode-cache: true, xcode-cache-target: macos }
-          - { name: "verify: Web (ubuntu-x64)",     runner: ubuntu-24.04,        make: verify-web,     timeout: 40, wasm-cache: true, wasm-build: true }
-          - { name: "verify: Web (macos-arm64) [P]",    runner: macos-14,            make: verify-web,     timeout: 40, wasm-cache: true, wasm-build: true, portability: true }
-          - { name: "verify: Web (win-x64) [P]",        runner: windows-2025-vs2026, make: verify-web,     timeout: 40, wasm-cache: true, wasm-build: true, portability: true }
-          - { name: "verify: Windows (win-x64)",    runner: windows-2025-vs2026, make: verify-windows, timeout: 40 }
+          # ── TEMPORARY: debug watchdog on Intel Android ──
+          - { name: "int: Android (macos-intel) [P]", runner: macos-15-intel, make: test-example-android, timeout: 60, java: true, hw-accel: true, gradle-cache: true, emulator: true, portability: true }
+          # ── ALL OTHER ENTRIES COMMENTED OUT FOR DEBUG ──
+          # - { name: "pkg: Linux (ubuntu-x64)",      runner: ubuntu-24.04,        make: test-pkg-native, timeout: 30 }
+          # - { name: "pkg: macOS (macos-arm64)",     runner: macos-14,            make: test-pkg-native, timeout: 30 }
+          # - { name: "pkg: Web (ubuntu-x64)",        runner: ubuntu-24.04,        make: test-ops-web,    timeout: 40, chrome: true, headless-display: true, wasm-cache: true, wasm-build: true }
+          # - { name: "pkg: Web (macos-arm64) [P]",       runner: macos-14,            make: test-ops-web,    timeout: 40, chrome: true, wasm-cache: true, wasm-build: true, portability: true }
+          # - { name: "pkg: Web (win-x64) [P]",           runner: windows-2025-vs2026, make: test-ops-web,    timeout: 40, chrome: true, wasm-cache: true, wasm-build: true, portability: true }
+          # - { name: "pkg: Windows (win-x64)",       runner: windows-2025-vs2026, make: test-pkg-native, timeout: 40 }
+          # - { name: "int: Android (ubuntu-x64)",    runner: ubuntu-24.04,        make: test-example-android, timeout: 40, java: true, hw-accel: true, gradle-cache: true, emulator: true }
+          # - { name: "int: Android (win-x64) [P]",       runner: windows-2025-vs2026, make: test-example-android, timeout: 60, java: true, hw-accel: true, gradle-cache: true, emulator: true, portability: true }
+          # - { name: "int: iOS (macos-arm64)",       runner: macos-14,            make: test-example-ios,     timeout: 60, xcode-cache: true, xcode-cache-target: ios, pods-cache: true, simulator: true }
+          # - { name: "int: Linux (ubuntu-x64)",      runner: ubuntu-24.04,        make: test-example-linux,   timeout: 30, headless-display: true }
+          # - { name: "int: macOS (macos-arm64)",     runner: macos-14,            make: test-example-macos,   timeout: 30, xcode-cache: true, xcode-cache-target: macos }
+          # - { name: "int: Web (ubuntu-x64)",        runner: ubuntu-24.04,        make: test-example-web,     timeout: 40, chrome: true, headless-display: true, wasm-cache: true, wasm-build: true }
+          # - { name: "int: Web (macos-arm64) [P]",       runner: macos-14,            make: test-example-web,     timeout: 40, chrome: true, wasm-cache: true, wasm-build: true, portability: true }
+          # - { name: "int: Web (win-x64) [P]",           runner: windows-2025-vs2026, make: test-example-web,     timeout: 40, chrome: true, wasm-cache: true, wasm-build: true, portability: true }
+          # - { name: "int: Windows (win-x64)",       runner: windows-2025-vs2026, make: test-example-windows, timeout: 40 }
+          # - { name: "verify: Android (ubuntu-x64)", runner: ubuntu-24.04,        make: verify-android, timeout: 40, java: true, gradle-cache: true }
+          # - { name: "verify: Android (macos-arm64) [P]",runner: macos-14,            make: verify-android, timeout: 40, java: true, gradle-cache: true, portability: true }
+          # - { name: "verify: Android (win-x64) [P]",    runner: windows-2025-vs2026, make: verify-android, timeout: 60, java: true, gradle-cache: true, portability: true }
+          # - { name: "verify: iOS (macos-arm64)",    runner: macos-14,            make: verify-ios,     timeout: 40, xcode-cache: true, xcode-cache-target: ios, pods-cache: true }
+          # - { name: "verify: Linux (ubuntu-x64)",   runner: ubuntu-24.04,        make: verify-linux,   timeout: 30 }
+          # - { name: "verify: macOS (macos-arm64)",  runner: macos-14,            make: verify-macos,   timeout: 40, xcode-cache: true, xcode-cache-target: macos }
+          # - { name: "verify: Web (ubuntu-x64)",     runner: ubuntu-24.04,        make: verify-web,     timeout: 40, wasm-cache: true, wasm-build: true }
+          # - { name: "verify: Web (macos-arm64) [P]",    runner: macos-14,            make: verify-web,     timeout: 40, wasm-cache: true, wasm-build: true, portability: true }
+          # - { name: "verify: Web (win-x64) [P]",        runner: windows-2025-vs2026, make: verify-web,     timeout: 40, wasm-cache: true, wasm-build: true, portability: true }
+          # - { name: "verify: Windows (win-x64)",    runner: windows-2025-vs2026, make: verify-windows, timeout: 40 }
 
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}

--- a/.github/workflows/full-test.yml
+++ b/.github/workflows/full-test.yml
@@ -72,34 +72,39 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # ── TEMPORARY: testing sccache server pre-start ──
-          - { name: "int: Android (macos-intel) [P]", runner: macos-15-intel, make: test-example-android, timeout: 60, java: true, hw-accel: true, gradle-cache: true, emulator: true, portability: true }
-          # ── ALL OTHER ENTRIES COMMENTED OUT FOR DEBUG ──
-          # - { name: "pkg: Linux (ubuntu-x64)",      runner: ubuntu-24.04,        make: test-pkg-native, timeout: 30 }
-          # - { name: "pkg: macOS (macos-arm64)",     runner: macos-14,            make: test-pkg-native, timeout: 30 }
-          # - { name: "pkg: Web (ubuntu-x64)",        runner: ubuntu-24.04,        make: test-ops-web,    timeout: 40, chrome: true, headless-display: true, wasm-cache: true, wasm-build: true }
-          # - { name: "pkg: Web (macos-arm64) [P]",       runner: macos-14,            make: test-ops-web,    timeout: 40, chrome: true, wasm-cache: true, wasm-build: true, portability: true }
-          # - { name: "pkg: Web (win-x64) [P]",           runner: windows-2025-vs2026, make: test-ops-web,    timeout: 40, chrome: true, wasm-cache: true, wasm-build: true, portability: true }
-          # - { name: "pkg: Windows (win-x64)",       runner: windows-2025-vs2026, make: test-pkg-native, timeout: 40 }
-          # - { name: "int: Android (ubuntu-x64)",    runner: ubuntu-24.04,        make: test-example-android, timeout: 40, java: true, hw-accel: true, gradle-cache: true, emulator: true }
-          # - { name: "int: Android (win-x64) [P]",       runner: windows-2025-vs2026, make: test-example-android, timeout: 60, java: true, hw-accel: true, gradle-cache: true, emulator: true, portability: true }
-          # - { name: "int: iOS (macos-arm64)",       runner: macos-14,            make: test-example-ios,     timeout: 60, xcode-cache: true, xcode-cache-target: ios, pods-cache: true, simulator: true }
-          # - { name: "int: Linux (ubuntu-x64)",      runner: ubuntu-24.04,        make: test-example-linux,   timeout: 30, headless-display: true }
-          # - { name: "int: macOS (macos-arm64)",     runner: macos-14,            make: test-example-macos,   timeout: 30, xcode-cache: true, xcode-cache-target: macos }
-          # - { name: "int: Web (ubuntu-x64)",        runner: ubuntu-24.04,        make: test-example-web,     timeout: 40, chrome: true, headless-display: true, wasm-cache: true, wasm-build: true }
-          # - { name: "int: Web (macos-arm64) [P]",       runner: macos-14,            make: test-example-web,     timeout: 40, chrome: true, wasm-cache: true, wasm-build: true, portability: true }
-          # - { name: "int: Web (win-x64) [P]",           runner: windows-2025-vs2026, make: test-example-web,     timeout: 40, chrome: true, wasm-cache: true, wasm-build: true, portability: true }
-          # - { name: "int: Windows (win-x64)",       runner: windows-2025-vs2026, make: test-example-windows, timeout: 40 }
-          # - { name: "verify: Android (ubuntu-x64)", runner: ubuntu-24.04,        make: verify-android, timeout: 40, java: true, gradle-cache: true }
-          # - { name: "verify: Android (macos-arm64) [P]",runner: macos-14,            make: verify-android, timeout: 40, java: true, gradle-cache: true, portability: true }
-          # - { name: "verify: Android (win-x64) [P]",    runner: windows-2025-vs2026, make: verify-android, timeout: 60, java: true, gradle-cache: true, portability: true }
-          # - { name: "verify: iOS (macos-arm64)",    runner: macos-14,            make: verify-ios,     timeout: 40, xcode-cache: true, xcode-cache-target: ios, pods-cache: true }
-          # - { name: "verify: Linux (ubuntu-x64)",   runner: ubuntu-24.04,        make: verify-linux,   timeout: 30 }
-          # - { name: "verify: macOS (macos-arm64)",  runner: macos-14,            make: verify-macos,   timeout: 40, xcode-cache: true, xcode-cache-target: macos }
-          # - { name: "verify: Web (ubuntu-x64)",     runner: ubuntu-24.04,        make: verify-web,     timeout: 40, wasm-cache: true, wasm-build: true }
-          # - { name: "verify: Web (macos-arm64) [P]",    runner: macos-14,            make: verify-web,     timeout: 40, wasm-cache: true, wasm-build: true, portability: true }
-          # - { name: "verify: Web (win-x64) [P]",        runner: windows-2025-vs2026, make: verify-web,     timeout: 40, wasm-cache: true, wasm-build: true, portability: true }
-          # - { name: "verify: Windows (win-x64)",    runner: windows-2025-vs2026, make: verify-windows, timeout: 40 }
+          # ── Package tests ──
+          - { name: "pkg: Linux (ubuntu-x64)",      runner: ubuntu-24.04,        make: test-pkg-native, timeout: 30 }
+          - { name: "pkg: macOS (macos-arm64)",     runner: macos-14,            make: test-pkg-native, timeout: 30 }
+          - { name: "pkg: Web (ubuntu-x64)",        runner: ubuntu-24.04,        make: test-ops-web,    timeout: 40, chrome: true, headless-display: true, wasm-cache: true, wasm-build: true }
+          - { name: "pkg: Web (macos-arm64) [P]",       runner: macos-14,            make: test-ops-web,    timeout: 40, chrome: true, wasm-cache: true, wasm-build: true, portability: true }
+          - { name: "pkg: Web (win-x64) [P]",           runner: windows-2025-vs2026, make: test-ops-web,    timeout: 40, chrome: true, wasm-cache: true, wasm-build: true, portability: true }
+          - { name: "pkg: Windows (win-x64)",       runner: windows-2025-vs2026, make: test-pkg-native, timeout: 40 }
+
+          # ── Integration tests ──
+          # Emulator needs Intel — macOS ARM runners are M1 VMs that can't virtualize the emulator:
+          # https://docs.github.com/en/actions/reference/runners/github-hosted-runners#limitations-for-arm64-macos-runners
+          - { name: "int: Android (ubuntu-x64)",    runner: ubuntu-24.04,        make: test-example-android, timeout: 40, java: true, hw-accel: true, gradle-cache: true, emulator: true }
+          - { name: "int: Android (macos-intel) [P]", runner: macos-15-intel,      make: test-example-android, timeout: 60, java: true, hw-accel: true, gradle-cache: true, emulator: true, portability: true }
+          - { name: "int: Android (win-x64) [P]",       runner: windows-2025-vs2026, make: test-example-android, timeout: 60, java: true, hw-accel: true, gradle-cache: true, emulator: true, portability: true }
+          - { name: "int: iOS (macos-arm64)",       runner: macos-14,            make: test-example-ios,     timeout: 60, xcode-cache: true, xcode-cache-target: ios, pods-cache: true, simulator: true }
+          - { name: "int: Linux (ubuntu-x64)",      runner: ubuntu-24.04,        make: test-example-linux,   timeout: 30, headless-display: true }
+          - { name: "int: macOS (macos-arm64)",     runner: macos-14,            make: test-example-macos,   timeout: 30, xcode-cache: true, xcode-cache-target: macos }
+          - { name: "int: Web (ubuntu-x64)",        runner: ubuntu-24.04,        make: test-example-web,     timeout: 40, chrome: true, headless-display: true, wasm-cache: true, wasm-build: true }
+          - { name: "int: Web (macos-arm64) [P]",       runner: macos-14,            make: test-example-web,     timeout: 40, chrome: true, wasm-cache: true, wasm-build: true, portability: true }
+          - { name: "int: Web (win-x64) [P]",           runner: windows-2025-vs2026, make: test-example-web,     timeout: 40, chrome: true, wasm-cache: true, wasm-build: true, portability: true }
+          - { name: "int: Windows (win-x64)",       runner: windows-2025-vs2026, make: test-example-windows, timeout: 40 }
+
+          # ── Verify (release builds) ──
+          - { name: "verify: Android (ubuntu-x64)", runner: ubuntu-24.04,        make: verify-android, timeout: 40, java: true, gradle-cache: true }
+          - { name: "verify: Android (macos-arm64) [P]",runner: macos-14,            make: verify-android, timeout: 40, java: true, gradle-cache: true, portability: true }
+          - { name: "verify: Android (win-x64) [P]",    runner: windows-2025-vs2026, make: verify-android, timeout: 60, java: true, gradle-cache: true, portability: true }
+          - { name: "verify: iOS (macos-arm64)",    runner: macos-14,            make: verify-ios,     timeout: 40, xcode-cache: true, xcode-cache-target: ios, pods-cache: true }
+          - { name: "verify: Linux (ubuntu-x64)",   runner: ubuntu-24.04,        make: verify-linux,   timeout: 30 }
+          - { name: "verify: macOS (macos-arm64)",  runner: macos-14,            make: verify-macos,   timeout: 40, xcode-cache: true, xcode-cache-target: macos }
+          - { name: "verify: Web (ubuntu-x64)",     runner: ubuntu-24.04,        make: verify-web,     timeout: 40, wasm-cache: true, wasm-build: true }
+          - { name: "verify: Web (macos-arm64) [P]",    runner: macos-14,            make: verify-web,     timeout: 40, wasm-cache: true, wasm-build: true, portability: true }
+          - { name: "verify: Web (win-x64) [P]",        runner: windows-2025-vs2026, make: verify-web,     timeout: 40, wasm-cache: true, wasm-build: true, portability: true }
+          - { name: "verify: Windows (win-x64)",    runner: windows-2025-vs2026, make: verify-windows, timeout: 40 }
 
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}

--- a/.github/workflows/full-test.yml
+++ b/.github/workflows/full-test.yml
@@ -72,7 +72,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # ── TEMPORARY: debug watchdog on Intel Android ──
+          # ── TEMPORARY: testing sccache server pre-start ──
           - { name: "int: Android (macos-intel) [P]", runner: macos-15-intel, make: test-example-android, timeout: 60, java: true, hw-accel: true, gradle-cache: true, emulator: true, portability: true }
           # ── ALL OTHER ENTRIES COMMENTED OUT FOR DEBUG ──
           # - { name: "pkg: Linux (ubuntu-x64)",      runner: ubuntu-24.04,        make: test-pkg-native, timeout: 30 }

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -371,18 +371,63 @@ Future<void> _compileNativeFromHook(
     _log.info('sccache enabled: $sccache');
   }
 
-  // DEBUG: write sccache diagnostics to /tmp for CI visibility.
-  // hooks_runner swallows hook stdout/stderr on success, so this
-  // is the only way to verify sccache is working from CI logs.
-  // The emulator-run.sh script cats this file after the build.
-  // Remove this block once sccache is confirmed working.
+  // DEBUG: exhaustive sccache diagnostics. Remove after confirmed working.
   final debugFile = File('/tmp/sccache-hook.txt');
   final debugBuf = StringBuffer()
     ..writeln('=== sccache hook debug ===')
     ..writeln('sccache on PATH: ${sccache ?? "NOT FOUND"}')
-    ..writeln('RUSTC_WRAPPER set to: ${env['RUSTC_WRAPPER'] ?? "NOT SET"}')
-    ..writeln('PATH (first 5): ${Platform.environment['PATH']?.split(':').take(5).join(':')}')
-    ..writeln('Platform.environment keys: ${Platform.environment.keys.where((k) => k.contains('SCCACHE') || k.contains('RUSTC') || k.contains('ACTIONS') || k.contains('CARGO')).toList()}');
+    ..writeln('RUSTC_WRAPPER in env map: ${env['RUSTC_WRAPPER'] ?? "NOT SET"}')
+    ..writeln('')
+    ..writeln('--- Platform.environment (ALL keys) ---')
+    ..writeln(Platform.environment.keys.toList()..sort())
+    ..writeln('')
+    ..writeln('--- RUSTC_WRAPPER in Platform.environment ---')
+    ..writeln('exists: ${Platform.environment.containsKey('RUSTC_WRAPPER')}')
+    ..writeln('value: "${Platform.environment['RUSTC_WRAPPER'] ?? '<null>'}"')
+    ..writeln('')
+    ..writeln('--- SCCACHE/ACTIONS/CARGO vars in Platform.environment ---');
+  for (final key in Platform.environment.keys) {
+    if (key.contains('SCCACHE') || key.contains('RUSTC') ||
+        key.contains('ACTIONS') || key.contains('CARGO')) {
+      debugBuf.writeln('  $key = ${Platform.environment[key]}');
+    }
+  }
+  debugBuf
+    ..writeln('')
+    ..writeln('--- Final environment passed to cargo (relevant keys) ---');
+  final cargoEnv = {...Platform.environment, ...env};
+  for (final key in cargoEnv.keys) {
+    if (key.contains('SCCACHE') || key.contains('RUSTC') ||
+        key.contains('ACTIONS') || key.contains('CARGO') ||
+        key == 'PATH') {
+      final val = cargoEnv[key]!;
+      debugBuf.writeln('  $key = ${val.length > 200 ? '${val.substring(0, 200)}...' : val}');
+    }
+  }
+  debugBuf
+    ..writeln('')
+    ..writeln('--- sccache server check ---');
+  try {
+    final serverCheck = await Process.run(
+        sccache ?? 'sccache', ['--show-stats'],
+        environment: cargoEnv);
+    debugBuf.writeln('exit: ${serverCheck.exitCode}');
+    debugBuf.writeln('stdout: ${serverCheck.stdout}');
+    debugBuf.writeln('stderr: ${serverCheck.stderr}');
+  } catch (e) {
+    debugBuf.writeln('sccache --show-stats failed: $e');
+  }
+  debugBuf
+    ..writeln('')
+    ..writeln('--- test: can cargo see RUSTC_WRAPPER? ---');
+  try {
+    final cargoTest = await Process.run('cargo', ['--version'],
+        environment: cargoEnv);
+    debugBuf.writeln('cargo version: ${cargoTest.stdout.toString().trim()}');
+    debugBuf.writeln('RUSTC_WRAPPER in cargoEnv: ${cargoEnv['RUSTC_WRAPPER']}');
+  } catch (e) {
+    debugBuf.writeln('cargo --version failed: $e');
+  }
   debugFile.writeAsStringSync(debugBuf.toString());
 
   final result = await Process.run(
@@ -399,17 +444,25 @@ Future<void> _compileNativeFromHook(
     environment: {...Platform.environment, ...env},
   );
 
-  // DEBUG: append sccache stats after cargo build.
-  // Remove this block once sccache is confirmed working.
+  // DEBUG: append post-build diagnostics.
+  final postBuf = StringBuffer()
+    ..writeln('')
+    ..writeln('=== POST-BUILD ===')
+    ..writeln('cargo exit code: ${result.exitCode}')
+    ..writeln('cargo stderr (last 500 chars): ${result.stderr.toString().length > 500 ? result.stderr.toString().substring(result.stderr.toString().length - 500) : result.stderr}')
+    ..writeln('');
   if (sccache != null) {
     try {
       final stats = await Process.run(sccache, ['--show-stats'],
-          environment: {...Platform.environment, ...env});
-      debugFile.writeAsStringSync(
-          '\n=== sccache stats after build ===\n${stats.stdout}\n',
-          mode: FileMode.append);
-    } catch (_) {}
+          environment: cargoEnv);
+      postBuf.writeln('=== sccache stats after build ===');
+      postBuf.writeln(stats.stdout);
+      postBuf.writeln(stats.stderr);
+    } catch (e) {
+      postBuf.writeln('sccache --show-stats failed: $e');
+    }
   }
+  debugFile.writeAsStringSync(postBuf.toString(), mode: FileMode.append);
 
   if (result.exitCode != 0) {
     throw StateError(

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -359,15 +359,21 @@ Future<void> _compileNativeFromHook(
         .join(':');
   }
 
-  // hooks_runner strips SCCACHE_* env vars (dart-lang/native#3396).
-  // sccache on PATH still works for local disk cache. GHA cache backend
-  // requires SCCACHE_GHA_ENABLED + ACTIONS_CACHE_URL which are stripped.
-  // Until upstream adds SCCACHE_ to the allowlist, native builds get
-  // local-disk-only sccache (helps on repeat builds, not across CI runs).
-  final sccache = _findOnPath('sccache');
-  if (sccache != null) {
-    env['RUSTC_WRAPPER'] = sccache;
-    _log.info('sccache enabled: $sccache');
+  // hooks_runner strips SCCACHE_* and ACTIONS_* env vars (dart-lang/native#3396).
+  // The rust CI capability writes /tmp/sccache-wrapper.sh that re-injects
+  // the stripped vars before calling sccache. Prefer it over raw sccache.
+  // On local dev or when the wrapper doesn't exist, fall back to raw sccache.
+  final wrapperPath = '/tmp/sccache-wrapper.sh';
+  final wrapper = File(wrapperPath);
+  if (wrapper.existsSync()) {
+    env['RUSTC_WRAPPER'] = wrapperPath;
+    _log.info('sccache enabled via wrapper (GHA cache)');
+  } else {
+    final sccache = _findOnPath('sccache');
+    if (sccache != null) {
+      env['RUSTC_WRAPPER'] = sccache;
+      _log.info('sccache enabled: $sccache (local cache only)');
+    }
   }
 
   final result = await Process.run(

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -371,65 +371,6 @@ Future<void> _compileNativeFromHook(
     _log.info('sccache enabled: $sccache');
   }
 
-  // DEBUG: exhaustive sccache diagnostics. Remove after confirmed working.
-  final debugFile = File('/tmp/sccache-hook.txt');
-  final debugBuf = StringBuffer()
-    ..writeln('=== sccache hook debug ===')
-    ..writeln('sccache on PATH: ${sccache ?? "NOT FOUND"}')
-    ..writeln('RUSTC_WRAPPER in env map: ${env['RUSTC_WRAPPER'] ?? "NOT SET"}')
-    ..writeln('')
-    ..writeln('--- Platform.environment (ALL keys) ---')
-    ..writeln(Platform.environment.keys.toList()..sort())
-    ..writeln('')
-    ..writeln('--- RUSTC_WRAPPER in Platform.environment ---')
-    ..writeln('exists: ${Platform.environment.containsKey('RUSTC_WRAPPER')}')
-    ..writeln('value: "${Platform.environment['RUSTC_WRAPPER'] ?? '<null>'}"')
-    ..writeln('')
-    ..writeln('--- SCCACHE/ACTIONS/CARGO vars in Platform.environment ---');
-  for (final key in Platform.environment.keys) {
-    if (key.contains('SCCACHE') || key.contains('RUSTC') ||
-        key.contains('ACTIONS') || key.contains('CARGO')) {
-      debugBuf.writeln('  $key = ${Platform.environment[key]}');
-    }
-  }
-  debugBuf
-    ..writeln('')
-    ..writeln('--- Final environment passed to cargo (relevant keys) ---');
-  final cargoEnv = {...Platform.environment, ...env};
-  for (final key in cargoEnv.keys) {
-    if (key.contains('SCCACHE') || key.contains('RUSTC') ||
-        key.contains('ACTIONS') || key.contains('CARGO') ||
-        key == 'PATH') {
-      final val = cargoEnv[key]!;
-      debugBuf.writeln('  $key = ${val.length > 200 ? '${val.substring(0, 200)}...' : val}');
-    }
-  }
-  debugBuf
-    ..writeln('')
-    ..writeln('--- sccache server check ---');
-  try {
-    final serverCheck = await Process.run(
-        sccache ?? 'sccache', ['--show-stats'],
-        environment: cargoEnv);
-    debugBuf.writeln('exit: ${serverCheck.exitCode}');
-    debugBuf.writeln('stdout: ${serverCheck.stdout}');
-    debugBuf.writeln('stderr: ${serverCheck.stderr}');
-  } catch (e) {
-    debugBuf.writeln('sccache --show-stats failed: $e');
-  }
-  debugBuf
-    ..writeln('')
-    ..writeln('--- test: can cargo see RUSTC_WRAPPER? ---');
-  try {
-    final cargoTest = await Process.run('cargo', ['--version'],
-        environment: cargoEnv);
-    debugBuf.writeln('cargo version: ${cargoTest.stdout.toString().trim()}');
-    debugBuf.writeln('RUSTC_WRAPPER in cargoEnv: ${cargoEnv['RUSTC_WRAPPER']}');
-  } catch (e) {
-    debugBuf.writeln('cargo --version failed: $e');
-  }
-  debugFile.writeAsStringSync(debugBuf.toString());
-
   final result = await Process.run(
     'cargo',
     [
@@ -443,26 +384,6 @@ Future<void> _compileNativeFromHook(
     ],
     environment: {...Platform.environment, ...env},
   );
-
-  // DEBUG: append post-build diagnostics.
-  final postBuf = StringBuffer()
-    ..writeln('')
-    ..writeln('=== POST-BUILD ===')
-    ..writeln('cargo exit code: ${result.exitCode}')
-    ..writeln('cargo stderr (last 500 chars): ${result.stderr.toString().length > 500 ? result.stderr.toString().substring(result.stderr.toString().length - 500) : result.stderr}')
-    ..writeln('');
-  if (sccache != null) {
-    try {
-      final stats = await Process.run(sccache, ['--show-stats'],
-          environment: cargoEnv);
-      postBuf.writeln('=== sccache stats after build ===');
-      postBuf.writeln(stats.stdout);
-      postBuf.writeln(stats.stderr);
-    } catch (e) {
-      postBuf.writeln('sccache --show-stats failed: $e');
-    }
-  }
-  debugFile.writeAsStringSync(postBuf.toString(), mode: FileMode.append);
 
   if (result.exitCode != 0) {
     throw StateError(

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -359,15 +359,24 @@ Future<void> _compileNativeFromHook(
         .join(':');
   }
 
-  // Dart build hooks run in a semi-hermetic environment that strips
-  // most env vars (dart-lang/native hooks_runner). CCACHE_ prefix is
-  // passed through but RUSTC_WRAPPER and SCCACHE_* are not. Detect
-  // sccache on PATH (which IS passed through) and set RUSTC_WRAPPER
-  // so cargo uses it for compilation caching on CI.
-  final sccache = _findOnPath('sccache');
-  if (sccache != null) {
-    env['RUSTC_WRAPPER'] = sccache;
-    _log.info('sccache enabled: $sccache');
+  // hooks_runner strips SCCACHE_* and ACTIONS_* env vars (dart-lang/native
+  // allowlist). sccache is on PATH but without SCCACHE_GHA_ENABLED and
+  // ACTIONS_CACHE_URL it falls back to local disk (useless on fresh CI).
+  //
+  // The rust CI capability writes /tmp/sccache-wrapper.sh that re-injects
+  // the stripped vars before calling sccache. Prefer it over raw sccache.
+  // On local dev or when the wrapper doesn't exist, fall back to raw sccache.
+  final wrapperPath = '/tmp/sccache-wrapper.sh';
+  final wrapper = File(wrapperPath);
+  if (wrapper.existsSync()) {
+    env['RUSTC_WRAPPER'] = wrapperPath;
+    _log.info('sccache enabled via wrapper (GHA cache)');
+  } else {
+    final sccache = _findOnPath('sccache');
+    if (sccache != null) {
+      env['RUSTC_WRAPPER'] = sccache;
+      _log.info('sccache enabled: $sccache (local cache only)');
+    }
   }
 
   final result = await Process.run(

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -359,24 +359,15 @@ Future<void> _compileNativeFromHook(
         .join(':');
   }
 
-  // hooks_runner strips SCCACHE_* and ACTIONS_* env vars (dart-lang/native
-  // allowlist). sccache is on PATH but without SCCACHE_GHA_ENABLED and
-  // ACTIONS_CACHE_URL it falls back to local disk (useless on fresh CI).
-  //
-  // The rust CI capability writes /tmp/sccache-wrapper.sh that re-injects
-  // the stripped vars before calling sccache. Prefer it over raw sccache.
-  // On local dev or when the wrapper doesn't exist, fall back to raw sccache.
-  final wrapperPath = '/tmp/sccache-wrapper.sh';
-  final wrapper = File(wrapperPath);
-  if (wrapper.existsSync()) {
-    env['RUSTC_WRAPPER'] = wrapperPath;
-    _log.info('sccache enabled via wrapper (GHA cache)');
-  } else {
-    final sccache = _findOnPath('sccache');
-    if (sccache != null) {
-      env['RUSTC_WRAPPER'] = sccache;
-      _log.info('sccache enabled: $sccache (local cache only)');
-    }
+  // hooks_runner strips SCCACHE_* env vars (dart-lang/native#3396).
+  // sccache on PATH still works for local disk cache. GHA cache backend
+  // requires SCCACHE_GHA_ENABLED + ACTIONS_CACHE_URL which are stripped.
+  // Until upstream adds SCCACHE_ to the allowlist, native builds get
+  // local-disk-only sccache (helps on repeat builds, not across CI runs).
+  final sccache = _findOnPath('sccache');
+  if (sccache != null) {
+    env['RUSTC_WRAPPER'] = sccache;
+    _log.info('sccache enabled: $sccache');
   }
 
   final result = await Process.run(

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -359,21 +359,16 @@ Future<void> _compileNativeFromHook(
         .join(':');
   }
 
-  // hooks_runner strips SCCACHE_* and ACTIONS_* env vars (dart-lang/native#3396).
-  // The rust CI capability writes /tmp/sccache-wrapper.sh that re-injects
-  // the stripped vars before calling sccache. Prefer it over raw sccache.
-  // On local dev or when the wrapper doesn't exist, fall back to raw sccache.
-  final wrapperPath = '/tmp/sccache-wrapper.sh';
-  final wrapper = File(wrapperPath);
-  if (wrapper.existsSync()) {
-    env['RUSTC_WRAPPER'] = wrapperPath;
-    _log.info('sccache enabled via wrapper (GHA cache)');
-  } else {
-    final sccache = _findOnPath('sccache');
-    if (sccache != null) {
-      env['RUSTC_WRAPPER'] = sccache;
-      _log.info('sccache enabled: $sccache (local cache only)');
-    }
+  // hooks_runner strips SCCACHE_* env vars (dart-lang/native#3396) but
+  // the sccache SERVER is pre-started by the rust CI capability while
+  // the GHA env vars are still available. The server reads its config
+  // at startup, so clients connecting later (from build hooks) get GHA
+  // cache backend even though their env is filtered. We just need to
+  // set RUSTC_WRAPPER so cargo calls sccache as a client.
+  final sccache = _findOnPath('sccache');
+  if (sccache != null) {
+    env['RUSTC_WRAPPER'] = sccache;
+    _log.info('sccache enabled: $sccache');
   }
 
   final result = await Process.run(

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -371,6 +371,20 @@ Future<void> _compileNativeFromHook(
     _log.info('sccache enabled: $sccache');
   }
 
+  // DEBUG: write sccache diagnostics to /tmp for CI visibility.
+  // hooks_runner swallows hook stdout/stderr on success, so this
+  // is the only way to verify sccache is working from CI logs.
+  // The emulator-run.sh script cats this file after the build.
+  // Remove this block once sccache is confirmed working.
+  final debugFile = File('/tmp/sccache-hook.txt');
+  final debugBuf = StringBuffer()
+    ..writeln('=== sccache hook debug ===')
+    ..writeln('sccache on PATH: ${sccache ?? "NOT FOUND"}')
+    ..writeln('RUSTC_WRAPPER set to: ${env['RUSTC_WRAPPER'] ?? "NOT SET"}')
+    ..writeln('PATH (first 5): ${Platform.environment['PATH']?.split(':').take(5).join(':')}')
+    ..writeln('Platform.environment keys: ${Platform.environment.keys.where((k) => k.contains('SCCACHE') || k.contains('RUSTC') || k.contains('ACTIONS') || k.contains('CARGO')).toList()}');
+  debugFile.writeAsStringSync(debugBuf.toString());
+
   final result = await Process.run(
     'cargo',
     [
@@ -384,6 +398,18 @@ Future<void> _compileNativeFromHook(
     ],
     environment: {...Platform.environment, ...env},
   );
+
+  // DEBUG: append sccache stats after cargo build.
+  // Remove this block once sccache is confirmed working.
+  if (sccache != null) {
+    try {
+      final stats = await Process.run(sccache, ['--show-stats'],
+          environment: {...Platform.environment, ...env});
+      debugFile.writeAsStringSync(
+          '\n=== sccache stats after build ===\n${stats.stdout}\n',
+          mode: FileMode.append);
+    } catch (_) {}
+  }
 
   if (result.exitCode != 0) {
     throw StateError(


### PR DESCRIPTION
Diagnose why watchdog didn't find the stuck adb force-stop. Now searches all descendants + uses pgrep -f force-stop directly. Probes every 30s with full process trees.