### PR TITLE
ci: unblock the release pipeline + supply-chain & workflow hardening

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -21,12 +21,15 @@ if printf '%s\n' "$msg" | grep -qE '^Merge '; then
   exit 1
 fi
 
-if ! printf '%s\n' "$msg" | grep -qE '^(feat|fix|docs|chore|ci|test|refactor|perf|build|deps)(\(.+\))?!?: .+'; then
+# Single source of truth for the type list: tool/commit-types.txt (pr-lint.yml
+# validates PR titles against the same file). cwd is the repo root during hooks.
+types=$(paste -sd'|' tool/commit-types.txt)
+if ! printf '%s\n' "$msg" | grep -qE "^(${types})(\(.+\))?!?: .+"; then
   echo "ERROR: Commit message must follow Conventional Commits format."
   echo ""
   echo "  <type>[optional scope]: <description>"
   echo ""
-  echo "  Types: feat fix docs chore ci test refactor perf build deps"
+  printf '  Types: %s\n' "$(paste -sd' ' tool/commit-types.txt)"
   echo "  Examples:"
   echo "    feat: add watermark support"
   echo "    fix(web): handle empty PDF edge case"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -2,9 +2,13 @@
 # Reject commits that add files matching .gitignore patterns.
 # Catches accidental `git add -f` of ignored files.
 
-bad_files=$(git diff --cached --name-only --diff-filter=A | while read f; do
-  git check-ignore --quiet "$f" 2>/dev/null && echo "$f"
-done)
+# --no-index is load-bearing: a force-added file is already in the index, and
+# without it git check-ignore treats an indexed path as tracked and reports
+# nothing, so the hook would silently never fire. NUL end to end
+# (core.quotepath=false stops octal-escaping, -z stops newline-splitting) keeps
+# paths with spaces or newlines intact; --stdin avoids a non-POSIX read -d '' loop.
+bad_files=$(git -c core.quotepath=false diff --cached --name-only --diff-filter=A -z \
+  | git check-ignore --no-index --stdin -z 2>/dev/null | tr '\0' '\n')
 
 if [ -n "$bad_files" ]; then
   echo "ERROR: These newly-added files are gitignored:"

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,3 +26,12 @@
 # (fetch_verified.sh), the publish pipeline + the hash-writing bump bot
 # (tool/ci/). A non-owner edit here is a supply-chain or release risk.
 /tool/                     @chaudharydeepanshu
+
+# Vendored engine submodules: bumping a gitlink pulls in that commit's build.rs
+# and build-dependencies, which cargo runs at compile time (before any test) in
+# CI. Without this, a bump falls to the maintainers team via `*`; gate the
+# pointer bump to the owner instead. Per-file rules like /vendor/**/build.rs are
+# deliberately absent: those files live inside the submodule repos, not this one,
+# so CODEOWNERS here can't match them. The submodule repos' own CODEOWNERS gate
+# their build scripts and lockfiles.
+/vendor/                   @chaudharydeepanshu

--- a/.github/actions/capabilities/rust/action.yml
+++ b/.github/actions/capabilities/rust/action.yml
@@ -96,11 +96,20 @@ runs:
         fi
         mkdir -p "$HOME/.cargo"
         CFG="$HOME/.cargo/config.toml"
-        # A fresh runner has no config.toml, so the append creates it. Guard
-        # the rare pre-existing case: a second [build] header is a TOML error,
-        # so insert the wrapper UNDER the existing table instead.
+        # A fresh runner has no config.toml, so the append creates it. Guard the
+        # rare pre-existing case (a second [build] header is a TOML error) by
+        # inserting the wrapper UNDER the existing table. Done with awk, not a
+        # GNU sed insert: the one-line append form is GNU-only (BSD wants a
+        # two-line backslash form), so it broke on macOS runners. SCCACHE_BIN
+        # rides ENVIRON, not awk -v, so a path is never backslash-interpreted.
+        # (An env var via GITHUB_ENV would be simpler but zizmor flags every
+        # dynamic GITHUB_ENV write as an injection vector — a file write is clean.)
         if [ -f "$CFG" ] && grep -q '^\[build\]' "$CFG"; then
-          sed -i.bak '/^\[build\]/a rustc-wrapper = "'"$SCCACHE_BIN"'"' "$CFG" && rm -f "$CFG.bak"
+          sk_w="$SCCACHE_BIN" awk '
+            BEGIN { w = ENVIRON["sk_w"] }
+            { print }
+            /^\[build\]/ && !seen { print "rustc-wrapper = \"" w "\""; seen=1 }
+          ' "$CFG" > "$CFG.tmp" && mv "$CFG.tmp" "$CFG"
         else
           printf '\n[build]\nrustc-wrapper = "%s"\n' "$SCCACHE_BIN" >> "$CFG"
         fi

--- a/.github/actions/capabilities/rust/action.yml
+++ b/.github/actions/capabilities/rust/action.yml
@@ -56,6 +56,10 @@ runs:
           # connection reset). cargo's default is 3 retries; 10 rides out a
           # short registry blip instead of failing the whole build.
           echo "CARGO_NET_RETRY=10"
+          # HTTP/2 multiplexing intermittently fails crates.io with a framing
+          # layer error (curl 16) that the retry above doesn't catch; HTTP/1.1
+          # avoids that class.
+          echo "CARGO_HTTP_MULTIPLEXING=false"
         } >> "$GITHUB_ENV"
         # Submodule pins arrive via env (hoisted from step outputs). Heredoc
         # with a random delimiter so a stray newline can't inject entries.

--- a/.github/actions/capabilities/rust/action.yml
+++ b/.github/actions/capabilities/rust/action.yml
@@ -96,14 +96,9 @@ runs:
         fi
         mkdir -p "$HOME/.cargo"
         CFG="$HOME/.cargo/config.toml"
-        # A fresh runner has no config.toml, so the append creates it. Guard the
-        # rare pre-existing case (a second [build] header is a TOML error) by
-        # inserting the wrapper UNDER the existing table. Done with awk, not a
-        # GNU sed insert: the one-line append form is GNU-only (BSD wants a
-        # two-line backslash form), so it broke on macOS runners. SCCACHE_BIN
-        # rides ENVIRON, not awk -v, so a path is never backslash-interpreted.
-        # (An env var via GITHUB_ENV would be simpler but zizmor flags every
-        # dynamic GITHUB_ENV write as an injection vector — a file write is clean.)
+        # Insert under [build] (a second header is a TOML error) with awk, not a
+        # GNU one-line sed append; that form broke on macOS. Pass the path via
+        # ENVIRON, not awk -v, which would interpret a backslash in it.
         if [ -f "$CFG" ] && grep -q '^\[build\]' "$CFG"; then
           sk_w="$SCCACHE_BIN" awk '
             BEGIN { w = ENVIRON["sk_w"] }

--- a/.github/actions/capabilities/rust/action.yml
+++ b/.github/actions/capabilities/rust/action.yml
@@ -104,7 +104,7 @@ runs:
             BEGIN { w = ENVIRON["sk_w"] }
             { print }
             /^\[build\]/ && !seen { print "rustc-wrapper = \"" w "\""; seen=1 }
-          ' "$CFG" > "$CFG.tmp" && mv "$CFG.tmp" "$CFG"
+          ' "$CFG" > "$CFG.tmp" && mv "$CFG.tmp" "$CFG" || rm -f "$CFG.tmp"
         else
           printf '\n[build]\nrustc-wrapper = "%s"\n' "$SCCACHE_BIN" >> "$CFG"
         fi

