### PR TITLE
ci: vendored-engine cargo tests + consistent job names

### DIFF
--- a/.github/actions/capabilities/free-disk-space/action.yml
+++ b/.github/actions/capabilities/free-disk-space/action.yml
@@ -1,0 +1,37 @@
+name: Free Disk Space
+description: >
+  Reclaim disk so the build-heavy vendored-engine cargo test can link.
+  Linux: deletes the preinstalled SDKs the build never uses (~25 GB) — a
+  stock runner's ~14 GB free overruns mid-link (rust-lld SIGBUS / "no
+  space left on device"). macOS/Windows: no-op (ample headroom).
+
+runs:
+  using: composite
+  steps:
+    - name: df -h before
+      if: runner.os == 'Linux'
+      shell: bash
+      run: df -h /
+
+    - name: Reclaim disk
+      if: runner.os == 'Linux'
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main @ 2024-04
+      with:
+        # Keep the hosted tool cache: the rust capability installs sccache
+        # there (the build's RUSTC_WRAPPER) before this step runs, and
+        # deleting it breaks every cargo invocation that follows.
+        tool-cache: false
+        android: true
+        dotnet: true
+        haskell: true
+        large-packages: true
+        docker-images: true
+        # Never set true: rust-lld leans on the 4 GB swapfile under
+        # parallel link, so removing it trades a disk-full failure for a
+        # silent OOM-SIGBUS.
+        swap-storage: false
+
+    - name: df -h after
+      if: runner.os == 'Linux'
+      shell: bash
+      run: df -h /

--- a/.github/actions/make-target/action.yml
+++ b/.github/actions/make-target/action.yml
@@ -9,6 +9,10 @@ inputs:
   make-target:
     description: "Makefile target to run"
     required: true
+  free-disk:
+    description: "Reclaim disk for build-heavy jobs (Linux)"
+    required: false
+    default: 'false'
   java:
     description: "Install JDK"
     required: false
@@ -66,6 +70,9 @@ runs:
     - uses: ./.github/actions/capabilities/rust
 
     # ── On demand ──
+    - uses: ./.github/actions/capabilities/free-disk-space
+      if: inputs.free-disk == 'true'
+
     - uses: ./.github/actions/capabilities/java
       if: inputs.java == 'true'
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,22 @@
-# Dependabot: auto-opens PRs when GitHub Actions have new versions.
-# One grouped PR per week instead of one per action. Targets dev branch.
+# Version updates only. Security fixes come from this repo's Dependabot alerts +
+# automated-security-fixes (enabled in settings), not from this file.
 version: 2
 updates:
+  - package-ecosystem: "pub"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    target-branch: "dev"
+    commit-message:
+      prefix: "chore"
+    labels:
+      - "dependencies"
+    groups:
+      deps:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 5
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ env:
 
 jobs:
   inputs:
+    name: Resolve inputs
     runs-on: ubuntu-24.04
     outputs:
       runner: ${{ steps.resolve.outputs.runner }}
@@ -36,6 +37,7 @@ jobs:
     runs-on: ${{ needs.inputs.outputs.runner }}
     outputs:
       code: ${{ steps.filter.outputs.code }}
