### PR TITLE
fix(ci): re-supply git push auth in release.sh

### DIFF
--- a/tool/ci/release.sh
+++ b/tool/ci/release.sh
@@ -125,10 +125,18 @@ gh_output() {
   echo "  output: $1=$2"
 }
 
-# Configure the git identity used for CI commits.
+# Configure the git identity + push auth used for CI commits.
 git_ci_identity() {
   git config user.name  "github-actions[bot]"
   git config user.email "github-actions[bot]@users.noreply.github.com"
+
+  # The release checkout uses persist-credentials:false (zizmor hardening leaves
+  # no token in git config for later steps to leak), so these pushes have no auth.
+  # Wire gh's token in as a credential helper — the same GH_TOKEN `gh release`
+  # already uses. Skipped on a local dry run, where the push uses your own creds.
+  if [ -n "${GH_TOKEN:-}" ]; then
+    gh auth setup-git
+  fi
 }
 
 # Extract one version's entry (body only, heading excluded) from a


### PR DESCRIPTION
## What

`create-release.yml`'s "Discover versions" job was failing in ~20s with:

```
fatal: could not read Username for 'https://github.com': No such device or address
```

## Why

The CI hardening (#113) set `persist-credentials: false` on the release checkouts. That strips the token `git push` needs. `gh release create` survived (it reads `GH_TOKEN`), but `release.sh`'s staging-branch push and tag force-push had nothing to authenticate with. v2.1.0 was the last release cut before #113 landed; every release since has been broken at this step.

## Fix

`git_ci_identity()` (the shared setup both push paths call) now runs `gh auth setup-git` when `GH_TOKEN` is set, wiring the token in as a git credential helper just before the pushes.

Considered flipping the discover job to `persist-credentials: true` instead. Ran the repo's auditor-persona invocation and it produces a medium `artipacked` finding, which breaks zizmor-zero and would need an avoidable ignore. Keeping `persist-credentials: false` and re-supplying via `gh` keeps the workflow hardened and zizmor clean.

Fixes both `--discover` and `--update-tag-hashes` push paths. Local: `bash -n` + `tool/lint_shell.sh` pass; zizmor unchanged at zero.