### PR TITLE
fix: addImageStamp preserves PNG transparency (no black box)

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ final hits = await doc.search(query: 'revenue', pages: PdfPages.all());
 
 await for (final page in doc.render(
     pages: PdfPages.all(), size: PdfRenderSize.thumbnail(200))) {
-  // page.width, page.height, page.data (PNG-encoded bytes)
+  // page.width, page.height, page.data — PNG-encoded bytes; decode to read pixels
 }
 
 await doc.dispose();

--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ final hits = await doc.search(query: 'revenue', pages: PdfPages.all());
 
 await for (final page in doc.render(
     pages: PdfPages.all(), size: PdfRenderSize.thumbnail(200))) {
-  // page.width, page.height, page.data (RGBA bytes)
+  // page.width, page.height, page.data (PNG-encoded bytes)
 }
 
 await doc.dispose();

--- a/lib/src/types/pdf_image.dart
+++ b/lib/src/types/pdf_image.dart
@@ -54,7 +54,7 @@ class RenderedPage {
   /// Bitmap height in pixels.
   final int height;
 
-  /// Raw RGBA pixel bytes.
+  /// PNG-encoded image of the page; decode it to read pixels.
   final Uint8List data;
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -65,6 +65,11 @@ dev_dependencies:
   # Test runner
   test: ^1.31.1
 
+  # PNG decode for render-output pixel assertions (the image-stamp
+  # transparency test reads pixels out of doc.render()'s PNG frames).
+  # Pure Dart — runs on VM and browser. Dev-only: ships nowhere.
+  image: ^4.0.0
+
   # Lint rules
   lints: ^6.1.0
 

--- a/test/ops/core/pdf_editor_battery.dart
+++ b/test/ops/core/pdf_editor_battery.dart
@@ -9,6 +9,7 @@
 
 import 'dart:typed_data';
 
+import 'package:image/image.dart' as img;
 import 'package:pdf_manipulator/pdf_manipulator.dart';
 import 'package:test/test.dart';
 
@@ -598,6 +599,79 @@ void registerEditorTests(Pdf Function() createPdf) {
       await editor.dispose();
       final output = sink.takeBytes();
       expect(output.length, greaterThan(minimalPdf.length));
+    }, timeout: t(1));
+
+    test('addImageStamp preserves PNG transparency', () async {
+      // A transparent-background PNG keeps its transparency only if the
+      // engine emits a grayscale /SMask from the alpha channel. Proof is
+      // SEMANTIC — render the stamped page and read the pixels.
+      //
+      // transparentPng is opaque red on the left half, fully transparent
+      // black on the right half. Stamped over a blank WHITE A4 page,
+      // oversized so no page edge stays white:
+      //   • the opaque half must render RED   — proves the stamp drew
+      //   • the transparent half must render WHITE — the page showing
+      //     through. A dropped alpha renders it BLACK, so white ≈ 0.
+      final pdf = createPdf();
+      final editor = await pdf.edit(src(fBlankA4));
+      await editor.addImageStamp(
+        0,
+        src(transparentPng),
+        rect: const PdfRect(x: 0, y: 0, width: 600, height: 850),
+      );
+      final stamped = TestSink();
+      await editor.save(stamped);
+      await editor.dispose();
+
+      final doc = await pdf.open(src(stamped.takeBytes()));
+      final pages = <RenderedPage>[];
+      await for (final page in doc.render(
+        pages: const PdfPages.single(0),
+        size: const PdfRenderSize.thumbnail(160),
+      )) {
+        pages.add(page);
+      }
+      await doc.dispose();
+
+      expect(pages, hasLength(1));
+      // doc.render() yields PNG-encoded frames — decode to pixels.
+      final decoded = img.decodePng(pages.single.data);
+      expect(decoded, isNotNull, reason: 'rendered page must be a valid PNG');
+      final bitmap = decoded!;
+
+      // Count red (opaque half), white (page revealed through the
+      // transparent half), and black (a dropped-alpha black box). With
+      // the /SMask: red ≈ 0.50, white ≈ 0.49, black ≈ 0. A dropped alpha
+      // gives red ≈ 0.07 (also corrupted), white ≈ 0, black ≈ 0.47.
+      var red = 0, white = 0, black = 0;
+      final total = bitmap.width * bitmap.height;
+      for (final p in bitmap) {
+        final r = p.r, g = p.g, b = p.b;
+        if (r > 200 && g < 70 && b < 70) red++;
+        if (r > 220 && g > 220 && b > 220) white++;
+        if (r < 40 && g < 40 && b < 40) black++;
+      }
+
+      expect(total, greaterThan(0));
+      // The opaque half drew — guards against a stamp that does nothing.
+      expect(
+        red / total,
+        greaterThan(0.30),
+        reason: 'opaque red half of the stamp must render',
+      );
+      // The transparent half reveals the white page; a dropped alpha
+      // paints it solid black, so white ≈ 0.
+      expect(
+        white / total,
+        greaterThan(0.30),
+        reason: 'transparent half must reveal the white page, not render black',
+      );
+      // And the transparent region must not be the black box itself.
+      expect(
+        black / total,
+        lessThan(0.05),
+        reason: 'transparent PNG must not render as a black box',
+      );
     }, timeout: t(1));
 
     // ── Content ──

--- a/tool/generate_fixtures.dart
+++ b/tool/generate_fixtures.dart
@@ -50,6 +50,19 @@ Future<void> main() async {
   ).writeAsStringSync(_emitBytes('photoPng', photoPng));
   exports.add("export 'f_photo_png.dart';");
 