+      rust: ${{ steps.filter.outputs.rust }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v4
@@ -53,8 +55,14 @@ jobs:
               - 'analysis_options.yaml'
               - 'Makefile'
               - '.github/**'
+            rust:
+              - 'vendor/**'
+              - 'build.json'
+              - 'Makefile'
+              - '.github/**'
 
   analyze:
+    name: Analyze
     needs: [inputs, changes]
     if: needs.changes.outputs.code == 'true'
     runs-on: ${{ needs.inputs.outputs.runner }}
@@ -67,6 +75,7 @@ jobs:
           make-target: analyze
 
   test:
+    name: Package tests
     needs: [inputs, changes]
     if: needs.changes.outputs.code == 'true'
     runs-on: ${{ needs.inputs.outputs.runner }}
@@ -78,10 +87,28 @@ jobs:
         with:
           make-target: test-pkg-native
 
+  # Vendored-engine cargo tests — only when a PR touches the engine, its
+  # features, the Makefile, or CI. Skipped on Dart-only PRs.
+  rust:
+    name: Rust tests
+    needs: [inputs, changes]
+    if: needs.changes.outputs.rust == 'true'
+    runs-on: ${{ needs.inputs.outputs.runner }}
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+        with: { submodules: recursive }
+      # free-disk: the engine's debug build overruns a stock runner's
+      # ~14 GB free; the capability reclaims room (Linux only).
+      - uses: ./.github/actions/make-target
+        with:
+          make-target: test-rust
+          free-disk: 'true'
+
   gate:
     name: CI Gate
     if: always()
-    needs: [inputs, changes, analyze, test]
+    needs: [inputs, changes, analyze, test, rust]
     runs-on: ${{ needs.inputs.outputs.runner }}
     steps:
       - name: Evaluate
@@ -92,6 +119,11 @@ jobs:
           fi
           if [[ "${{ needs.analyze.result }}" != "success" ]] || [[ "${{ needs.test.result }}" != "success" ]]; then
             echo "FAILED: analyze=${{ needs.analyze.result }} test=${{ needs.test.result }}"
+            exit 1
+          fi
+          # rust runs only when the engine/features/Makefile/CI change; skipped is OK.
+          if [[ "${{ needs.rust.result }}" != "success" && "${{ needs.rust.result }}" != "skipped" ]]; then
+            echo "FAILED: rust=${{ needs.rust.result }}"
             exit 1
           fi
           echo "All CI checks passed"

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -42,6 +42,7 @@ env:
 
 jobs:
   inputs:
+    name: Resolve inputs
     runs-on: ubuntu-24.04
     outputs:
       runner: ${{ steps.resolve.outputs.runner }}

--- a/.github/workflows/full-test.yml
+++ b/.github/workflows/full-test.yml
@@ -51,6 +51,7 @@ env:
 
 jobs:
   inputs:
+    name: Resolve inputs
     runs-on: ubuntu-24.04
     outputs:
       runner: ${{ steps.resolve.outputs.runner }}

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -23,6 +23,7 @@ env:
 
 jobs:
   inputs:
+    name: Resolve inputs
     runs-on: ubuntu-24.04
     outputs:
       runner: ${{ steps.resolve.outputs.runner }}

--- a/.github/workflows/retry.yml
+++ b/.github/workflows/retry.yml
@@ -22,6 +22,7 @@ permissions:
 
 jobs:
   retry:
+    name: Re-run failed jobs
     # Only when the run failed on its first attempt.
     if: >-
       github.event.workflow_run.conclusion == 'failure' &&

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -19,6 +19,7 @@ env:
 
 jobs:
   inputs:
+    name: Resolve inputs
     runs-on: ubuntu-24.04
     outputs:
       runner: ${{ steps.resolve.outputs.runner }}
@@ -28,6 +29,7 @@ jobs:
 
   # ── Auto-label by file path (actions/labeler) ──
   label-by-files:
+    name: Label by changed files
     needs: inputs
     if: github.event_name == 'pull_request_target'
     runs-on: ${{ needs.inputs.outputs.runner }}
@@ -38,6 +40,7 @@ jobs:
 
   # ── Auto-label by PR title + branch ──
   label-by-title:
+    name: Label by title
     needs: inputs
     if: github.event_name == 'pull_request_target' && github.event.action == 'opened'
     runs-on: ${{ needs.inputs.outputs.runner }}
@@ -68,6 +71,7 @@ jobs:
 
   # ── Auto-assign maintainer ──
   assign:
+    name: Assign maintainer
     needs: inputs
     runs-on: ${{ needs.inputs.outputs.runner }}
     steps:
@@ -86,6 +90,7 @@ jobs:
 
   # ── Revoke stale ready-to-test on new commits ──
   revoke-ready-to-test:
+    name: Revoke ready-to-test
     needs: inputs
     if: >-
       github.event_name == 'pull_request_target' &&
@@ -106,6 +111,7 @@ jobs:
 
   # ── Dependabot recreate notice ──
   dependabot-needs-recreate:
+    name: Dependabot recreate notice
     needs: inputs
     if: >-
       github.event_name == 'pull_request_target' &&

--- a/.github/workflows/upgrade-check.yml
+++ b/.github/workflows/upgrade-check.yml
@@ -25,6 +25,7 @@ env:
 
 jobs:
   inputs:
+    name: Resolve inputs
     runs-on: ubuntu-24.04
     outputs:
       runner: ${{ steps.resolve.outputs.runner }}
@@ -33,6 +34,7 @@ jobs:
         run: echo "runner=${{ inputs.runner || env.DEFAULT_RUNNER }}" >> $GITHUB_OUTPUT
 
   check:
+    name: Flutter upgrade check
     needs: inputs
     runs-on: ${{ needs.inputs.outputs.runner }}
     steps:
@@ -154,6 +156,7 @@ jobs:
           fi
 
   package-deps:
+    name: Package dependency report
     needs: inputs
     runs-on: ${{ needs.inputs.outputs.runner }}
     timeout-minutes: 15

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: check analyze check-deps fixtures test-guards \
        build build-native build-wasm \
        compile-macos compile-ios compile-android compile-linux compile-windows compile-wasm compile-natives \
-       test test-pkg-native test-unit \
+       test test-pkg-native test-unit test-rust \
        test-ops test-ops-native test-ops-web test-ops-opfs test-ops-jspi test-ops-atomics \
        test-example test-example-matrix test-example-macos test-example-linux test-example-windows \
        test-example-android test-example-ios test-example-device \
@@ -19,6 +19,7 @@
 
 DART    ?= fvm dart
 FLUTTER ?= fvm flutter
+CARGO   ?= cargo
 TEST_RESULTS_DIR ?= test-results
 TIMEOUT := $(if $(CI),--timeout=30x,)
 VERBOSE := $(if $(CI),--verbose,)
@@ -165,6 +166,7 @@ compile-natives:
 # make test-ops-opfs     Ops: web OPFS.
 # make test-ops-jspi     Ops: web JSPI.
 # make test-ops-atomics  Ops: web Atomics.
+# make test-rust         cargo tests for both vendored crates.
 
 test: fixtures test-unit test-ops
 
@@ -198,6 +200,20 @@ test-ops-atomics:
 	@echo "=== Ops: Web Atomics ==="
 	@mkdir -p $(TEST_RESULTS_DIR)
 	$(DART) test $(TIMEOUT) test/ops/runners/web_atomics_runner_test.dart -p chrome-coi --concurrency=1 --file-reporter json:$(TEST_RESULTS_DIR)/ops-atomics.json
+
+# Rust unit + integration tests for both vendored crates. Most of the
+# engine's tests sit behind features we don't ship (ml / ocr / fips /
+# python / wasm), which need ONNX / pdfium / Python / a wasm target and
+# can't run natively here. pdf_oxide reuses build.json's native feature
+# set — the SAME source the build and analyze read — plus test-support,
+# so a feature added to build.json is tested automatically; office_oxide
+# runs default.
+test-rust:
+	@echo "=== Rust: pdf_oxide ==="
+	$(CARGO) test --manifest-path vendor/pdf_oxide/Cargo.toml \
+	  --features "$$(bash tool/compile_rust.sh --features native),test-support"
+	@echo "=== Rust: office_oxide ==="
+	$(CARGO) test --manifest-path vendor/office_oxide/Cargo.toml
 
 # ═══════════════════════════════════════════════════════════════════
 # § 6 — Integration tests (example app)
@@ -347,7 +363,10 @@ verify-web:
 # § 8 — Clean
 # ═══════════════════════════════════════════════════════════════════
 #
-# make clean   Remove generated build + test-result artifacts.
+# make clean   Full clean — Dart build-hook artifacts, test results, and
+#              both vendored crates' cargo target/ (the bulk of the disk
+#              use). Run deliberately; the next build recompiles fresh.
 
 clean:
 	rm -rf .dart_tool/hooks_runner/ .dart_tool/lib/ .dart_tool/native_assets/ build_output/ test-results/
+	rm -rf vendor/pdf_oxide/target/ vendor/office_oxide/target/

--- a/deploy/.deploy/secrets.sh
+++ b/deploy/.deploy/secrets.sh
@@ -12,6 +12,7 @@
 #   ./secrets.sh list  <env>                 List secret names for an environment
 #   ./secrets.sh dump  <env>                 Show values (careful!)
 #   ./secrets.sh upload <env|all>            Push all from Bitwarden → GitHub
+#   ./secrets.sh rm    <env>/<KEY>           Delete from Bitwarden + GitHub
 # ============================================================================
 set -e
 
@@ -110,6 +111,50 @@ cmd_set() {
     ghn="$key"
     gh secret set "$ghn" --env "$env" --body "$value" --repo "$REPO"
     echo "✓ GitHub:    $REPO → $env → $ghn"
+}
+
+# Deletes from both backends, scoped to THIS repo only: GitHub by --repo/--env,
+# Bitwarden by the "$BW_PREFIX/$env/" key prefix — it can't reach another repo's
+# secrets. Idempotent: a missing secret is reported, not an error.
+cmd_rm() {
+    local path="$1"
+    if [ -z "$path" ]; then
+        echo "Usage: ./secrets.sh rm <env>/<KEY>"
+        echo "Deletes the secret from Bitwarden AND this repo's GitHub environment."
+        exit 1
+    fi
+
+    local env key
+    env=$(echo "$path" | cut -d/ -f1)
+    key=$(echo "$path" | cut -d/ -f2-)
+    validate_env "$env"
+
+    local ghn
+    ghn="$key"
+    if gh secret list --env "$env" --repo "$REPO" 2>/dev/null | grep -qE "^${ghn}[[:space:]]"; then
+        if gh secret delete "$ghn" --env "$env" --repo "$REPO" 2>/dev/null; then
+            echo "✓ GitHub:    $REPO → $env → $ghn (deleted)"
+        else
+            echo "✗ GitHub:    $REPO → $env → $ghn (delete FAILED — still present)"
+            exit 1
+        fi
+    else
+        echo "· GitHub:    $REPO → $env → $ghn (not present)"
+    fi
+
+    local bw_key="$BW_PREFIX/$env/$key"
+    local id
+    id=$(bws_get_id "$bw_key")
+    if [ -n "$id" ]; then
+        if $BWS secret delete "$id" > /dev/null 2>&1; then
+            echo "✓ Bitwarden: $bw_key (deleted)"
+        else
+            echo "✗ Bitwarden: $bw_key (delete failed)"
+            exit 1
+        fi
+    else
+        echo "· Bitwarden: $bw_key (not present)"
+    fi
 }
 
 cmd_get() {
@@ -234,6 +279,7 @@ case "${1:-}" in
     list)   cmd_list "$2" ;;
     dump)   cmd_dump "$2" ;;
     upload) cmd_upload "$2" ;;
