### PR TITLE
ci: verify the dependency floor compiles (analyze on oldest deps)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,24 @@ jobs:
         with:
           make-target: analyze
 
+  # Analyze the shipped code (lib/bin/hook) against the OLDEST in-range deps, so
+  # the wide lower bounds are honest, not just the newest a fresh build resolves.
+  # Static analysis only: no fixtures, no native build, no submodules needed.
+  analyze-floor:
+    name: Analyze (floor deps)
+    needs: [inputs, changes]
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ${{ needs.inputs.outputs.runner }}
+    timeout-minutes: 15
+    permissions:
+      contents: read  # checkout + static analyze, read-only
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with: { persist-credentials: false }
+      - uses: ./.github/actions/make-target
+        with:
+          make-target: analyze-floor
+
   test:
     name: Package tests
     needs: [inputs, changes]
@@ -127,7 +145,7 @@ jobs:
   gate:
     name: CI Gate
     if: always()
-    needs: [inputs, changes, analyze, test, rust]
+    needs: [inputs, changes, analyze, analyze-floor, test, rust]
     runs-on: ${{ needs.inputs.outputs.runner }}
     timeout-minutes: 5
     permissions: {}
@@ -138,6 +156,7 @@ jobs:
           CHANGES: ${{ needs.changes.result }}
           CODE: ${{ needs.changes.outputs.code }}
           ANALYZE: ${{ needs.analyze.result }}
+          FLOOR: ${{ needs.analyze-floor.result }}
           TEST: ${{ needs.test.result }}
           RUST: ${{ needs.rust.result }}
         run: |
@@ -152,8 +171,8 @@ jobs:
             echo "Doc-only PR — CI gate passes"
             exit 0
           fi
-          if [[ "$ANALYZE" != "success" ]] || [[ "$TEST" != "success" ]]; then
-            echo "FAILED: analyze=$ANALYZE test=$TEST"
+          if [[ "$ANALYZE" != "success" ]] || [[ "$FLOOR" != "success" ]] || [[ "$TEST" != "success" ]]; then
+            echo "FAILED: analyze=$ANALYZE floor=$FLOOR test=$TEST"
             exit 1
           fi
           # rust runs only when the engine/features/Makefile/CI change; skipped is OK.

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,22 @@ hooks:
 analyze: fixtures
 	@DART="$(DART)" FLUTTER="$(FLUTTER)" bash tool/analyze.sh
 
+# make analyze-floor  Resolve to the OLDEST in-range dependencies and analyze
+#                     the shipped code (lib bin hook). The wide lower bounds
+#                     (e.g. package_config >=2.1.0) are only honest if the code
+#                     analyzes against them, not just the newest a fresh build
+#                     resolves: the dependency half of "works for some, breaks
+#                     for some". Static analysis only, so no fixtures and no
+#                     native build. Tests are excluded on purpose; a consumer
+#                     sees lib, never your tests. Snapshots and restores the lock
+#                     so a local run leaves the tree clean.
+analyze-floor:
+	@cp pubspec.lock pubspec.lock.floorbak; \
+	$(DART) pub downgrade --no-example >/dev/null && $(DART) analyze --fatal-infos lib bin hook; rc=$$?; \
+	mv pubspec.lock.floorbak pubspec.lock; \
+	$(DART) pub get --no-example >/dev/null 2>&1 || true; \
+	exit $$rc
+
 # make lint-shell  Shell portability gate: shellcheck + a bash 4.0+ scan
 #                  that catches macOS bash 3.2 breaks in scripts and in
 #                  workflow run: blocks. Mirrors the CI workflow-lint job.


### PR DESCRIPTION
Closes the dependency half of "works for some, breaks for some" for pdf_manipulator as a published package.

**Gap:** CI only built on the newest resolution, so the wide lower bounds (`package_config: >=2.1.0 <4.0.0` and friends) were claimed but never exercised. A consumer resolving the oldest in-range deps got an untested package.

**Fix:** `make analyze-floor` downgrades to the oldest in-range deps and analyzes the shipped code (`lib bin hook`). Static only: no fixtures, no native build, no submodules. Tests are excluded since a consumer never runs them. Snapshots and restores the lock so a local run leaves the tree clean. The CI gate now requires it, so a future bump that needs newer deps than the constraints advertise turns red instead of shipping.

**Verified:** dogfooded locally, the shipped code analyzes clean on its floor, so the `>=3.10.0` floor (forced by `hooks`/`code_assets`) and the wide constraints are honest.

Local gates: actionlint clean, zizmor `--persona=auditor` zero (no new ignores).