--- a/.github/labels.json
+++ b/.github/labels.json
@@ -1,14 +1,16 @@
 [
-  { "name": "bug",              "color": "D93F0B", "description": "Something broken" },
-  { "name": "feature",          "color": "0E8A16", "description": "New capability" },
-  { "name": "ci",               "color": "BFD4F2", "description": "Build, CI, workflows" },
-  { "name": "web",              "color": "1D76DB", "description": "Web or WASM specific" },
-  { "name": "upstream",         "color": "5319E7", "description": "Needs upstream pdf_oxide change" },
-  { "name": "dependencies",     "color": "0366D6", "description": "Dependency version bumps" },
-  { "name": "ready-to-test",    "color": "FBCA04", "description": "Triggers full test suite" },
-  { "name": "release",          "color": "6F42C1", "description": "Release promotion PR" },
-  { "name": "needs-info",       "color": "D876E3", "description": "Waiting on reporter" },
-  { "name": "wont-fix",         "color": "EEEEEE", "description": "Intentional or out of scope" },
-  { "name": "resolved",         "color": "1A7F37", "description": "Done from maintainer side; auto-closes after a grace period" },
-  { "name": "bot-closing-soon", "color": "CFD3D7", "description": "Auto-close in progress; bot-managed, do not edit" }
+  { "name": "bug",              "color": "D93F0B", "description": "Broken behavior (auto)" },
+  { "name": "feature",          "color": "0E8A16", "description": "New capability (auto)" },
+  { "name": "ci",               "color": "BFD4F2", "description": "Build, CI, or workflow change (auto)" },
+  { "name": "web",              "color": "1D76DB", "description": "Web or WASM specific (auto)" },
+  { "name": "upstream",         "color": "5319E7", "description": "Needs a pdf_oxide change (auto)" },
+  { "name": "dependencies",     "color": "0366D6", "description": "Dependency version bump (auto)" },
+  { "name": "upgrade-pins",     "color": "1D76DB", "description": "Pinned tool or binary bump, review the hashes (auto)" },
+  { "name": "upgrade-locks",    "color": "1D76DB", "description": "Lockfile refresh (auto)" },
+  { "name": "ready-to-test",    "color": "FBCA04", "description": "Triggers the full cross-target test run (manual)" },
+  { "name": "release",          "color": "6F42C1", "description": "Release promotion PR (manual)" },
+  { "name": "needs-info",       "color": "D876E3", "description": "Awaiting the reporter (manual)" },
+  { "name": "wont-fix",         "color": "EEEEEE", "description": "Intentional or out of scope (manual)" },
+  { "name": "resolved",         "color": "1A7F37", "description": "Fixed, auto-closes after a grace period (manual)" },
+  { "name": "bot-closing-soon", "color": "CFD3D7", "description": "Auto-close pending, do not edit (auto)" }
 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
   inputs:
     name: Resolve inputs
     runs-on: ubuntu-24.04
+    timeout-minutes: 5
     permissions: {}
     outputs:
       runner: ${{ steps.resolve.outputs.runner }}
@@ -42,6 +43,7 @@ jobs:
     name: Detect changes
     needs: inputs
     runs-on: ${{ needs.inputs.outputs.runner }}
+    timeout-minutes: 5
     permissions:
       contents: read  # checkout + paths-filter, read-only
     outputs:
@@ -127,6 +129,7 @@ jobs:
     if: always()
     needs: [inputs, changes, analyze, test, rust]
     runs-on: ${{ needs.inputs.outputs.runner }}
+    timeout-minutes: 5
     permissions: {}
     steps:
       - name: Evaluate

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -54,6 +54,7 @@ jobs:
   inputs:
     name: Resolve inputs
     runs-on: ubuntu-24.04
+    timeout-minutes: 5
     permissions: {}
     outputs:
       runner: ${{ steps.resolve.outputs.runner }}
@@ -69,6 +70,7 @@ jobs:
     name: Release gate
     needs: inputs
     runs-on: ${{ needs.inputs.outputs.runner }}
+    timeout-minutes: 5
     permissions:
       contents: read  # checkout + changelog gate, read-only
     outputs:
@@ -104,6 +106,7 @@ jobs:
       group: release-${{ needs.gate.outputs.version || github.run_id }}
       cancel-in-progress: true
     runs-on: ${{ needs.inputs.outputs.runner }}
+    timeout-minutes: 20
     permissions:
       contents: write  # release.sh --discover creates the GitHub release
     outputs:
@@ -140,6 +143,7 @@ jobs:
           - { name: windows, runner: windows-2025-vs2026 }
     name: compile-${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
     permissions:
       contents: read  # checkout + build; artifacts use run storage, no API
     steps:
@@ -162,6 +166,7 @@ jobs:
     needs: [inputs, discover, compile]
     if: needs.discover.outputs.has_release == 'true'
     runs-on: ${{ needs.inputs.outputs.runner }}
+    timeout-minutes: 15
     permissions:
       contents: write  # uploads binaries + stamps the release tag
     steps:
@@ -258,6 +263,7 @@ jobs:
     needs: [inputs, discover, upload-assets]
     if: needs.discover.outputs.has_release == 'true'
     runs-on: ${{ needs.inputs.outputs.runner }}
+    timeout-minutes: 20
     environment: ${{ inputs.branch || github.ref_name }}
     permissions:
       contents: write  # ephemeral stamp commit + release-notes install snippet

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -218,6 +218,9 @@ jobs:
       - name: Upload binaries to the release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # This step runs before any checkout, so gh has no .git to infer the
+          # target repo from. GH_REPO names it, or gh exits "not a git repo".
+          GH_REPO: ${{ github.repository }}
           TAG: ${{ needs.discover.outputs.tag }}
         # gh ships on the runner; the release already exists (discover
         # created it), so just upload the binaries, clobbering on rerun.

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -267,10 +267,8 @@ jobs:
           ref: '${{ needs.discover.outputs.tag }}'
           fetch-depth: 0
           persist-credentials: false
-      # Verified fvm via the shared capability — the same hash-pinned fetch
-      # every other job uses, not an unverified `pub global activate`. This job
-      # holds the pub.dev credentials, so it must not acquire tooling through a
-      # weaker path than the rest of the pipeline.
+      # Use the verified fvm capability, not an unverified pub global activate:
+      # this job holds the pub.dev credentials, so don't weaken its tooling path.
       - uses: ./.github/actions/capabilities/fvm
       - name: Build filtered changelog
         env:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -267,14 +267,11 @@ jobs:
           ref: '${{ needs.discover.outputs.tag }}'
           fetch-depth: 0
           persist-credentials: false
-      - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
-      - name: Install fvm + project SDK
-        # Pin the fvm TOOL (the Flutter SDK is pinned in .fvmrc). Version
-        # lives in tool/versions.env so it never floats on @latest.
-        run: |
-          source tool/versions.env
-          dart pub global activate fvm "$FVM_VERSION"
-          fvm install
+      # Verified fvm via the shared capability — the same hash-pinned fetch
+      # every other job uses, not an unverified `pub global activate`. This job
+      # holds the pub.dev credentials, so it must not acquire tooling through a
+      # weaker path than the rest of the pipeline.
+      - uses: ./.github/actions/capabilities/fvm
       - name: Build filtered changelog
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/full-test.yml
+++ b/.github/workflows/full-test.yml
@@ -55,6 +55,7 @@ jobs:
   inputs:
     name: Resolve inputs
     runs-on: ubuntu-24.04
+    timeout-minutes: 5
     permissions: {}
     outputs:
       runner: ${{ steps.resolve.outputs.runner }}
@@ -184,6 +185,7 @@ jobs:
     if: always()
     needs: [inputs, test]
     runs-on: ${{ needs.inputs.outputs.runner }}
+    timeout-minutes: 5
     permissions: {}
     steps:
       - name: Evaluate

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -3,6 +3,12 @@
 # makes GitHub match it: creates missing, recolours/redescribes changed, and
 # deletes any label not listed. Never edit labels in the UI; the next run
 # reverts the drift. The sync is authoritative, so labels.json must be complete.
+#
+# Description style: a terse phrase, sentence case, no trailing period; a comma
+# adds at most one substantive qualifier; no prefixes, no semicolons; noun
+# phrase unless the label's whole job is an action. Every one ends with an
+# applier tag: (auto) when a bot applies or manages it in the normal flow,
+# (manual) when you apply it.
 name: Labels
 
 on:

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -30,6 +30,7 @@ jobs:
   inputs:
     name: Resolve inputs
     runs-on: ubuntu-24.04
+    timeout-minutes: 5
     outputs:
       runner: ${{ steps.resolve.outputs.runner }}
     steps:
@@ -45,6 +46,7 @@ jobs:
     name: Conventional Commit
     needs: inputs
     runs-on: ${{ needs.inputs.outputs.runner }}
+    timeout-minutes: 5
     steps:
       - name: Check PR title
         shell: bash
@@ -72,6 +74,7 @@ jobs:
     name: Promotion Chain
     needs: inputs
     runs-on: ${{ needs.inputs.outputs.runner }}
+    timeout-minutes: 5
     steps:
       - name: Validate promotion path
         shell: bash
@@ -103,6 +106,7 @@ jobs:
     name: Changelog Versions
     needs: inputs
     runs-on: ${{ needs.inputs.outputs.runner }}
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:
@@ -133,6 +137,7 @@ jobs:
     name: Workflow lint
     needs: inputs
     runs-on: ${{ needs.inputs.outputs.runner }}
+    timeout-minutes: 15
     permissions:
       contents: read  # checkout only; both tools read the workflow files
     steps:

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -165,6 +165,7 @@ jobs:
     name: Pin availability
     needs: inputs
     runs-on: ${{ needs.inputs.outputs.runner }}
+    timeout-minutes: 15
     permissions:
       contents: read  # checkout only; HEADs the pinned asset URLs
     steps:

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -156,3 +156,21 @@ jobs:
       - name: shell lint (shellcheck + bash 3.2 portability)
         shell: bash
         run: bash tool/lint_shell.sh
+
+  # Runs on PR activity (not just the daily cron, which GitHub disables after
+  # ~60 idle days): HEADs every pinned asset so a pruned pin fails the PR that
+  # sits on it, before it fail-closes a build. Fails on a definitive 404/410,
+  # warns on transient.
+  pin-availability:
+    name: Pin availability
+    needs: inputs
+    runs-on: ${{ needs.inputs.outputs.runner }}
+    permissions:
+      contents: read  # checkout only; HEADs the pinned asset URLs
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Pinned assets still reachable
+        shell: bash
+        run: bash tool/ci/upgrade.sh check-availability

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -47,18 +47,25 @@ jobs:
     needs: inputs
     runs-on: ${{ needs.inputs.outputs.runner }}
     timeout-minutes: 5
+    permissions:
+      contents: read  # checkout only; reads tool/commit-types.txt
     steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Check PR title
         shell: bash
         env:
           TITLE: ${{ github.event.pull_request.title }}
         run: |
-          if ! grep -qE '^(feat|fix|docs|chore|ci|test|refactor|perf|build|deps)(\(.+\))?!?: .+' <<< "$TITLE"; then
+          # Same type list as the commit-msg hook (tool/commit-types.txt).
+          types=$(paste -sd'|' tool/commit-types.txt)
+          if ! grep -qE "^(${types})(\(.+\))?!?: .+" <<< "$TITLE"; then
             echo "::error::PR title must follow Conventional Commits format."
             echo ""
             echo "  <type>[optional scope]: <description>"
             echo ""
-            echo "  Types: feat fix docs chore ci test refactor perf build deps"
+            printf '  Types: %s\n' "$(paste -sd' ' tool/commit-types.txt)"
             echo "  Examples:"
             echo "    feat: add watermark support"
             echo "    fix(web): handle empty PDF edge case"

--- a/.github/workflows/upgrade-check.yml
+++ b/.github/workflows/upgrade-check.yml
@@ -40,6 +40,7 @@ jobs:
   inputs:
     name: Resolve inputs
     runs-on: ubuntu-24.04
+    timeout-minutes: 5
     permissions: {}
     outputs:
       runner: ${{ steps.resolve.outputs.runner }}
@@ -57,6 +58,7 @@ jobs:
     name: Pinned versions
     needs: inputs
     runs-on: ${{ needs.inputs.outputs.runner }}
+    timeout-minutes: 30
     permissions:
       contents: write       # pushes the chore/pins branch
       pull-requests: write  # opens / edits the pins PR
@@ -155,6 +157,7 @@ jobs:
     name: Lockfile refresh
     needs: inputs
     runs-on: ${{ needs.inputs.outputs.runner }}
+    timeout-minutes: 20
     permissions:
       contents: write       # pushes the chore/lockfiles branch
       pull-requests: write  # opens / edits the lockfiles PR

--- a/.github/workflows/upgrade-check.yml
+++ b/.github/workflows/upgrade-check.yml
@@ -1,8 +1,11 @@
-# Daily upgrade radar — everything pinned that Dependabot can't see (Flutter
-# SDK, versions.env tools/binaries, zizmor + actionlint gate pins) PLUS the
-# committed lockfiles, all refreshed to latest in-range; drift → opens (or
-# updates) one reviewed PR you full-test before merge. Pin logic lives in
-# tool/ci/upgrade.sh; the lock refresh is `pub upgrade` here.
+# Daily upgrade radar — everything pinned that Dependabot can't see, split by
+# risk class into TWO reviewed PRs you full-test before merge:
+#   pins      — Flutter SDK (.fvmrc) + tool/versions.env tool/binary pins with
+#               recomputed sha256s. Security-sensitive, so it reviews on its own
+#               and a hash change is never buried in lockfile churn. Re-hashes
+#               the already-pinned assets FIRST (repoint alarm), then bumps.
+#   lockfiles — pubspec.lock refreshed to latest in-range against current dev.
+# Pin logic lives in tool/ci/upgrade.sh; the lock refresh is `pub upgrade` here.
 # Runner-agnostic — configurable via workflow_dispatch (default: ubuntu-24.04).
 name: Upgrade Check
 
@@ -47,25 +50,30 @@ jobs:
           DEFAULT: ${{ env.DEFAULT_RUNNER }}
         run: echo "runner=${OVERRIDE:-$DEFAULT}" >> "$GITHUB_OUTPUT"
 
-  # Every pinned thing Dependabot can't see — the Flutter SDK (.fvmrc), the
-  # tools/binaries + zizmor/actionlint gate pins (tool/versions.env), plus the
-  # committed lockfiles. Pin compare + sha256 recompute live in
-  # tool/ci/upgrade.sh; the lockfiles refresh via `fvm dart pub upgrade`.
-  # One reviewed PR carries it all — full-test it before merge.
-  upgrade:
-    name: Pinned versions + lockfile upgrade
+  # Security-sensitive: the Flutter SDK pin (.fvmrc) + tool/versions.env (tool /
+  # binary pins, sha256s recomputed from upstream assets). Kept OFF the lockfile
+  # PR so a reviewer sees every hash change on its own, undiluted by lock churn.
+  pins:
+    name: Pinned versions
     needs: inputs
     runs-on: ${{ needs.inputs.outputs.runner }}
     permissions:
-      contents: write       # pushes the chore/upgrades branch
-      pull-requests: write  # opens / edits the upgrade PR
+      contents: write       # pushes the chore/pins branch
+      pull-requests: write  # opens / edits the pins PR
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: dev
           persist-credentials: false
 
-      - name: Prepare upgrade branch
+      # Tamper check FIRST: re-hash the already-pinned assets. A hash that moved
+      # while its version did NOT is an upstream repoint — fail, never bump.
+      - name: Verify pinned assets unchanged
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash tool/ci/upgrade.sh verify-pinned
+
+      - name: Prepare pins branch
         id: branch
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -75,25 +83,108 @@ jobs:
           # persist-credentials:false leaves the remote unauthenticated — wire
           # gh's token into git so the branch push below works.
           gh auth setup-git
-          gh label create upgrade --description "Auto: pinned version + lockfile bump" --color "1d76db" 2>/dev/null || true
-          EXISTING_PR=$(gh pr list --label upgrade --state open --json number --jq '.[0].number // empty')
+          gh label create upgrade-pins --description "Auto: pinned version bump (review the hashes)" --color "1d76db" 2>/dev/null || true
+          EXISTING_PR=$(gh pr list --label upgrade-pins --state open --json number --jq '.[0].number // empty')
           echo "existing_pr=$EXISTING_PR" >> "$GITHUB_OUTPUT"
           if [ -n "$EXISTING_PR" ]; then
-            git fetch origin chore/upgrades 2>/dev/null || true
-            git checkout -B chore/upgrades origin/chore/upgrades 2>/dev/null || git checkout -b chore/upgrades
+            git fetch origin chore/pins 2>/dev/null || true
+            git checkout -B chore/pins origin/chore/pins 2>/dev/null || git checkout -b chore/pins
           else
-            git checkout -b chore/upgrades
+            git checkout -b chore/pins
           fi
 
-      # Bump .fvmrc + tool/versions.env in place. Pure curl/sed/gh (no Dart), so
-      # it runs before the SDK is even set up.
+      # Bump .fvmrc + tool/versions.env in place. Pure curl/jq/sed/gh (no Dart,
+      # no SDK), so it runs before any SDK setup.
       - name: Bump pinned versions
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bash tool/ci/upgrade.sh apply
 
-      # Install the SDK pinned in the just-bumped .fvmrc, so the lock refresh
-      # below resolves against the version a fresh consumer would build on.
+      - name: Commit + open or update the pins PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EXISTING_PR: ${{ steps.branch.outputs.existing_pr }}
+        run: |
+          git add tool/versions.env ':(glob)**/.fvmrc'
+          git commit -m "chore: bump pinned versions" || {
+            echo "Pins already fresh — nothing to bump."
+            exit 0
+          }
+          if [ -n "$EXISTING_PR" ]; then
+            git push origin chore/pins
+          else
+            # Any remote copy is debris from a closed PR. Plain --force, not
+            # --force-with-lease: only the bot pushes this branch, and lease
+            # fails when there's no remote-tracking ref (fresh or post-merge).
+            git push --force origin chore/pins
+          fi
+
+          PR_BODY="$(cat <<'EOF'
+          Supply-chain pin bump — review the recomputed hashes in the diff:
+
+          - **Flutter SDK** (`.fvmrc`)
+          - **tools / binaries + the zizmor + actionlint gate pins** (`tool/versions.env`) —
+            sha256s recomputed from the upstream release assets, re-verified by
+            `fetch_verified` on every build
+
+          The already-pinned assets were re-hashed before this bump (repoint alarm).
+          Add `ready-to-test` for the full cross-target run, then merge once green.
+
+          _Auto-generated by upgrade-check.yml_
+          EOF
+          )"
+
+          if [ -z "$EXISTING_PR" ]; then
+            gh pr create \
+              --base dev \
+              --head chore/pins \
+              --title "chore: bump pinned versions" \
+              --label upgrade-pins \
+              --draft \
+              --body "$PR_BODY"
+          else
+            gh pr edit "$EXISTING_PR" \
+              --title "chore: bump pinned versions" \
+              --body "$PR_BODY"
+          fi
+
+  # Routine: pubspec.lock refreshed to the latest in-range, resolved against the
+  # SDK currently pinned on dev. Independent of the pins PR by design — an SDK
+  # bump rides pins and gets full-tested before it changes lock resolution.
+  lockfiles:
+    name: Lockfile refresh
+    needs: inputs
+    runs-on: ${{ needs.inputs.outputs.runner }}
+    permissions:
+      contents: write       # pushes the chore/lockfiles branch
+      pull-requests: write  # opens / edits the lockfiles PR
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: dev
+          persist-credentials: false
+
+      - name: Prepare lockfiles branch
+        id: branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          # persist-credentials:false leaves the remote unauthenticated — wire
+          # gh's token into git so the branch push below works.
+          gh auth setup-git
+          gh label create upgrade-locks --description "Auto: lockfile refresh" --color "1d76db" 2>/dev/null || true
+          EXISTING_PR=$(gh pr list --label upgrade-locks --state open --json number --jq '.[0].number // empty')
+          echo "existing_pr=$EXISTING_PR" >> "$GITHUB_OUTPUT"
+          if [ -n "$EXISTING_PR" ]; then
+            git fetch origin chore/lockfiles 2>/dev/null || true
+            git checkout -B chore/lockfiles origin/chore/lockfiles 2>/dev/null || git checkout -b chore/lockfiles
+          else
+            git checkout -b chore/lockfiles
+          fi
+
+      # Resolve against the SDK pinned on current dev — what a fresh consumer builds on.
       - uses: ./.github/actions/capabilities/fvm
 
       - name: Refresh lockfiles to latest in-range
@@ -101,39 +192,29 @@ jobs:
           fvm dart pub upgrade
           ( cd example && fvm dart pub upgrade )
 
-      - name: Commit + open or update the PR
+      - name: Commit + open or update the lockfiles PR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           EXISTING_PR: ${{ steps.branch.outputs.existing_pr }}
         run: |
-          # Glob so a new subpackage lockfile or .fvmrc is staged automatically.
-          # :(glob) is required — a bare **/pubspec.lock skips the repo-root file
-          # (its leading **/ needs a slash), which is the main lockfile.
-          git add tool/versions.env ':(glob)**/.fvmrc' ':(glob)**/pubspec.lock'
-          git commit -m "chore: bump pinned versions + refresh lockfiles" || {
-            echo "Everything already fresh — nothing to bump."
+          # Glob so a new subpackage lockfile is staged automatically. :(glob) is
+          # required — a bare **/pubspec.lock skips the repo-root file (its
+          # leading **/ needs a slash), which is the main lockfile.
+          git add ':(glob)**/pubspec.lock'
+          git commit -m "chore: refresh lockfiles" || {
+            echo "Lockfiles already fresh — nothing to bump."
             exit 0
           }
           if [ -n "$EXISTING_PR" ]; then
-            # Live PR branch — append only.
-            git push origin chore/upgrades
+            git push origin chore/lockfiles
           else
-            # Any remote copy here is debris from a closed PR. Plain --force,
-            # not --force-with-lease: nothing but the bot pushes this branch,
-            # and lease fails when there's no remote-tracking ref (a fresh
-            # branch, or one deleted after a merge).
-            git push --force origin chore/upgrades
+            git push --force origin chore/lockfiles
           fi
 
           PR_BODY="$(cat <<'EOF'
-          Automated refresh of everything Dependabot can't see:
+          Routine lockfile refresh to the latest in-range — what a fresh consumer resolves:
 
-          - **Flutter SDK** (`.fvmrc`)
-          - **tools / binaries + the zizmor + actionlint gate pins** (`tool/versions.env`) —
-            sha256s recomputed from the upstream release assets, re-verified by
-            `fetch_verified` on every build
-          - **lockfiles** (`pubspec.lock`, `example/pubspec.lock`) bumped to the
-            latest in-range — what a fresh consumer resolves
+          - **lockfiles** (`pubspec.lock`, `example/pubspec.lock`)
 
           Add `ready-to-test` for the full cross-target run, then merge once green.
 
@@ -144,14 +225,13 @@ jobs:
           if [ -z "$EXISTING_PR" ]; then
             gh pr create \
               --base dev \
-              --head chore/upgrades \
-              --title "chore: bump pinned versions + refresh lockfiles" \
-              --label upgrade \
+              --head chore/lockfiles \
+              --title "chore: refresh lockfiles" \
+              --label upgrade-locks \
               --draft \
               --body "$PR_BODY"
           else
             gh pr edit "$EXISTING_PR" \
-              --title "chore: bump pinned versions + refresh lockfiles" \
+              --title "chore: refresh lockfiles" \
               --body "$PR_BODY"
           fi
-

--- a/Makefile
+++ b/Makefile
@@ -79,24 +79,28 @@ lint-shell:
 fixtures:
 	$(DART) run tool/generate_fixtures.dart
 
+# Two static guards. Guard 1: tests run identically on VM and browser, so no
+# dart:io; a test that genuinely needs it carries an 'io-exempt: <reason>'
+# comment. Guard 2: content claims go through extract/search/render. Its
+# exclusions are always-fine idioms (sublist(0, 5) is the %PDF magic check,
+# isNot(contains ...)), not per-file opt-outs, so they stay positional;
+# bytegrep-exempt is the per-line opt-out, and pdf_builder_battery is excluded
+# whole rather than marked 15 times.
 test-guards:
-	@bad=$$(grep -rln "dart:io" test/ --include="*.dart" \
-	  | grep -v "test/harness/asset_server.dart" \
-	  | grep -v "test/ops/platform/native/" \
-	  | grep -v "test/io/file_source_test.dart" \
-	  | grep -v "test/io/file_sink_test.dart" \
-	  | grep -v "test/bridge/protocol/wire_sync_test.dart" \
-	  | grep -v "test/runtime/web/lane_worker_sync_test.dart" \
-	  | grep -v "test/runtime/dumb_edges_test.dart" || true); \
+	@bad=$$(for f in $$(grep -rln "dart:io" test/ --include="*.dart"); do \
+	  grep -q "io-exempt:" "$$f" || echo "$$f"; \
+	done); \
 	if [ -n "$$bad" ]; then \
-	  echo "dart:io in tests — tests must run identically on VM and"; \
-	  echo "browser; fixtures are imported Dart source, never file I/O:"; \
+	  echo "dart:io in a test. Tests run identically on VM and browser;"; \
+	  echo "fixtures are imported Dart source, never file I/O. A test that"; \
+	  echo "legitimately needs dart:io carries an 'io-exempt:' comment with"; \
+	  echo "the reason. Missing it:"; \
 	  echo "$$bad"; exit 1; fi
 	@bad=$$(grep -rn "String.fromCharCodes" test/ops/ --include="*.dart" \
 	  | grep -v "sublist(0, 5)" | grep -v "isNot(contains" | grep -v "bytegrep-exempt" \
 	  | grep -v "pdf_builder_battery.dart" || true); \
 	if [ -n "$$bad" ]; then \
-	  echo "byte-grep content assertion — content claims go through"; \
+	  echo "byte-grep content assertion: content claims go through"; \
 	  echo "extract/search/render, or carry a bytegrep-exempt marker"; \
 	  echo "with the reason:"; \
 	  echo "$$bad"; exit 1; fi

--- a/Makefile
+++ b/Makefile
@@ -113,9 +113,17 @@ build: build-native build-wasm
 
 # Triggers the build hook to compile the native binary for the
 # current host. Runs a non-existent test name so dart test starts
-# (invoking the hook) but no actual test executes.
+# (invoking the hook) but no actual test executes. A missing test
+# match and a build-hook compile failure both exit non-zero and the
+# tee pipe masks the code, so gate on the tooling's failure markers:
+# a broken native build must not pass silently.
 build-native:
-	$(DART) test test/ops/runners/native_runner_test.dart --concurrency=1 --name='DOES_NOT_EXIST' || true
+	@tmp=$$(mktemp); \
+	$(DART) test test/ops/runners/native_runner_test.dart --concurrency=1 --name='DOES_NOT_EXIST' 2>&1 | tee "$$tmp" || true; \
+	if grep -qE 'Building assets for package .* failed|returned with exit code|could not compile' "$$tmp"; then \
+		rm -f "$$tmp"; echo "build-native: native build hook failed (see output above)"; exit 1; \
+	fi; \
+	rm -f "$$tmp"
 
 build-wasm:
 	bash tool/compile_rust.sh wasm

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,7 +34,7 @@ These are conscious trade-offs, documented so they aren't mistaken for oversight
 
 - **`git:`-ref consumers fetch the engine at build time.** Depending on this package by git ref initializes the engine submodules from `whuppi/*`. The supply-chain trust is the same as any git dependency.
 
-- **Some pinned binary hashes are self-computed, not upstream-published.** FVM (leoafarias/fvm) and Chrome for Testing publish no digests, so their `tool/versions.env` sha256 pins come from the assets we first downloaded, not from an upstream source of truth. The pins still catch a later swap (a repointed tag, a CDN substitution), but the first download defines trust: had a release already been compromised when `upgrade.sh` first fetched it, the bad hash would simply be recorded. Inherent to the first-to-download problem; not closable without upstream digest publication.
+- **Some pinned binary hashes are self-computed, not upstream-published.** FVM (leoafarias/fvm) and Chrome for Testing publish no digests, so their `tool/versions.env` sha256 pins come from the assets we first downloaded, not from an upstream source of truth. The pins still catch a later swap (a repointed tag, a CDN substitution), and `upgrade.sh verify-pinned` re-hashes them on the daily radar while `check-availability` HEADs them on every PR, so a swap or prune surfaces before a build fails on it. But the first download still defines trust: had a release already been compromised when `upgrade.sh` first fetched it, the bad hash would simply be recorded. Inherent to the first-to-download problem; not closable without upstream digest publication.
 
 ## Response
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -616,8 +616,12 @@ user-facing text (README, pubspec).
    instructions on dev. `rustup target add` and `cargo install` are
    always safe (user-space). System packages auto-install only on CI.
 
-3. **Dart is never called from bash.** Bash reads `build.json` with
-   pure `sed`/`grep`. No python3, no jq, no dart.
+3. **jq is the JSON tool for bash; Dart is never invoked from bash.**
+   Bash reads `build.json` (and any JSON) through `lib.sh`'s jq-backed
+   accessor (`json_get`), never hand-rolled `sed`/`grep` field extraction;
+   `ensure_jq` guarantees jq is present. The native build hook
+   (`hook/build.dart`) reads `build.json` in Dart. Bash never shells out to
+   dart or python.
 
 4. **Capabilities, not layers.** Each CI concern is one action under
    `capabilities/`. No runner layer, no target layer — just

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -80,12 +80,13 @@ branch not currently checked out.
 `.fvmrc` (root + `example/.fvmrc`) is the single source of truth for
 the Flutter SDK version. Never hardcode the version anywhere else.
 
-`upgrade-check.yml` runs daily. Its `upgrade` job detects drift in every
-pinned version Dependabot can't see — the Flutter SDK, the tools and
-verified binaries in `tool/versions.env`, and the zizmor + actionlint gate
-pins — and opens a single draft PR on `chore/upgrades` that bumps them
-(binary sha256s recomputed from the upstream assets). Review, test, merge
-when ready.
+`upgrade-check.yml` runs daily and splits the work by risk into two draft
+PRs. The `pins` job re-hashes the current pins to catch a repoint, then bumps
+every pinned version Dependabot can't see (the Flutter SDK, the tools and
+verified binaries in `tool/versions.env`, the zizmor + actionlint gate pins,
+binary sha256s recomputed from the upstream assets) onto `chore/pins`. The
+`lockfiles` job refreshes `pubspec.lock` onto `chore/lockfiles`. Review, test,
+merge each when ready.
 
 ---
 

--- a/test/bridge/protocol/wire_sync_test.dart
+++ b/test/bridge/protocol/wire_sync_test.dart
@@ -12,6 +12,7 @@
 @TestOn('vm')
 library;
 
+// io-exempt: reads bridge_api.rs from disk to check Dart/Rust op parity.
 import 'dart:io';
 
 import 'package:pdf_manipulator/src/bridge/protocol/op.dart';

--- a/test/harness/asset_server.dart
+++ b/test/harness/asset_server.dart
@@ -8,6 +8,8 @@
 //   final channel = spawnHybridUri('/test/harness/asset_server.dart', stayAlive: true);
 //   final port = (await channel.stream.first as double).toInt();
 
+// io-exempt: hybrid-isolate harness; runs an HttpServer so chrome tests can
+// fetch web_assets/.
 import 'dart:io';
 
 import 'package:shelf/shelf.dart';

--- a/test/io/file_sink_test.dart
+++ b/test/io/file_sink_test.dart
@@ -1,5 +1,5 @@
-// FileSink — streams written chunks to a file on disk. Native only, so this
-// test needs `dart:io` (test-guards exempts it for that reason).
+// FileSink — streams written chunks to a file on disk.
+// io-exempt: native-only; this writes a real on-disk file.
 
 @TestOn('vm')
 library;

--- a/test/io/file_source_test.dart
+++ b/test/io/file_source_test.dart
@@ -1,5 +1,5 @@
-// FileSource — positioned reads over a file on disk. Native only, so this
-// test needs `dart:io` (test-guards exempts it for that reason).
+// FileSource — positioned reads over a file on disk.
+// io-exempt: native-only; this reads a real on-disk file.
 
 @TestOn('vm')
 library;

--- a/test/ops/platform/native/dispose_exit_payload.dart
+++ b/test/ops/platform/native/dispose_exit_payload.dart
@@ -7,6 +7,7 @@
 // FATAL-aborts ("Callback invoked after it has been deleted") instead
 // of exiting 0.
 
+// io-exempt: subprocess payload (sets exitCode) for the finalizer test.
 import 'dart:io';
 
 import 'package:pdf_manipulator/pdf_manipulator.dart';

--- a/test/ops/platform/native/native_finalizer_battery.dart
+++ b/test/ops/platform/native/native_finalizer_battery.dart
@@ -9,6 +9,7 @@
 // Subprocess because FATAL aborts the process — test harness can't
 // catch it. Same pattern as Dart SDK's own FFI callback tests.
 
+// io-exempt: spawns a subprocess (a FATAL abort can't be caught in-process).
 import 'dart:io';
 
 import 'package:test/test.dart';

--- a/test/runtime/dumb_edges_test.dart
+++ b/test/runtime/dumb_edges_test.dart
@@ -9,6 +9,7 @@
 @TestOn('vm')
 library;
 
+// io-exempt: reads adapter sources from disk to verify the lanes stay dumb.
 import 'dart:io';
 
 import 'package:test/test.dart';

--- a/test/runtime/web/lane_worker_sync_test.dart
+++ b/test/runtime/web/lane_worker_sync_test.dart
@@ -9,6 +9,7 @@
 @TestOn('vm')
 library;
 
+// io-exempt: reads lane_worker.js from disk to pin the web wire contract.
 import 'dart:io';
 
 import 'package:pdf_manipulator/src/runtime/web/lane_protocol.dart';

--- a/tool/ci/release.sh
+++ b/tool/ci/release.sh
@@ -139,6 +139,12 @@ git_ci_identity() {
   fi
 }
 
+# A changelog version is owner-written, but it flows into seds, awk programs,
+# and file paths, so a stray / or & would corrupt them. Accept only semver.
+valid_semver() {  # X.Y.Z with optional -prerelease and +build
+  printf '%s' "$1" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'
+}
+
 # Extract one version's entry (body only, heading excluded) from a
 # changelog file. The version is regex-escaped before matching.
 extract_entry() {
@@ -210,12 +216,19 @@ stamp_asset_hashes() {
   read -r -d '' jq_filter <<'JQ' || true
 .assets[]|select(.digest!=null and (.name|startswith("Source")|not))|"\(.name)\t\(.digest)"
 JQ
-  release_entries=$(gh api "repos/$REPO/releases/tags/$tag" --jq "$jq_filter" \
-    | sort | while IFS=$'\t' read -r name digest; do
-      hash="${digest#sha256:}"
-      echo "  '$name': '$hash',"
-      echo "  $name ... ${hash:0:12}..." >&2
-    done)
+  # Process substitution (not a `| while` subshell) so a bad digest can `return`
+  # and fail the whole function, and assert the algo so a non-sha256 digest
+  # fails loud instead of stamping a malformed hash.
+  local name digest
+  while IFS=$'\t' read -r name digest; do
+    [ -z "$name" ] && continue
+    case "$digest" in
+      sha256:*) : ;;
+      *) echo "::error::non-sha256 digest for $name: $digest" >&2; return 1 ;;
+    esac
+    release_entries+="  '$name': '${digest#sha256:}',"$'\n'
+    echo "  $name ... ${digest:7:12}..." >&2
+  done < <(gh api "repos/$REPO/releases/tags/$tag" --jq "$jq_filter" | sort)
 
   # Hand-written web assets — hash from the tag's web_assets/ directory.
   # Reads local filenames + asset names from build.json, skipping
@@ -252,8 +265,10 @@ JQ
   local end_marker="  // --- GENERATED HASHES END ---"
   local tmp
   tmp=$(mktemp)
-  awk -v start="$start_marker" -v end="$end_marker" -v entries="$all_entries" '
-    $0 == start { print; print entries; skip=1; next }
+  # entries via ENVIRON, not awk -v, which would interpret a backslash in a
+  # filename; the markers stay -v (fixed literals).
+  sah_entries="$all_entries" awk -v start="$start_marker" -v end="$end_marker" '
+    $0 == start { print; print ENVIRON["sah_entries"]; skip=1; next }
     $0 == end   { print; skip=0; next }
     !skip       { print }
   ' "$hash_file" > "$tmp"
@@ -495,8 +510,11 @@ cmd_gate() {
   fi
 
   local changed_files
-  if ! changed_files=$(git diff --name-only "${BEFORE:-}" "${AFTER:-HEAD}" 2>/dev/null); then
-    echo "Gate: git diff failed (force-push, new branch, or workflow_dispatch) — assuming $target_file changed"
+  if [ -z "${BEFORE:-}" ]; then
+    echo "Gate: no BEFORE (dispatch, force-push, or new branch); assuming $target_file changed"
+    changed_files="$target_file"
+  elif ! changed_files=$(git diff --name-only "$BEFORE" "${AFTER:-HEAD}" 2>/dev/null); then
+    echo "Gate: git diff failed; assuming $target_file changed"
     changed_files="$target_file"
   fi
 
@@ -568,9 +586,9 @@ cmd_discover() {
 
   local version
   version=$(get_changelog_versions "$file" | head -1 || true)
-  if [ -z "$version" ]; then
+  if [ -z "$version" ] || ! valid_semver "$version"; then
     gh_output "has_release" "false"
-    echo "No version heading in $file"
+    echo "No valid version heading in $file"
     return 0
   fi
 
@@ -619,7 +637,14 @@ cmd_discover() {
   fi
 
   if ! grep -q '^  - /vendor/\*\*$' pubspec.yaml; then
-    awk '/^false_secrets:/{print; print "  - /vendor/**"; next} 1' pubspec.yaml > pubspec.yaml.tmp && mv pubspec.yaml.tmp pubspec.yaml
+    if grep -q '^false_secrets:' pubspec.yaml; then
+      awk '/^false_secrets:/{print; print "  - /vendor/**"; next} 1' pubspec.yaml > pubspec.yaml.tmp
+    else
+      { cat pubspec.yaml; printf 'false_secrets:\n  - /vendor/**\n'; } > pubspec.yaml.tmp
+    fi
+    mv pubspec.yaml.tmp pubspec.yaml
+    grep -q '^  - /vendor/\*\*$' pubspec.yaml \
+      || { echo "::error::failed to add false_secrets /vendor/** to pubspec.yaml"; exit 1; }
     echo "  pubspec.yaml += false_secrets /vendor/**"
   fi
 
@@ -652,7 +677,7 @@ cmd_discover() {
     --target "$stamped_sha" \
     --title "$PKG_NAME $version" \
     --notes-file "$notes_file" \
-    "${flags[@]}"
+    "${flags[@]+"${flags[@]}"}"
   rm -f "$notes_file"
   echo "  Created release $tag at $stamped_sha"
 
@@ -901,6 +926,16 @@ cmd_check_versions() {
   local total=0
   if [ -n "$parsed" ]; then
     total=$(grep -c . <<< "$parsed")
+  fi
+  # The top heading is the release candidate that gets stamped; validate its
+  # shape here so a malformed version fails the PR, not the release.
+  if [ -n "$parsed" ]; then
+    local rc_ver
+    rc_ver=$(head -1 <<< "$parsed" | cut -f1)
+    if ! valid_semver "$rc_ver"; then
+      echo "✗ $file: top version '$rc_ver' is not valid semver" >&2
+      return 1
+    fi
   fi
   if [ "$total" -le 1 ]; then
     echo "✓ $file: $total version heading(s) — nothing below the top to check"

--- a/tool/ci/upgrade.sh
+++ b/tool/ci/upgrade.sh
@@ -35,8 +35,8 @@ source "$ROOT/tool/lib.sh"
 
 MODE="${1:-check}"
 case "$MODE" in
-  check|apply|verify-pinned) ;;
-  *) echo "usage: tool/ci/upgrade.sh [check|apply|verify-pinned]" >&2; exit 2 ;;
+  check|apply|verify-pinned|check-availability) ;;
+  *) echo "usage: tool/ci/upgrade.sh [check|apply|verify-pinned|check-availability]" >&2; exit 2 ;;
 esac
 
 ensure_jq
@@ -92,53 +92,83 @@ set_kv() {  # KEY value file — replace the KEY="old" line with KEY="new"
   fi
 }
 
-# Re-hash the currently-pinned assets to catch a same-version repoint, which
-# version-compare can't see. URL patterns mirror the bump blocks; keep in sync.
-_vp() {  # tool platform url want-sha
-  local got; got="$(sha256_of "$3")"
-  if [ -z "$got" ]; then
-    echo "verify-pinned: $1 $2 — asset fetch failed (skipped; a 404 is a prune, not a tamper)" >&2
-    return 0
-  fi
-  [ "$got" = "$4" ] && return 0
-  echo "::error::verify-pinned: $1 $2 REPOINT — pinned $4, now $got ($3)" >&2
+# Every pinned asset as tool<TAB>platform<TAB>url<TAB>sha256. Single source for
+# the checks below; mirrors the bump blocks, so keep the two in sync.
+asset_urls() {
+  local fu="https://github.com/leoafarias/fvm/releases/download/$FVM_VERSION"
+  printf 'fvm\tlinux-x64\t%s\t%s\n'   "$fu/fvm-$FVM_VERSION-linux-x64.tar.gz"   "$FVM_SHA256_LINUX_X64"
+  printf 'fvm\tmacos-arm64\t%s\t%s\n' "$fu/fvm-$FVM_VERSION-macos-arm64.tar.gz" "$FVM_SHA256_MACOS_ARM64"
+  printf 'fvm\tmacos-x64\t%s\t%s\n'   "$fu/fvm-$FVM_VERSION-macos-x64.tar.gz"   "$FVM_SHA256_MACOS_X64"
+  printf 'fvm\twindows-x64\t%s\t%s\n' "$fu/fvm-$FVM_VERSION-windows-x64.zip"    "$FVM_SHA256_WINDOWS_X64"
+  local bu="https://github.com/WebAssembly/binaryen/releases/download/$BINARYEN_VERSION"
+  printf 'binaryen\tlinux-x64\t%s\t%s\n'   "$bu/binaryen-$BINARYEN_VERSION-x86_64-linux.tar.gz"   "$BINARYEN_SHA256_LINUX_X64"
+  printf 'binaryen\tmacos-arm64\t%s\t%s\n' "$bu/binaryen-$BINARYEN_VERSION-arm64-macos.tar.gz"    "$BINARYEN_SHA256_MACOS_ARM64"
+  printf 'binaryen\twindows-x64\t%s\t%s\n' "$bu/binaryen-$BINARYEN_VERSION-x86_64-windows.tar.gz" "$BINARYEN_SHA256_WINDOWS_X64"
+  local ru="https://github.com/ekzhang/bore/releases/download/$BORE_VERSION"
+  printf 'bore\tlinux-x64\t%s\t%s\n'   "$ru/bore-$BORE_VERSION-x86_64-unknown-linux-musl.tar.gz" "$BORE_SHA256_LINUX_X64"
+  printf 'bore\tmacos-arm64\t%s\t%s\n' "$ru/bore-$BORE_VERSION-aarch64-apple-darwin.tar.gz"      "$BORE_SHA256_MACOS_ARM64"
+  printf 'bore\twindows-x64\t%s\t%s\n' "$ru/bore-$BORE_VERSION-x86_64-pc-windows-msvc.zip"       "$BORE_SHA256_WINDOWS_X64"
+  local cu="https://storage.googleapis.com/chrome-for-testing-public/$CHROME_VERSION"
+  printf 'chrome\tlinux-x64\t%s\t%s\n'   "$cu/linux64/chrome-linux64.zip"     "$CHROME_SHA256_LINUX_X64"
+  printf 'chrome\tmacos-arm64\t%s\t%s\n' "$cu/mac-arm64/chrome-mac-arm64.zip" "$CHROME_SHA256_MACOS_ARM64"
+  printf 'chrome\twindows-x64\t%s\t%s\n' "$cu/win64/chrome-win64.zip"         "$CHROME_SHA256_WINDOWS_X64"
+  printf 'chromedriver\tlinux-x64\t%s\t%s\n'   "$cu/linux64/chromedriver-linux64.zip"     "$CHROMEDRIVER_SHA256_LINUX_X64"
+  printf 'chromedriver\tmacos-arm64\t%s\t%s\n' "$cu/mac-arm64/chromedriver-mac-arm64.zip" "$CHROMEDRIVER_SHA256_MACOS_ARM64"
+  printf 'chromedriver\twindows-x64\t%s\t%s\n' "$cu/win64/chromedriver-win64.zip"         "$CHROMEDRIVER_SHA256_WINDOWS_X64"
+}
+
+# HTTP status of a URL, following GitHub's asset redirect, or 000 if unreachable.
+# Always exits 0 so a caller's $(...) never trips set -e.
+http_status() {  # url -> code
+  local code
+  code="$(curl -sS -o /dev/null -IL --connect-timeout 10 --retry 2 --retry-delay 2 \
+          --max-redirs 5 -w '%{http_code}' "$1" 2>/dev/null || true)"
+  printf '%s' "${code:-000}"
+}
+
+# Daily integrity: a 404/410 means the pin was pruned, a 200 with a changed hash
+# means a same-version repoint. A transient code warns rather than failing.
+verify_pinned() {
+  local t=0 tool plat url want code got
+  while IFS=$'\t' read -r tool plat url want; do
+    code="$(http_status "$url")"
+    case "$code" in
+      404|410) echo "::error::verify-pinned: $tool $plat pruned upstream ($code), re-pin: $url" >&2; t=1; continue ;;
+      200) ;;
+      *) echo "::warning::verify-pinned: $tool $plat HEAD returned $code (transient?): $url" >&2; continue ;;
+    esac
+    got="$(sha256_of "$url")"
+    if [ -z "$got" ]; then
+      echo "::warning::verify-pinned: $tool $plat 200 but empty body (transient?): $url" >&2
+    elif [ "$got" != "$want" ]; then
+      echo "::error::verify-pinned: $tool $plat REPOINT, pinned $want now $got: $url" >&2; t=1
+    fi
+  done < <(asset_urls)
+  [ "$t" -eq 0 ] && { echo "verify-pinned: all pinned assets present and matching."; return 0; }
+  echo "::error::verify-pinned: a pinned asset is gone or changed; do NOT bump, investigate" >&2
   return 1
 }
 