+    rm)     cmd_rm "$2" ;;
     *)
         echo "pdf_manipulator secrets manager"
         echo ""
@@ -243,11 +289,13 @@ case "${1:-}" in
         echo "  ./secrets.sh list  <env>                 List secret names"
         echo "  ./secrets.sh dump  <env>                 Show values (careful!)"
         echo "  ./secrets.sh upload <env|all>            Push Bitwarden → GitHub"
+        echo "  ./secrets.sh rm    <env>/<KEY>           Delete from Bitwarden + GitHub"
         echo ""
         echo "Examples:"
         echo "  ./secrets.sh set prod/PUB_CREDENTIALS '{\"accessToken\":\"...\",\"refreshToken\":\"...\"}'"
         echo "  ./secrets.sh get prod/PUB_CREDENTIALS"
         echo "  ./secrets.sh list prod"
         echo "  ./secrets.sh upload all"
+        echo "  ./secrets.sh rm prod/OLD_KEY"
         ;;
 esac

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -638,17 +638,26 @@ user-facing text (README, pubspec).
    combo = one line. Adding a new capability = one action + one
    input on `make-target` + add to rows that need it.
 
+8. **Every job is named.** A job's YAML key (its ID) is the code
+   handle — terse, lowercase, used only by `needs:` and
+   `${{ needs.<id>.* }}`, and hyphen-free where referenced in a `needs`
+   expression (a hyphen reads as minus there, so `rust`, not
+   `rust-tests`). The `name:` is the human label the GitHub UI shows
+   and is REQUIRED on every job — never let one fall back to its raw
+   ID. Matrix jobs set `name: <prefix>: ${{ matrix.name }}`.
+
 ### Actions
 
 ```
 .github/actions/
-├── capabilities/          13 independent leaves
+├── capabilities/          14 independent leaves
 │   ├── fvm/               Flutter SDK (all runners)
 │   ├── rust/              Rust toolchain + sccache (all runners)
 │   ├── java/              JDK (all runners)
 │   ├── chrome/            Chrome + ChromeDriver (Linux/macOS/Windows)
 │   ├── headless-display/  xvfb on Linux, no-op elsewhere
 │   ├── hw-accel/          KVM on Linux, no-op elsewhere
+│   ├── free-disk-space/   Reclaim disk on Linux, no-op elsewhere
 │   ├── gradle-cache/      Two-phase restore/save + daemon stop
 │   ├── xcode-cache/       Xcode derived data cache
 │   ├── pods-cache/        CocoaPods cache

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -105,13 +105,14 @@ done
 
 ```sh
 git rebase vNEW