+  // The transparent raster the image-stamp transparency test feeds in.
+  final transparentPng = buildTransparentPng();
+  File('$_generatedDir/f_transparent_png.dart').writeAsStringSync(
+    _emitBytes(
+      'transparentPng',
+      transparentPng,
+      'RGBA PNG: opaque-red left half, transparent-black right half. The '
+          'transparent half must survive image-stamp embedding as an /SMask '
+          'instead of painting black.',
+    ),
+  );
+  exports.add("export 'f_transparent_png.dart';");
+
   for (final spec in catalog) {
     final sw = Stopwatch()..start();
     final bytes = await spec.build(photoPng);
@@ -91,8 +104,15 @@ String _stampInputs() {
   return sha256.convert(bytes).toString();
 }
 
-/// Emit raw bytes as a base64 Dart constant named [ident].
-String _emitBytes(String ident, List<int> bytes) {
+/// Emit raw bytes as a base64 Dart constant named [ident]. [doc] is the
+/// `///` doc body for the constant (default describes the photo raster).
+String _emitBytes(
+  String ident,
+  List<int> bytes, [
+  String doc =
+      'Photo-like 128x128 PNG (seeded noise) — JPEG-q50 beats its Flate\n'
+      '/// stream, so optimizeImages finds work. Decoded once at first use.',
+]) {
   final b64 = base64Encode(bytes);
   final chunks = <String>[
     for (var i = 0; i < b64.length; i += 76)
@@ -105,8 +125,7 @@ String _emitBytes(String ident, List<int> bytes) {
 import 'dart:convert';
 import 'dart:typed_data';
 
-/// Photo-like 128x128 PNG (seeded noise) — JPEG-q50 beats its Flate
-/// stream, so optimizeImages finds work. Decoded once at first use.
+/// $doc
 final Uint8List $ident = base64Decode(_b64);
 
 const _b64 =
@@ -202,8 +221,46 @@ Uint8List buildPhotoPng({int seed = 42, int size = 128}) {
   return _assemblePng(size, size, Uint8List.fromList(idat));
 }
 
+/// Build a [size]×[size] RGBA (colour type 6) PNG: opaque red on the
+/// left half, fully transparent black on the right half. The transparent
+/// half must survive image-stamp embedding as an /SMask, not paint black.
+Uint8List buildTransparentPng({int size = 32}) {
+  // Raw image data: one filter byte (0 = none) per scanline, then RGBA
+  // quads. Left half opaque red, right half transparent black.
+  final raw = BytesBuilder(copy: false);
+  final half = size ~/ 2;
+  for (var y = 0; y < size; y++) {
+    raw.addByte(0); // filter: none
+    for (var x = 0; x < size; x++) {
+      if (x < half) {
+        raw
+          ..addByte(255) // R
+          ..addByte(0) // G
+          ..addByte(0) // B
+          ..addByte(255); // A — opaque
+      } else {
+        raw
+          ..addByte(0) // R
+          ..addByte(0) // G
+          ..addByte(0) // B
+          ..addByte(0); // A — transparent
+      }
+    }
+  }
+
+  final idat = ZLibCodec().encode(raw.takeBytes());
+  return _assemblePng(size, size, Uint8List.fromList(idat), colorType: 6);
+}
+
 /// Wrap IDAT bytes in the PNG container: signature, IHDR, IDAT, IEND.
-Uint8List _assemblePng(int width, int height, Uint8List idat) {
+/// [colorType] is the PNG colour type byte: 2 = truecolour RGB (default),
+/// 6 = truecolour with alpha (RGBA).
+Uint8List _assemblePng(
+  int width,
+  int height,
+  Uint8List idat, {
+  int colorType = 2,
+}) {
   final out = BytesBuilder(copy: false);
   out.add(const [137, 80, 78, 71, 13, 10, 26, 10]); // PNG signature
 
@@ -211,7 +268,7 @@ Uint8List _assemblePng(int width, int height, Uint8List idat) {
     ..add(_u32(width))
     ..add(_u32(height))
     ..addByte(8) // bit depth
-    ..addByte(2) // colour type: truecolour RGB
+    ..addByte(colorType) // colour type: 2 = RGB, 6 = RGBA
     ..addByte(0) // compression
     ..addByte(0) // filter
     ..addByte(0); // interlace


### PR DESCRIPTION
## What

`addImageStamp` rendered a transparent-background PNG as a solid black box.

## Root cause

`edit_add_image_stamp` (our `vendor/pdf_oxide` host code) assembled the image XObject dict by hand, dropping two things `ImageData::from_bytes` had already prepared:

- the alpha **`/SMask`** — so transparent pixels painted solid black over the page (the reported symptom);
- the PNG **`/DecodeParms` Predictor=15** that `from_png()`'s per-row filter bytes require — so the opaque pixels were scrambled too (latent second bug).

## Fix

Use the engine's own `build_xobject_dict()` (carries the predictor params) and emit the grayscale `/SMask` via `build_soft_mask_dict()`. No new engine code — both helpers already existed; the stamp path just wasn't calling them.

Engine submodule bumped to `whuppi/pdf_oxide@76469cb8` (branch `pdf_manipulator/0.3.64-patches`).

## Test

`editor addImageStamp preserves PNG transparency` (editor battery): stamps a half-opaque-red / half-transparent PNG over a blank white page, renders, decodes the PNG frame, and asserts the transparent half reveals the white page rather than rendering black. Confirmed **failing on the buggy engine** (transparent half ≈ 47% black, 0% white) and **passing on the fix** (≈ 49% white, 0% black). Runs on native + all three web modes.

`make check` is green: analyze (Dart + Rust, both crates), unit, ops (native + OPFS/JSPI/Atomics), and example integration on macOS + the three web modes.

## Also

Corrected the `RenderedPage.data` doc-comment and the README render example — `doc.render()` returns PNG-encoded bytes, not raw RGBA.

Fixes #103