-verify_pinned() {
-  local t=0
-  local fu="https://github.com/leoafarias/fvm/releases/download/$FVM_VERSION"
-  _vp fvm linux-x64   "$fu/fvm-$FVM_VERSION-linux-x64.tar.gz"   "$FVM_SHA256_LINUX_X64"   || t=1
-  _vp fvm macos-arm64 "$fu/fvm-$FVM_VERSION-macos-arm64.tar.gz" "$FVM_SHA256_MACOS_ARM64" || t=1
-  _vp fvm macos-x64   "$fu/fvm-$FVM_VERSION-macos-x64.tar.gz"   "$FVM_SHA256_MACOS_X64"   || t=1
-  _vp fvm windows-x64 "$fu/fvm-$FVM_VERSION-windows-x64.zip"    "$FVM_SHA256_WINDOWS_X64" || t=1
-  local bu="https://github.com/WebAssembly/binaryen/releases/download/$BINARYEN_VERSION"
-  _vp binaryen linux-x64   "$bu/binaryen-$BINARYEN_VERSION-x86_64-linux.tar.gz"   "$BINARYEN_SHA256_LINUX_X64"   || t=1
-  _vp binaryen macos-arm64 "$bu/binaryen-$BINARYEN_VERSION-arm64-macos.tar.gz"    "$BINARYEN_SHA256_MACOS_ARM64" || t=1
-  _vp binaryen windows-x64 "$bu/binaryen-$BINARYEN_VERSION-x86_64-windows.tar.gz" "$BINARYEN_SHA256_WINDOWS_X64" || t=1
-  local ru="https://github.com/ekzhang/bore/releases/download/$BORE_VERSION"
-  _vp bore linux-x64   "$ru/bore-$BORE_VERSION-x86_64-unknown-linux-musl.tar.gz" "$BORE_SHA256_LINUX_X64"   || t=1
-  _vp bore macos-arm64 "$ru/bore-$BORE_VERSION-aarch64-apple-darwin.tar.gz"      "$BORE_SHA256_MACOS_ARM64" || t=1
-  _vp bore windows-x64 "$ru/bore-$BORE_VERSION-x86_64-pc-windows-msvc.zip"       "$BORE_SHA256_WINDOWS_X64" || t=1
-  local cu="https://storage.googleapis.com/chrome-for-testing-public/$CHROME_VERSION"
-  _vp chrome linux-x64   "$cu/linux64/chrome-linux64.zip"     "$CHROME_SHA256_LINUX_X64"   || t=1
-  _vp chrome macos-arm64 "$cu/mac-arm64/chrome-mac-arm64.zip" "$CHROME_SHA256_MACOS_ARM64" || t=1
-  _vp chrome windows-x64 "$cu/win64/chrome-win64.zip"         "$CHROME_SHA256_WINDOWS_X64" || t=1
-  _vp chromedriver linux-x64   "$cu/linux64/chromedriver-linux64.zip"     "$CHROMEDRIVER_SHA256_LINUX_X64"   || t=1
-  _vp chromedriver macos-arm64 "$cu/mac-arm64/chromedriver-mac-arm64.zip" "$CHROMEDRIVER_SHA256_MACOS_ARM64" || t=1
-  _vp chromedriver windows-x64 "$cu/win64/chromedriver-win64.zip"         "$CHROMEDRIVER_SHA256_WINDOWS_X64" || t=1
-  if [ "$t" -ne 0 ]; then
-    echo "::error::verify-pinned: a pinned asset changed under a fixed version — possible upstream repoint; do NOT bump, investigate" >&2
-    return 1
-  fi
-  echo "verify-pinned: all pinned assets still match their sha256."
+# PR hot-path existence check, HEAD only (no download or hash). Fails on a
+# definitive 404/410, warns on transient. Runs on PR activity, so a disabled
+# daily cron can't hide a pruned pin until the build breaks.
+check_availability() {
+  local bad=0 tool plat url _sha code
+  while IFS=$'\t' read -r tool plat url _sha; do
+    code="$(http_status "$url")"
+    case "$code" in
+      200) ;;
+      404|410) echo "::error::pin unavailable: $tool $plat gone upstream ($code): $url" >&2; bad=1 ;;
+      *) echo "::warning::pin check: $tool $plat HEAD returned $code (transient?): $url" >&2 ;;
+    esac
+  done < <(asset_urls)
+  [ "$bad" -eq 0 ] && echo "check-availability: all pinned assets reachable."
+  return "$bad"
 }
 
