### PR TITLE
fix(ci): refresh the example lockfile with flutter, not dart

### DIFF
--- a/.github/workflows/upgrade-check.yml
+++ b/.github/workflows/upgrade-check.yml
@@ -192,8 +192,11 @@ jobs:
 
       - name: Refresh lockfiles to latest in-range
         run: |
-          fvm dart pub upgrade
-          ( cd example && fvm dart pub upgrade )
+          # Root is a pure-Dart package: --no-example so `dart pub` does not try
+          # to resolve the Flutter example (it has no sky_engine, dart can't).
+          # The example is a Flutter app, so refresh it with `flutter pub`.
+          fvm dart pub upgrade --no-example
+          ( cd example && fvm flutter pub upgrade )
 
       - name: Commit + open or update the lockfiles PR
         env:


### PR DESCRIPTION
The lockfile-refresh lane (`upgrade-check.yml`) ran `dart pub upgrade` for both the root and the `example/`. The example is a Flutter app, so `dart pub` can't resolve it (no `sky_engine`), and the job failed at exit 69 (see Upgrade Check #12).

Fix: `--no-example` for the root (pure Dart), `flutter pub upgrade` for the example. Same dart/flutter split `analyze.sh` already uses.

Local gates: actionlint clean, zizmor `--persona=auditor` zero (no new ignores), lint_shell passed.