### PR TITLE
ci: gate .gitmodules to the owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -35,3 +35,9 @@
 # so CODEOWNERS here can't match them. The submodule repos' own CODEOWNERS gate
 # their build scripts and lockfiles.
 /vendor/                   @chaudharydeepanshu
+
+# Adding any submodule requires editing .gitmodules, so gating this one file
+# forces owner review for a new submodule at any path. The /vendor/ rule above
+# only covers the existing engine's gitlink bumps; a brand-new submodule (with
+# its own build.rs that cargo runs at compile time) would otherwise land via `*`.
+/.gitmodules               @chaudharydeepanshu


### PR DESCRIPTION
Completes the submodule-RCE hardening from #121's CODEOWNERS change.

`#121` gated `/vendor/` so the engine's gitlink bumps need owner review (a bumped `build.rs` runs at cargo-compile time in CI). The residual: a *brand-new* submodule at a non-`/vendor/` path (say `/libs/x`) touches only its own path + `.gitmodules`, both of which fall to the maintainers team via `*`. Since adding any submodule requires editing `.gitmodules`, gating that one file is the choke point that forces owner review for a new submodule anywhere.

A URL-only repoint of an existing submodule can't deliver code (gitlink SHAs are content-addressed), so this is purely about new-submodule introduction.