-# verify-pinned runs only the tamper check (no drift scan), then exits.
-if [ "$MODE" = verify-pinned ]; then
-  verify_pinned && exit 0
-  exit 1
-fi
+# Each check runs alone, then exits.
+if [ "$MODE" = verify-pinned ]; then verify_pinned && exit 0; exit 1; fi
+if [ "$MODE" = check-availability ]; then check_availability && exit 0; exit 1; fi
 
 # ── Flutter SDK (.fvmrc + example/.fvmrc) ────────────────────────────
 flutter_cur="$(json_get '.flutter' "$ROOT/.fvmrc")"

--- a/tool/ci/upgrade.sh
+++ b/tool/ci/upgrade.sh
@@ -42,8 +42,8 @@ esac
 ensure_jq
 
 drift=0
-blocked=0   # set when a bump is available but its asset fetch failed; the run
-            # then fails loud at the end instead of exiting 0 into the void.
+blocked=0   # a bump whose asset fetch failed sets this; the run then exits
+            # nonzero at the end instead of passing silently.
 
 gh_latest_tag() {  # owner/repo -> latest release tag, verbatim
   gh api "repos/$1/releases/latest" --jq '.tag_name' 2>/dev/null || true
@@ -65,13 +65,9 @@ sha256_of() {  # url
 }
 
 set_kv() {  # KEY value file — replace the KEY="old" line with KEY="new"
-  # versions.env is SOURCED (executed) by every consumer, so a value is only
-  # safe to persist if its SHAPE is known. Validate before writing: a version is
-  # [A-Za-z0-9._+-]+, a sha256 is 64 lowercase hex. This is what keeps the file
-  # safe as a sourced KEY="value" format — a malformed upstream string (say one
-  # carrying a quote) can be neither written nor, therefore, executed on the next
-  # source. A jq-read versions.json would also close this, at the cost of
-  # rewriting every consumer; the shape-gate closes the actual hole without it.
+  # versions.env is sourced, so a value is executed on read. Validate the shape
+  # before writing (version or 64-hex sha) so a malformed upstream string can't
+  # be persisted and run.
   case "$1" in
     *SHA256*)  printf '%s' "$2" | grep -qE '^[0-9a-f]{64}$' \
                  || { echo "set_kv: refusing non-sha256 for $1: '$2'" >&2; return 1; } ;;
@@ -96,11 +92,8 @@ set_kv() {  # KEY value file — replace the KEY="old" line with KEY="new"
   fi
 }
 
-# ── verify-pinned: re-hash the CURRENTLY-pinned assets and compare to the
-# stored sha256. A hash that changed while the VERSION did NOT means the
-# upstream asset was swapped under a fixed tag (a repoint) — the one supply-
-# chain attack that version-compare and set_kv's shape-check are both blind to.
-# URL patterns mirror the bump blocks below; keep the two in sync.
+# Re-hash the currently-pinned assets to catch a same-version repoint, which
+# version-compare can't see. URL patterns mirror the bump blocks; keep in sync.
 _vp() {  # tool platform url want-sha
   local got; got="$(sha256_of "$3")"
   if [ -z "$got" ]; then
@@ -152,10 +145,8 @@ flutter_cur="$(json_get '.flutter' "$ROOT/.fvmrc")"
 releases="$(_fetch https://storage.googleapis.com/flutter_infra_release/releases/releases_linux.json 2>/dev/null || true)"
 stable_hash="$(jq -r '.current_release.stable // empty' <<< "$releases" 2>/dev/null || true)"
 flutter_latest="$(jq -r --arg h "$stable_hash" '.releases[] | select(.hash == $h) | .version // empty' <<< "$releases" 2>/dev/null | head -1 || true)"
-# Second injection sink, independent of set_kv: flutter_latest flows raw into
-# the sed below. On GNU sed (the ubuntu runner) a value carrying a slash then an
-# `e` command would run a shell command, not just corrupt the file. Stable
-# Flutter versions are plain X.Y.Z, so refuse anything that is not exact semver.
+# flutter_latest is interpolated into the sed below, bypassing set_kv. Keep the
+# exact-semver gate or a crafted upstream value becomes sed injection.
 if [ -n "$flutter_latest" ] && ! printf '%s' "$flutter_latest" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
   echo "::error::refuse: implausible flutter version from upstream: '$flutter_latest'" >&2
   exit 1
@@ -260,10 +251,6 @@ fi
 # chrome-for-testing publishes no digests, so each bump re-downloads and
 # self-hashes all 6 assets. The CDN prunes old versions, so this must keep
 # the pin fresh or the chrome action's verified download 404s.
-# We deliberately do NOT mirror these assets to our own release: re-hosting
-# hundreds of MB per bump plus a new upload failure mode is a sledgehammer for
-# CDN pruning that a daily bump + verify-pinned already cover. Freshness rides
-# this radar, not a parallel mirror.
 manifest="$(_fetch https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json 2>/dev/null || true)"
 chrome_latest="$(jq -r '.channels.Stable.version // empty' <<< "$manifest" 2>/dev/null || true)"
 if [ -n "$chrome_latest" ] && [ "$chrome_latest" != "$CHROME_VERSION" ]; then

--- a/tool/ci/upgrade.sh
+++ b/tool/ci/upgrade.sh
@@ -35,13 +35,15 @@ source "$ROOT/tool/lib.sh"
 
 MODE="${1:-check}"
 case "$MODE" in
-  check|apply) ;;
-  *) echo "usage: tool/ci/upgrade.sh [check|apply]" >&2; exit 2 ;;
+  check|apply|verify-pinned) ;;
+  *) echo "usage: tool/ci/upgrade.sh [check|apply|verify-pinned]" >&2; exit 2 ;;
 esac
 
 ensure_jq
 
 drift=0
