### PR TITLE
ci: flatten README <picture> banner for the pub.dev tarball

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -238,6 +238,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bash tool/release.sh --stamp-changelog ${{ needs.discover.outputs.tag }}
+      - name: Flatten README banner for pub.dev
+        run: bash tool/release.sh --stamp-readme
       - name: Ephemeral commit (clean git for pub publish)
         run: |
           git config user.name "github-actions[bot]"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+<!--
+  Banner stays <picture> for GitHub's dark/light. pub.dev strips <picture>
+  when sanitizing the README, so the publish step flattens it to the inner
+  <img> via `tool/release.sh --stamp-readme` (the repo copy is untouched).
+  Drop both once pub.dev renders <picture>. Tracking:
+  dart-lang/pub-dev#5923, dart-lang/pub-dev#6363, google/dart-neats#383.
+-->
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)"  srcset="assets/banner_dark-web-min.webp">

--- a/tool/release.sh
+++ b/tool/release.sh
@@ -5,15 +5,18 @@
 # The CI workflow only does job orchestration (checkout, compile,
 # upload, publish); every decision and mutation lives here.
 #
-# Seven modes
+# Nine modes
 # ───────────
 #   --gate               Check if this push should trigger a release.
 #   --discover           Find the version, create the stamped tag and
 #                        the GitHub Release.
+#   --check-versions     Fail if the changelog adds >1 unreleased version.
 #   --github-notes       Print GitHub Release notes to stdout.
 #   --update-tag-hashes  Stamp asset hashes into the tag and update it.
 #   --stamp-changelog    Build the filtered CHANGELOG.md for the pub.dev
 #                        tarball.
+#   --stamp-readme       Flatten the README <picture> banner to a single
+#                        <img> for the pub.dev tarball.
 #   --add-git-install    Append the git-install snippet to release notes.
 #   --add-pub-install    Append the pub.dev-install snippet to notes.
 #
@@ -29,6 +32,7 @@
 #                  --add-git-install
 #                  --update-tag-hashes
 #   5. publish   → --stamp-changelog
+#                  --stamp-readme
 #                  dart pub publish
 #                  --add-pub-install
 #
@@ -86,6 +90,7 @@ Modes:
   --github-notes TAG        Print GitHub Release notes to stdout.
   --update-tag-hashes TAG   Stamp asset hashes into the tag (post-upload).
   --stamp-changelog TAG     Build the filtered CHANGELOG.md for pub.dev.
+  --stamp-readme            Flatten the README <picture> banner for pub.dev.
   --add-git-install TAG     Append the git-install snippet to the notes.
   --add-pub-install TAG     Append the pub.dev-install snippet to the notes.
 
@@ -718,6 +723,40 @@ cmd_stamp_changelog() {
 
 
 # ════════════════════════════════════════════════════════════════════
+# § 8b — Mode: --stamp-readme
+#
+# pub.dev strips <picture>/<source> when sanitizing the README, dropping
+# the whole block so the banner renders blank. GitHub renders <picture>
+# fine, so the repo keeps the dark/light version and we flatten it to the
+# inner <img> only in the pub.dev tarball, here at publish time.
+#
+# Remove this mode (and its call in create-release.yml) once pub.dev
+# renders <picture>. Tracking:
+#   https://github.com/dart-lang/pub-dev/issues/5923
+#   https://github.com/dart-lang/pub-dev/issues/6363
+#   https://github.com/google/dart-neats/pull/383
+# ════════════════════════════════════════════════════════════════════
+
+cmd_stamp_readme() {
+  echo "=== Flattening README <picture> banner for pub.dev ==="
+  if ! grep -qE '^[[:space:]]*<picture>[[:space:]]*$' README.md; then
+    echo "  no <picture> banner; nothing to flatten"
+    return 0
+  fi
+  # Match <picture>/<source> only as a tag alone on its line (the banner),
+  # never a mention inside comment prose.
+  awk '
+    /^[[:space:]]*<picture>[[:space:]]*$/   { inpic = 1; next }
+    /^[[:space:]]*<\/picture>[[:space:]]*$/ { inpic = 0; next }
+    inpic && /<source/ { next }
+    { print }
+  ' README.md > /tmp/_readme_pubdev.md
+  mv /tmp/_readme_pubdev.md README.md
+  echo "  README.md banner flattened to a single <img>"
+}
+
+
+# ════════════════════════════════════════════════════════════════════
 # § 9 — Modes: --add-git-install / --add-pub-install
 #
 # Append an install snippet to the existing GitHub Release notes.
@@ -936,6 +975,7 @@ main() {
     --github-notes)      cmd_github_notes ;;
     --update-tag-hashes) cmd_update_tag_hashes ;;
     --stamp-changelog)   cmd_stamp_changelog ;;
+    --stamp-readme)      cmd_stamp_readme ;;
     --add-git-install)   cmd_add_git_install ;;
     --add-pub-install)   cmd_add_pub_install ;;
     *)


### PR DESCRIPTION
pub.dev strips `<picture>`/`<source>` when sanitizing the README, so the dark/light banner renders blank on the package page. This adds a `--stamp-readme` mode to `tool/release.sh` that flattens the banner to its inner `<img>` in the pub.dev tarball at publish time, the same way `--stamp-changelog` rewrites the changelog. `README.md` in the repo stays `<picture>`, so GitHub keeps the dark/light version.

Tested: the flatten keeps the tracking comment intact, removes only the banner's `<picture>`/`<source>` tags, and is idempotent.

Also corrected the mode count and list in the release.sh header comment, which had drifted (it was missing `--check-versions`).

Refs: dart-lang/pub-dev#5923, dart-lang/pub-dev#6363, google/dart-neats#383
