### PR TITLE
ci: auto-close resolved issues with an opt-out guard

### DIFF
--- a/.github/workflows/auto-close-arm.yml
+++ b/.github/workflows/auto-close-arm.yml
@@ -1,0 +1,22 @@
+# Posts the opt-out notice the moment you add the `resolved` label, so the
+# reporter has the full grace window to object. See auto-close.yml.
+name: Arm auto-close on resolved
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  issues: write
+
+jobs:
+  arm:
+    if: github.event.label.name == 'resolved'
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NUM: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+          MSG: 'Marked resolved, auto-closing in 7 days. Still need it open? Reply `keep open: your reason` (example: keep open: still crashes on Android 14).'
+        run: |
+          gh issue comment "$NUM" --repo "$REPO" --body "$MSG"

--- a/.github/workflows/auto-close-guard.yml
+++ b/.github/workflows/auto-close-guard.yml
@@ -37,5 +37,7 @@ jobs:
             | cut -c1-280)
           [ -z "$reason" ] && reason='(no reason given, see the comment)'
           gh issue edit "$NUM" --repo "$REPO" --remove-label resolved
+          # may also carry the stale marker if it opted out during the close window
+          gh issue edit "$NUM" --repo "$REPO" --remove-label bot-closing-soon 2>/dev/null || true
           gh issue comment "$NUM" --repo "$REPO" --body \
             "$(printf '@chaudharydeepanshu @slopfairy kept open by @%s.\nReason: %s' "$WHO" "$reason")"

--- a/.github/workflows/auto-close-guard.yml
+++ b/.github/workflows/auto-close-guard.yml
@@ -1,0 +1,41 @@
+# Stops the auto-close the instant a non-maintainer replies `keep open`.
+# Removes `resolved` (which takes the issue out of auto-close.yml's pool),
+# flags `needs-review`, and tags the maintainers with who asked and why.
+# Only acts on open issues, so it never reopens a closed one.
+name: Keep open on opt-out
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+
+jobs:
+  keep-open:
+    if: >
+      github.event.issue.state == 'open' &&
+      github.event.issue.pull_request == null &&
+      contains(github.event.issue.labels.*.name, 'resolved') &&
+      github.event.comment.author_association != 'OWNER' &&
+      github.event.comment.author_association != 'MEMBER' &&
+      github.event.comment.author_association != 'COLLABORATOR'
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BODY: ${{ github.event.comment.body }}
+          WHO: ${{ github.event.comment.user.login }}
+          NUM: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Comment body via env var, never interpolated into the script (injection-safe).
+          grep -qiE 'keep open' <<< "$BODY" || exit 0
+          reason=$(printf '%s' "$BODY" | tr '\n' ' ' \
+            | sed -E 's/.*[Kk]eep [Oo]pen//' \
+            | sed -E 's/^[[:space:]:,.-]+//' \
+            | sed -E 's/[[:space:]]+/ /g' \
+            | cut -c1-280)
+          [ -z "$reason" ] && reason='(no reason given, see the comment)'
+          gh issue edit "$NUM" --repo "$REPO" --remove-label resolved --add-label needs-review
+          gh issue comment "$NUM" --repo "$REPO" --body \
+            "$(printf '@chaudharydeepanshu @slopfairy kept open by @%s.\nReason: %s' "$WHO" "$reason")"

--- a/.github/workflows/auto-close-guard.yml
+++ b/.github/workflows/auto-close-guard.yml
@@ -1,6 +1,6 @@
 # Stops the auto-close the instant a non-maintainer replies `keep open`.
-# Removes `resolved` (which takes the issue out of auto-close.yml's pool),
-# flags `needs-review`, and tags the maintainers with who asked and why.
+# Removes `resolved` (which takes the issue out of auto-close.yml's pool)
+# and tags the maintainers with who asked and why.
 # Only acts on open issues, so it never reopens a closed one.
 name: Keep open on opt-out
 on:
@@ -36,6 +36,6 @@ jobs:
             | sed -E 's/[[:space:]]+/ /g' \
             | cut -c1-280)
           [ -z "$reason" ] && reason='(no reason given, see the comment)'
-          gh issue edit "$NUM" --repo "$REPO" --remove-label resolved --add-label needs-review
+          gh issue edit "$NUM" --repo "$REPO" --remove-label resolved
           gh issue comment "$NUM" --repo "$REPO" --body \
             "$(printf '@chaudharydeepanshu @slopfairy kept open by @%s.\nReason: %s' "$WHO" "$reason")"

--- a/.github/workflows/auto-close.yml
+++ b/.github/workflows/auto-close.yml
@@ -12,7 +12,6 @@ on:
 
 permissions:
   issues: write
-  pull-requests: write
 
 jobs:
   stale:

--- a/.github/workflows/auto-close.yml
+++ b/.github/workflows/auto-close.yml
@@ -25,9 +25,8 @@ jobs:
           days-before-issue-close: 3
           days-before-pr-stale: -1
           days-before-pr-close: -1
-          stale-issue-label: 'pending-auto-close'
+          stale-issue-label: 'bot-closing-soon'
           close-issue-reason: 'completed'
-          exempt-issue-labels: 'keep-open'
           remove-stale-when-updated: false
           operations-per-run: 60
           stale-issue-message: >

--- a/.github/workflows/auto-close.yml
+++ b/.github/workflows/auto-close.yml
@@ -1,0 +1,38 @@
+# Auto-close issues marked `resolved` after a grace period.
+#
+# You add the `resolved` label when an issue is done from your side.
+# auto-close-arm.yml comments immediately. This job (daily) posts the
+# reminder at day 4 and closes at day 7. Only an explicit opt-out
+# (auto-close-guard.yml removing `resolved`) stops it; chatter does not.
+name: Auto-close resolved issues
+on:
+  schedule:
+    - cron: '0 9 * * *'   # daily, 09:00 UTC
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          only-labels: 'resolved'
+          days-before-issue-stale: 4
+          days-before-issue-close: 3
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          stale-issue-label: 'pending-auto-close'
+          close-issue-reason: 'completed'
+          exempt-issue-labels: 'keep-open'
+          remove-stale-when-updated: false
+          operations-per-run: 60
+          stale-issue-message: >
+            Closing in 3 days. If it still affects you, reply
+            `keep open: your reason` and it stays open.
+          close-issue-message: >
+            Auto-closing: marked resolved with no objection in the grace
+            window. Comment any time and it will be looked at.


### PR DESCRIPTION
Label-driven auto-close so resolved issues sanitize themselves without manual babysitting.

Flow:
- You add `resolved` when an issue is done from your side. The reporter immediately gets the opt-out notice (`auto-close-arm.yml`).
- Day 4: a reminder. Day 7: close as completed (`auto-close.yml`, `actions/stale`). `remove-stale-when-updated: false`, so a thanks or other chatter never stops the close.
- Only an explicit `keep open: <reason>` from a non-maintainer stops it: the guard removes `resolved` and `bot-closing-soon` (taking it out of the close pool) and tags @chaudharydeepanshu and @slopfairy with who asked and the reason (`auto-close-guard.yml`).
- After close, comments stay open and nothing auto-reopens.

Two labels: `resolved` (you add) and `bot-closing-soon` (managed by `actions/stale` as its stale marker; bot-only, do not edit).

Validated with actionlint. Comment bodies are read via env vars, never interpolated into the run script. Issues only, never PRs.