+blocked=0   # set when a bump is available but its asset fetch failed; the run
+            # then fails loud at the end instead of exiting 0 into the void.
 
 gh_latest_tag() {  # owner/repo -> latest release tag, verbatim
   gh api "repos/$1/releases/latest" --jq '.tag_name' 2>/dev/null || true
@@ -63,6 +65,20 @@ sha256_of() {  # url
 }
 
 set_kv() {  # KEY value file — replace the KEY="old" line with KEY="new"
+  # versions.env is SOURCED (executed) by every consumer, so a value is only
+  # safe to persist if its SHAPE is known. Validate before writing: a version is
+  # [A-Za-z0-9._+-]+, a sha256 is 64 lowercase hex. This is what keeps the file
+  # safe as a sourced KEY="value" format — a malformed upstream string (say one
+  # carrying a quote) can be neither written nor, therefore, executed on the next
+  # source. A jq-read versions.json would also close this, at the cost of
+  # rewriting every consumer; the shape-gate closes the actual hole without it.
+  case "$1" in
+    *SHA256*)  printf '%s' "$2" | grep -qE '^[0-9a-f]{64}$' \
+                 || { echo "set_kv: refusing non-sha256 for $1: '$2'" >&2; return 1; } ;;
+    *VERSION*) printf '%s' "$2" | grep -qE '^[A-Za-z0-9._+-]+$' \
+                 || { echo "set_kv: refusing malformed version for $1: '$2'" >&2; return 1; } ;;
+    *)         echo "set_kv: unknown key shape '$1' (expect *_VERSION or *_SHA256_*)" >&2; return 1 ;;
+  esac
   # The value travels via the environment — not a sed replacement, not awk -v —
   # so a |, &, or backslash in it stays literal data (sed's replacement string
   # and awk's -v both interpret those). tmp+mv leaves the file intact if awk