-cargo test --features native-bridge
+(cd ../.. && make test-rust)
 ```
 
 Resolve conflicts commit by commit. `Cargo.lock` conflicts: take the
 base (`git checkout vNEW -- Cargo.lock`) and let cargo re-add our
-feature deps on the next build. Full `cargo test`, not `--lib` — the
-`tests/` tree catches signature drift the lib tests miss.
+feature deps on the next build. `make test-rust` runs the full `cargo
+test` (not `--lib`) for both crates — the `tests/` tree catches
+signature drift the lib tests miss.
 
 ### 4. Rename branch
 
@@ -164,9 +165,9 @@ patch:
 ```sh
 cd vendor/pdf_oxide
 grep -rl "pdf_manipulator patch" src/ --include="*.rs"
-
-cargo test --features native-bridge
 cd ../..
+
+make test-rust
 make build-wasm
 make check
 ```
@@ -429,9 +430,10 @@ make analyze
 If the Rust check fails, it prints the exact file:line and warning.
 Fix them before committing.
 
-The feature set (`RUST_FEATURES` in the Makefile) must match
-`compile_rust.sh`'s feature definitions — if they diverge, CI catches
-warnings that `make analyze` misses.
+The feature set lives once in `build.json` (`features.native` /
+`features.wasm`); `compile_rust.sh`, the build hook, `make analyze`,
+and `make test-rust` all read it, so the built, analyzed, and tested
+feature sets can't drift apart.
 
 ### Common warning types and fixes
 


### PR DESCRIPTION
## What

Adds `make test-rust` and runs it in CI whenever a PR touches the vendored engine, so the Rust crates' own test suites are exercised — not just the Dart end-to-end tests and the cargo-check warnings `make analyze` already does.

## Makefile

- **`make test-rust`** — `cargo test` for both vendored crates. `pdf_oxide` reads its feature set from `build.json` (the same source the build and `make analyze` read) plus `test-support`, so adding a feature to `build.json` tests it automatically — no parallel list to maintain. `office_oxide` runs default.
- **`make clean`** — now a true full clean: also removes both crates' `target/` dirs (the bulk of local disk use). Run deliberately; the next build recompiles from scratch.

## CI (`ci.yml`)

- A new `rust` job runs `make test-rust` **only when** a PR changes `vendor/**`, `build.json`, the `Makefile`, or CI. Dart-only PRs skip it. Gated by the existing **CI Gate** (skipped = OK).
- `make-target` already provisions the Rust toolchain for every job, so no new capability is needed.

## Docs

- The upstream-bump and patch-edit flows now run `make test-rust`; corrected the feature-set source to `build.json`.

## Verified

Ran `make test-rust` locally — both crates pass, 0 failures, under the `build.json` feature set + `test-support`. The features that can't run in a native `cargo test` (`ml` / `ocr` / `fips` / `python` / `wasm` — they need ONNX / pdfium / Python / a wasm target) are excluded, mirroring how upstream splits them into separate jobs.

## CI job naming (audit + guideline)

Audited every workflow and found inconsistent job labels — some jobs had a `name:`, many showed their raw ID (`test`, `analyze`, `inputs`, …). Decided the rule and documented it as a CI/CD principle in `ARCHITECTURE.md`:

> Every job declares an explicit `name:` (the UI label). The job ID is the code handle for `needs:` / expressions — terse, lowercase, hyphen-free where referenced in a `needs` expression.

Applied across all seven workflows so no job falls back to its raw ID.
