### PR TITLE
docs: add 2.1.1 changelog entry for the README fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,10 @@ CONTENT RULES (never change)
 
 <!-- Add new versions below, newest first. -->
 
+## 2.1.1
+
+- Fixed the README
+
 ## 2.1.0
 
 - Added document producer and creation-date metadata — `PdfEditor.setProducer()` / `getProducer()` and `setCreationDate()` / `getCreationDate()` (raw PDF date strings, e.g. `D:20240101120000Z`), plus `PdfDoc.producer`, `PdfDoc.creator`, and `PdfDoc.creationDate` read on open

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@ CONTENT RULES (never change)
 
 ## 2.1.1
 
-- Fixed the README
+- Fixed the README banner not rendering on pub.dev — the `<picture>` element is flattened to a plain image in the published package ([PR #111](https://github.com/whuppi/pdf_manipulator/pull/111))
 
 ## 2.1.0
 

--- a/CHANGELOG.pre.md
+++ b/CHANGELOG.pre.md
@@ -62,7 +62,7 @@ CONTENT RULES (never change)
 
 ## 2.1.1-dev.0
 
-- Fixed the README
+- Fixed the README banner not rendering on pub.dev — the `<picture>` element is flattened to a plain image in the published package ([PR #111](https://github.com/whuppi/pdf_manipulator/pull/111))
 
 ## 2.1.0-dev.0
 

--- a/CHANGELOG.pre.md
+++ b/CHANGELOG.pre.md
@@ -60,6 +60,10 @@ CONTENT RULES (never change)
 
 <!-- Add new versions below, newest first. -->
 
+## 2.1.1-dev.0
+
+- Fixed the README
+
 ## 2.1.0-dev.0
 
 - Added document producer and creation-date metadata — `PdfEditor.setProducer()` / `getProducer()` and `setCreationDate()` / `getCreationDate()` (raw PDF date strings, e.g. `D:20240101120000Z`), plus `PdfDoc.producer`, `PdfDoc.creator`, and `PdfDoc.creationDate` read on open


### PR DESCRIPTION
Adds `## 2.1.1` to CHANGELOG.md and `## 2.1.1-dev.0` to CHANGELOG.pre.md, each with `- Fixed the README`.

`v2.1.0` is already tagged/shipped, so the unreleased README fix lands in a new patch version (2.1.1), not the frozen 2.1.0. Both lanes pass `release.sh --check-versions` (one untagged version at the top; every heading below is tagged).