@@ -79,6 +95,57 @@ set_kv() {  # KEY value file — replace the KEY="old" line with KEY="new"
     return 1
   fi
 }
+
+# ── verify-pinned: re-hash the CURRENTLY-pinned assets and compare to the
+# stored sha256. A hash that changed while the VERSION did NOT means the
+# upstream asset was swapped under a fixed tag (a repoint) — the one supply-
+# chain attack that version-compare and set_kv's shape-check are both blind to.
+# URL patterns mirror the bump blocks below; keep the two in sync.
+_vp() {  # tool platform url want-sha
+  local got; got="$(sha256_of "$3")"
+  if [ -z "$got" ]; then
+    echo "verify-pinned: $1 $2 — asset fetch failed (skipped; a 404 is a prune, not a tamper)" >&2
+    return 0
+  fi
+  [ "$got" = "$4" ] && return 0
+  echo "::error::verify-pinned: $1 $2 REPOINT — pinned $4, now $got ($3)" >&2
+  return 1
+}
+
+verify_pinned() {
+  local t=0
+  local fu="https://github.com/leoafarias/fvm/releases/download/$FVM_VERSION"
+  _vp fvm linux-x64   "$fu/fvm-$FVM_VERSION-linux-x64.tar.gz"   "$FVM_SHA256_LINUX_X64"   || t=1
+  _vp fvm macos-arm64 "$fu/fvm-$FVM_VERSION-macos-arm64.tar.gz" "$FVM_SHA256_MACOS_ARM64" || t=1
+  _vp fvm macos-x64   "$fu/fvm-$FVM_VERSION-macos-x64.tar.gz"   "$FVM_SHA256_MACOS_X64"   || t=1
+  _vp fvm windows-x64 "$fu/fvm-$FVM_VERSION-windows-x64.zip"    "$FVM_SHA256_WINDOWS_X64" || t=1
+  local bu="https://github.com/WebAssembly/binaryen/releases/download/$BINARYEN_VERSION"
+  _vp binaryen linux-x64   "$bu/binaryen-$BINARYEN_VERSION-x86_64-linux.tar.gz"   "$BINARYEN_SHA256_LINUX_X64"   || t=1
+  _vp binaryen macos-arm64 "$bu/binaryen-$BINARYEN_VERSION-arm64-macos.tar.gz"    "$BINARYEN_SHA256_MACOS_ARM64" || t=1
+  _vp binaryen windows-x64 "$bu/binaryen-$BINARYEN_VERSION-x86_64-windows.tar.gz" "$BINARYEN_SHA256_WINDOWS_X64" || t=1
+  local ru="https://github.com/ekzhang/bore/releases/download/$BORE_VERSION"
+  _vp bore linux-x64   "$ru/bore-$BORE_VERSION-x86_64-unknown-linux-musl.tar.gz" "$BORE_SHA256_LINUX_X64"   || t=1
+  _vp bore macos-arm64 "$ru/bore-$BORE_VERSION-aarch64-apple-darwin.tar.gz"      "$BORE_SHA256_MACOS_ARM64" || t=1
+  _vp bore windows-x64 "$ru/bore-$BORE_VERSION-x86_64-pc-windows-msvc.zip"       "$BORE_SHA256_WINDOWS_X64" || t=1
+  local cu="https://storage.googleapis.com/chrome-for-testing-public/$CHROME_VERSION"
+  _vp chrome linux-x64   "$cu/linux64/chrome-linux64.zip"     "$CHROME_SHA256_LINUX_X64"   || t=1
+  _vp chrome macos-arm64 "$cu/mac-arm64/chrome-mac-arm64.zip" "$CHROME_SHA256_MACOS_ARM64" || t=1
+  _vp chrome windows-x64 "$cu/win64/chrome-win64.zip"         "$CHROME_SHA256_WINDOWS_X64" || t=1
+  _vp chromedriver linux-x64   "$cu/linux64/chromedriver-linux64.zip"     "$CHROMEDRIVER_SHA256_LINUX_X64"   || t=1
+  _vp chromedriver macos-arm64 "$cu/mac-arm64/chromedriver-mac-arm64.zip" "$CHROMEDRIVER_SHA256_MACOS_ARM64" || t=1
+  _vp chromedriver windows-x64 "$cu/win64/chromedriver-win64.zip"         "$CHROMEDRIVER_SHA256_WINDOWS_X64" || t=1
+  if [ "$t" -ne 0 ]; then
+    echo "::error::verify-pinned: a pinned asset changed under a fixed version — possible upstream repoint; do NOT bump, investigate" >&2
+    return 1
+  fi
+  echo "verify-pinned: all pinned assets still match their sha256."
+}
+
+# verify-pinned runs only the tamper check (no drift scan), then exits.
+if [ "$MODE" = verify-pinned ]; then
+  verify_pinned && exit 0
+  exit 1
+fi
 
 # ── Flutter SDK (.fvmrc + example/.fvmrc) ────────────────────────────
 flutter_cur="$(json_get '.flutter' "$ROOT/.fvmrc")"
@@ -112,7 +179,7 @@ if [ -n "$fvm_latest" ] && [ "$fvm_latest" != "$FVM_VERSION" ]; then
       set_kv FVM_SHA256_MACOS_X64 "$mx" "$VERSIONS"
       set_kv FVM_SHA256_WINDOWS_X64 "$win" "$VERSIONS"
     else
-      echo "fvm: $fvm_latest available but an asset download failed — bump by hand"
+      echo "::error::fvm: $fvm_latest available but an asset download failed — bump by hand"; blocked=1
     fi
   else
     drift=1; echo "fvm: $FVM_VERSION -> $fvm_latest (apply fetches + verifies 4 sha256)"
@@ -152,7 +219,7 @@ if [ -n "$bin_latest" ] && [ "$bin_latest" != "$BINARYEN_VERSION" ]; then
       set_kv BINARYEN_SHA256_MACOS_ARM64 "$mac" "$VERSIONS"
       set_kv BINARYEN_SHA256_WINDOWS_X64 "$win" "$VERSIONS"
     else
-      echo "binaryen: $bin_latest available but an asset download failed — bump by hand"
+      echo "::error::binaryen: $bin_latest available but an asset download failed — bump by hand"; blocked=1
     fi
   else
     drift=1; echo "binaryen: $BINARYEN_VERSION -> $bin_latest (apply fetches + verifies 3 sha256)"
@@ -174,7 +241,7 @@ if [ -n "$bore_latest" ] && [ "$bore_latest" != "$BORE_VERSION" ]; then
       set_kv BORE_SHA256_MACOS_ARM64 "$mac" "$VERSIONS"
       set_kv BORE_SHA256_WINDOWS_X64 "$win" "$VERSIONS"
     else
-      echo "bore: $bore_latest available but an asset download failed — bump by hand"
+      echo "::error::bore: $bore_latest available but an asset download failed — bump by hand"; blocked=1
     fi
   else
     drift=1; echo "bore: $BORE_VERSION -> $bore_latest (apply fetches + verifies 3 sha256)"
@@ -185,6 +252,10 @@ fi
 # chrome-for-testing publishes no digests, so each bump re-downloads and
 # self-hashes all 6 assets. The CDN prunes old versions, so this must keep
 # the pin fresh or the chrome action's verified download 404s.
+# We deliberately do NOT mirror these assets to our own release: re-hosting
+# hundreds of MB per bump plus a new upload failure mode is a sledgehammer for
+# CDN pruning that a daily bump + verify-pinned already cover. Freshness rides
+# this radar, not a parallel mirror.
 manifest="$(_fetch https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json 2>/dev/null || true)"
 chrome_latest="$(jq -r '.channels.Stable.version // empty' <<< "$manifest" 2>/dev/null || true)"
 if [ -n "$chrome_latest" ] && [ "$chrome_latest" != "$CHROME_VERSION" ]; then
@@ -203,7 +274,7 @@ if [ -n "$chrome_latest" ] && [ "$chrome_latest" != "$CHROME_VERSION" ]; then
       set_kv CHROMEDRIVER_SHA256_MACOS_ARM64 "$dm" "$VERSIONS"
       set_kv CHROMEDRIVER_SHA256_WINDOWS_X64 "$dw" "$VERSIONS"
     else
-      echo "chrome: $chrome_latest available but an asset download failed — bump by hand"
+      echo "::error::chrome: $chrome_latest available but an asset download failed — bump by hand"; blocked=1
     fi
   else
     drift=1; echo "chrome: $CHROME_VERSION -> $chrome_latest (apply fetches + verifies 6 sha256)"
@@ -211,4 +282,8 @@ if [ -n "$chrome_latest" ] && [ "$chrome_latest" != "$CHROME_VERSION" ]; then
 fi
 
 [ "$drift" -eq 0 ] && echo "All watched pins are current."
+if [ "$blocked" -ne 0 ]; then
+  echo "::error::one or more pins are blocked (upstream had a new version but its asset fetch failed); fix by hand" >&2
+  exit 1
+fi
 exit 0

--- a/tool/ci/upgrade.sh
+++ b/tool/ci/upgrade.sh
@@ -152,6 +152,14 @@ flutter_cur="$(json_get '.flutter' "$ROOT/.fvmrc")"
 releases="$(_fetch https://storage.googleapis.com/flutter_infra_release/releases/releases_linux.json 2>/dev/null || true)"
 stable_hash="$(jq -r '.current_release.stable // empty' <<< "$releases" 2>/dev/null || true)"
 flutter_latest="$(jq -r --arg h "$stable_hash" '.releases[] | select(.hash == $h) | .version // empty' <<< "$releases" 2>/dev/null | head -1 || true)"
+# Second injection sink, independent of set_kv: flutter_latest flows raw into
+# the sed below. On GNU sed (the ubuntu runner) a value carrying a slash then an
+# `e` command would run a shell command, not just corrupt the file. Stable
+# Flutter versions are plain X.Y.Z, so refuse anything that is not exact semver.
+if [ -n "$flutter_latest" ] && ! printf '%s' "$flutter_latest" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+  echo "::error::refuse: implausible flutter version from upstream: '$flutter_latest'" >&2
+  exit 1
+fi
 if [ -n "$flutter_latest" ] && [ -n "$flutter_cur" ] && [ "$flutter_cur" != "$flutter_latest" ]; then
   drift=1
   echo "flutter: $flutter_cur -> $flutter_latest"

--- a/tool/ci/upgrade.sh
+++ b/tool/ci/upgrade.sh
@@ -210,7 +210,7 @@ if [ -n "$fvm_latest" ] && [ "$fvm_latest" != "$FVM_VERSION" ]; then
       set_kv FVM_SHA256_MACOS_X64 "$mx" "$VERSIONS"
       set_kv FVM_SHA256_WINDOWS_X64 "$win" "$VERSIONS"
     else
-      echo "::error::fvm: $fvm_latest available but an asset download failed — bump by hand"; blocked=1
+      echo "::error::fvm: $fvm_latest available but an asset download failed; bump by hand"; blocked=1
     fi
   else
     drift=1; echo "fvm: $FVM_VERSION -> $fvm_latest (apply fetches + verifies 4 sha256)"
@@ -250,7 +250,7 @@ if [ -n "$bin_latest" ] && [ "$bin_latest" != "$BINARYEN_VERSION" ]; then
       set_kv BINARYEN_SHA256_MACOS_ARM64 "$mac" "$VERSIONS"
       set_kv BINARYEN_SHA256_WINDOWS_X64 "$win" "$VERSIONS"
     else
-      echo "::error::binaryen: $bin_latest available but an asset download failed — bump by hand"; blocked=1
+      echo "::error::binaryen: $bin_latest available but an asset download failed; bump by hand"; blocked=1
     fi
   else
     drift=1; echo "binaryen: $BINARYEN_VERSION -> $bin_latest (apply fetches + verifies 3 sha256)"
@@ -272,7 +272,7 @@ if [ -n "$bore_latest" ] && [ "$bore_latest" != "$BORE_VERSION" ]; then
       set_kv BORE_SHA256_MACOS_ARM64 "$mac" "$VERSIONS"
       set_kv BORE_SHA256_WINDOWS_X64 "$win" "$VERSIONS"
     else
-      echo "::error::bore: $bore_latest available but an asset download failed — bump by hand"; blocked=1
+      echo "::error::bore: $bore_latest available but an asset download failed; bump by hand"; blocked=1
     fi
   else
     drift=1; echo "bore: $BORE_VERSION -> $bore_latest (apply fetches + verifies 3 sha256)"
@@ -301,7 +301,7 @@ if [ -n "$chrome_latest" ] && [ "$chrome_latest" != "$CHROME_VERSION" ]; then
       set_kv CHROMEDRIVER_SHA256_MACOS_ARM64 "$dm" "$VERSIONS"
       set_kv CHROMEDRIVER_SHA256_WINDOWS_X64 "$dw" "$VERSIONS"
     else
-      echo "::error::chrome: $chrome_latest available but an asset download failed — bump by hand"; blocked=1
+      echo "::error::chrome: $chrome_latest available but an asset download failed; bump by hand"; blocked=1
     fi
   else
     drift=1; echo "chrome: $CHROME_VERSION -> $chrome_latest (apply fetches + verifies 6 sha256)"

--- a/tool/ci/upgrade.sh
+++ b/tool/ci/upgrade.sh
@@ -23,8 +23,10 @@ set -euo pipefail
 # ensure_jq + jq for curl'd manifests. In-place version bumps stay targeted
 # sed (to preserve each file's formatting). No python, no dart.
 #
-# Usage:  tool/ci/upgrade.sh check   # report drift, write nothing
-#         tool/ci/upgrade.sh apply   # rewrite the pinned files in place
+# Usage:  tool/ci/upgrade.sh check              # report drift, write nothing
+#         tool/ci/upgrade.sh apply              # rewrite the pinned files in place
+#         tool/ci/upgrade.sh verify-pinned      # re-hash the pins, flag a repoint
+#         tool/ci/upgrade.sh check-availability # HEAD the pins, flag a prune
 
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"  # tool/ci/ → repo root
 VERSIONS="$ROOT/tool/versions.env"

--- a/tool/commit-types.txt
+++ b/tool/commit-types.txt
@@ -1,0 +1,10 @@
+feat
+fix
+docs
+chore
+ci
+test
+refactor
+perf
+build
+deps

--- a/tool/fetch_verified.sh
+++ b/tool/fetch_verified.sh
@@ -23,18 +23,16 @@ DEST="${3:?usage: fetch_verified.sh <url> <sha256> <dest>}"
 # not a usage error — a missing pin is the exact case to refuse loudly.
 WANT="${2-}"
 WANT="${WANT#sha256:}"
-# Normalize, then accept ONLY exactly 64 lowercase hex. An allowlist beats a
-# blocklist of known placeholders: one rule fails closed on every malformed pin
-# at once — empty, TODO, a truncated digest, an uppercase value, stray space.
+# Accept only exactly 64 lowercase hex; one rule fails closed on every other
+# shape (empty, TODO, truncated, uppercase, whitespace).
 WANT="$(printf '%s' "$WANT" | tr 'A-Z' 'a-z' | tr -d '[:space:]')"
 if ! printf '%s' "$WANT" | grep -qE '^[0-9a-f]{64}$'; then
   echo "refusing to download $URL — pin is not a 64-char sha256 (fail-closed)." >&2
   exit 2
 fi
 
-# Bound on PROGRESS, not total wall-clock: abort only on a genuine stall
-# (under 2KB/s for 30s), so a large asset on a slow-but-moving link still
-# finishes. --max-time stays as a generous backstop against a truly hung pipe.
+# Bound on stall (under 2KB/s for 30s), not total time, so a large asset on a
+# slow link still finishes; --max-time is the backstop for a hung pipe.
 curl -sSL --fail --retry 3 --retry-delay 2 --max-redirs 5 --connect-timeout 10 \
      --speed-limit 2048 --speed-time 30 --max-time 1800 "$URL" -o "$DEST" \
   || { echo "download failed or stalled: $URL" >&2; exit 1; }

--- a/tool/fetch_verified.sh
+++ b/tool/fetch_verified.sh
@@ -23,16 +23,21 @@ DEST="${3:?usage: fetch_verified.sh <url> <sha256> <dest>}"
 # not a usage error — a missing pin is the exact case to refuse loudly.
 WANT="${2-}"
 WANT="${WANT#sha256:}"
+# Normalize, then accept ONLY exactly 64 lowercase hex. An allowlist beats a
+# blocklist of known placeholders: one rule fails closed on every malformed pin
+# at once — empty, TODO, a truncated digest, an uppercase value, stray space.
+WANT="$(printf '%s' "$WANT" | tr 'A-Z' 'a-z' | tr -d '[:space:]')"
+if ! printf '%s' "$WANT" | grep -qE '^[0-9a-f]{64}$'; then
+  echo "refusing to download $URL — pin is not a 64-char sha256 (fail-closed)." >&2
+  exit 2
+fi
 
-case "$WANT" in
-  ""|"TODO"|"unknown"|"none")
-    echo "refusing to download $URL — no pinned sha256 (fail-closed)." >&2
-    exit 2
-    ;;
-esac
-
-curl -sSL --fail --retry 3 --retry-delay 2 --max-redirs 5 --connect-timeout 10 --max-time 180 "$URL" -o "$DEST" \
-  || { echo "download failed: $URL" >&2; exit 1; }
+# Bound on PROGRESS, not total wall-clock: abort only on a genuine stall
+# (under 2KB/s for 30s), so a large asset on a slow-but-moving link still
+# finishes. --max-time stays as a generous backstop against a truly hung pipe.
+curl -sSL --fail --retry 3 --retry-delay 2 --max-redirs 5 --connect-timeout 10 \
+     --speed-limit 2048 --speed-time 30 --max-time 1800 "$URL" -o "$DEST" \
+  || { echo "download failed or stalled: $URL" >&2; exit 1; }
 
 # Feed the file on stdin, never as a path argument: GNU coreutils (and Perl
 # shasum) escape the output line — a backslash before the digest — when the

--- a/tool/lint_shell.sh
+++ b/tool/lint_shell.sh
@@ -98,11 +98,6 @@ if ! command -v yq >/dev/null 2>&1; then
   skip_note yq "brew install yq / snap install yq (mikefarah Go build) / choco install yq"
 else
   nonbash=0
-  # Exact-match on the resolved shell, deliberately: no run step uses `bash`
-  # with flags today, and this check's job is Windows-safety (the runner default
-  # is pwsh). Matching only the command word and allowing `sh` would let a step
-  # land on a shell that may be absent on Windows runners. If a step ever needs
-  # `bash -e {0}`, parse the command word THEN, and keep the allowlist bash-only.
   for wf in .github/workflows/*.yml; do
     [ -e "$wf" ] || continue
     bad=$(yq '(.defaults.run.shell // "") as $d | .jobs[] | select(.steps) | .steps[] | select(has("run")) | select((.shell // $d) != "bash") | (.name // .id // "unnamed")' "$wf" 2>/dev/null || true)
@@ -157,16 +152,6 @@ if [ "$gnuism" -eq 0 ]; then
 else
   status=1
 fi
-
-# Two lint ideas were weighed for this gate and deliberately left out, both too
-# noisy to pay their way. A dangling-path check (every referenced script path
-# must resolve) flags an illustrative path in a doc or comment as broken, and a
-# plain substring match also trips on a generated path that lives under a
-# directory whose name ends in the prefix being matched; a precise boundary
-# would need the non-portable regex forms this very file bans. A doc-vs-code
-# tool-ban check (a file claims a tool is unused while code runs it) cannot tell
-# a scoped-true claim (the build hook genuinely uses no jq) from a global-false
-# one, so it would fight a correct doc. Both stay review concerns, not gates.
 
 echo ""
 if [ "$status" -eq 0 ]; then

--- a/tool/lint_shell.sh
+++ b/tool/lint_shell.sh
@@ -153,6 +153,25 @@ else
   status=1
 fi
 
+# ── 5. versions.env single-writer (set_kv only) ──────────────────────
+# versions.env is sourced (executed), so every write must pass set_kv's shape
+# gate. set_kv writes through a temp file and a rename, never a literal redirect
+# into the file, so a second writer (a redirect, a tee, or an in-place stream
+# edit that names versions.env) would slip an unvalidated value into a sourced
+# file. Flag any such writer. (Constructs are named in prose, not pasted, so
+# this rule doesn't match itself.)
+echo "── versions.env single-writer (set_kv only) ──"
+vw_files=(/dev/null)
+while IFS= read -r f; do vw_files+=("$f"); done < <(git ls-files '*.sh'; git ls-files '.github' | grep -E '\.ya?ml$')
+vw=$(grep -nE '(>>?[[:space:]]*"?[^"[:space:]]*versions\.env|(^|[^[:alnum:]_])tee[[:space:]][^|]*versions\.env|(^|[^[:alnum:]_])sed[[:space:]]+(-[a-zA-Z]+[[:space:]]+)*-i[^|]*versions\.env)' "${vw_files[@]}" 2>/dev/null || true)
+if [ -z "$vw" ]; then
+  echo "  clean — only set_kv writes versions.env"
+else
+  echo "  versions.env written outside set_kv (sourced file; an unvalidated write executes):" >&2
+  printf '%s\n' "$vw" | sed 's/^/    /' >&2
+  status=1
+fi
+
 echo ""
 if [ "$status" -eq 0 ]; then
   echo "Shell lint passed."

--- a/tool/lint_shell.sh
+++ b/tool/lint_shell.sh
@@ -98,6 +98,11 @@ if ! command -v yq >/dev/null 2>&1; then
   skip_note yq "brew install yq / snap install yq (mikefarah Go build) / choco install yq"
 else
   nonbash=0
+  # Exact-match on the resolved shell, deliberately: no run step uses `bash`
+  # with flags today, and this check's job is Windows-safety (the runner default
+  # is pwsh). Matching only the command word and allowing `sh` would let a step
+  # land on a shell that may be absent on Windows runners. If a step ever needs
+  # `bash -e {0}`, parse the command word THEN, and keep the allowlist bash-only.
   for wf in .github/workflows/*.yml; do
     [ -e "$wf" ] || continue
     bad=$(yq '(.defaults.run.shell // "") as $d | .jobs[] | select(.steps) | .steps[] | select(has("run")) | select((.shell // $d) != "bash") | (.name // .id // "unnamed")' "$wf" 2>/dev/null || true)
@@ -152,6 +157,16 @@ if [ "$gnuism" -eq 0 ]; then
 else
   status=1
 fi
+
+# Two lint ideas were weighed for this gate and deliberately left out, both too
+# noisy to pay their way. A dangling-path check (every referenced script path
+# must resolve) flags an illustrative path in a doc or comment as broken, and a
+# plain substring match also trips on a generated path that lives under a
+# directory whose name ends in the prefix being matched; a precise boundary
+# would need the non-portable regex forms this very file bans. A doc-vs-code
+# tool-ban check (a file claims a tool is unused while code runs it) cannot tell
+# a scoped-true claim (the build hook genuinely uses no jq) from a global-false
+# one, so it would fight a correct doc. Both stay review concerns, not gates.
 
 echo ""
 if [ "$status" -eq 0 ]; then


### PR DESCRIPTION
Carries the release-critical fix plus a hardening pass on the CI and supply-chain tooling, all on one branch per request.

## Release-critical (ships v2.1.1)

Two regressions from the #113 hardening left the release pipeline broken at its first two steps. #120 fixed the push auth; this fixes the next: `gh release upload` runs before its checkout, so it had no repo to infer, and `GH_REPO` names it. Together they unblock the pipeline end to end.

## Supply-chain hardening

Suggestions on the pin and upgrade tooling. Every item was checked against the code before acting.

### Applied
- **Injection on write.** `set_kv` shape-checks each value (version or 64-hex sha) before writing the sourced `versions.env`, and the Flutter version is gated to exact semver before it reaches `sed` (a separate sink, where GNU sed's `e` command is RCE). A shell-lint check enforces that only `set_kv` writes the file.
- **Tamper + availability.** `verify-pinned` HEADs then re-hashes each pin (404/410 = pruned, 200 with a changed hash = repoint, transient = warn). A HEAD-only `check-availability` runs from pr-lint on every PR, so a stale pin fails the PR even when the daily cron is disabled after 60 idle days.
- **fetch_verified.** Fail-closed on a 64-hex allowlist (was a placeholder blocklist); bounds the download on stall rather than a flat timeout.
- **Fail loud.** A blocked pin bump exits nonzero instead of passing silently.
- **Portable cargo config.** awk in place of a GNU-only `sed` insert that broke on macOS.
- **Verified publish.** The publish job uses the hash-pinned fvm capability, not an unverified `pub global activate`.
- **Upgrade radar split.** Security-sensitive pin bumps get their own PR (`chore/pins`), reviewed undiluted by lockfile churn; lockfiles refresh on `chore/lockfiles`.

### Declined, with the reason
- **yq command-word + sh allowlist:** no current false-positive, and allowing `sh` weakens the Windows-safety this check exists for.
- **dangling-path lint:** false-positives on `.dart_tool/` substrings and example paths in docs; a precise boundary needs the non-portable regex the file bans.
- **mirror pins to our own release:** hundreds of MB per bump plus a new failure mode. The cheap half (detect pruning) is applied instead, via the PR-time availability check above.
- **doc/code tool-ban grep:** can't tell a scoped-true "the hook uses no jq" from a global-false claim.

## Workflow hardening

A full inspection found 19 jobs across five workflows (ci, create-release, full-test, pr-lint, upgrade-check) with no `timeout-minutes`, falling back to the 6-hour default. Every job is now bounded: 5 for trivial orchestration, 10 to 20 for checkout and network jobs, 30 to 45 for the heavy download and compile jobs. Checkout hardening (SHA-pinned, persist-credentials:false) and per-job permissions were already uniform.

## Dev-tooling gates

Three local gates claimed to enforce something they didn't:

- **The gitignore pre-commit hook never fired.** `git check-ignore` consults the index by default, so a force-added file (the only way to stage an ignored one) reads as tracked, not ignored, and the guard saw nothing. `--no-index` applies the rules regardless of index state; path handling is now NUL-safe end to end.
- **`make build-native` passed on a failed compile.** The recipe swallowed the build hook's exit with `|| true`; since a no-match test and a compile failure both exit nonzero, a broken native build looked green. It now tees the output and fails on the dart-native tooling's build-failure markers.
- **The conventional-commit type list was duplicated** in the commit-msg hook and pr-lint, free to drift apart. Both now read `tool/commit-types.txt`.

- **The `dart:io` test guard didn't say why anything was exempt.** `test-guards` listed its exemptions as positional `grep -v` paths in the Makefile, so the reason a test was allowed `dart:io` lived nowhere and a rename would silently drop a file from the list. Each exempt test now carries an `io-exempt: <reason>` comment and the guard greps for the marker. The byte-grep guard stays positional on purpose: `sublist(0, 5)` and `isNot(contains ...)` are always-fine idioms (not per-file opt-outs), and `pdf_builder_battery` has 15 such lines where one file exclusion beats marking each.

## Review gating

CODEOWNERS gated `.github/`, `/tool/`, and lockfiles to the owner but let `/vendor/` fall to the maintainers team via `*`. A submodule pointer bump pulls in that commit's `build.rs`, which cargo runs at compile time in CI, so the gitlink bump is the merge gate that matters; it's now owner-gated. The per-file patterns an audit usually adds (`/vendor/**/build.rs`, `Cargo.lock`) are intentionally omitted: those files live inside the submodule repos, where a parent CODEOWNERS can't match them, so they're gated by the submodule repos' own CODEOWNERS.

## Docs

Brought up to date with the above: ARCHITECTURE principle 3 (bash uses jq, the hook is Dart), SECURITY's self-computed-pin note (now references verify-pinned/check-availability), UPDATING's upgrade flow (the pins/lockfiles split), and upgrade.sh's usage header (the new modes). Labels gained a consistent description schema and an (auto)/(manual) applier tag.

Local gates green: shellcheck, lint_shell (bash 3.2 + BSD/GNU), zizmor `--persona=auditor` at zero with no new ignores, actionlint.



