### PR TITLE
fix(ci): resolve fvm on windows via native fvm.exe, not a .bat shim

### DIFF
--- a/.github/actions/capabilities/fvm/action.yml
+++ b/.github/actions/capabilities/fvm/action.yml
@@ -86,17 +86,10 @@ runs:
             DEST=/c/fvm
             mkdir -p "$DEST"
             cp -R "$FVM_BIN/." "$DEST/"
-            # fvm ships only fvm.bat on Windows, and Git Bash won't resolve a
-            # bare `fvm` to a .bat (MSYS execvp skips .bat extensions). Drop a
-            # POSIX shim that runs the .bat through cmd, so every later bash
-            # step calls `fvm` exactly like the native launcher elsewhere.
-            printf '%s\n' \
-              '#!/usr/bin/env bash' \
-              'set -euo pipefail' \
-              'here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"' \
-              'exec cmd //c "$(cygpath -w "$here/fvm.bat")" "$@"' \
-              > "$DEST/fvm"
-            chmod +x "$DEST/fvm"
+            # fvm 4.x ships a native fvm.exe (plus its src/ runtime), not a .bat.
+            # Git Bash's execvp auto-appends .exe, so a bare `fvm` on PATH
+            # resolves straight to fvm.exe, exactly like the launcher elsewhere.
+            # A POSIX shim file named `fvm` would only shadow the real .exe.
             # The \f reads like an escape but is literal here: GitHub runs this
             # step as bash, whose echo leaves backslashes alone (C:\fvm, not
             # C: + form-feed). Keep echo, not printf — see the zizmor note below.


### PR DESCRIPTION
## What

Drop the broken Windows `fvm.bat` shim in the fvm capability action. A bare `fvm` on PATH now resolves to the native `fvm.exe`.

## Why it was failing

The pinned **fvm 4.1.1 Windows zip** ships exactly two files: `fvm/fvm.exe` and `fvm/src/LICENSE`. There is no `fvm.bat`. (Verified: the downloaded zip's sha256 matches the pin in `tool/versions.env`.)

The action assumed fvm ships a `.bat` and wrote a POSIX shim that `exec`s `C:\fvm\fvm.bat`. So every Windows job died at `fvm --version`:

```
'C:\fvm\fvm.bat' is not recognized as an internal or external command
Error: Process completed with exit code 1.
```

The shim (a file literally named `fvm`) also *shadowed* the real `fvm.exe`.

## The fix

Remove the shim. `fvm.exe` is a native binary, and Git Bash's `execvp` auto-appends `.exe`, so a bare `fvm` on `C:\fvm` (already on PATH) resolves straight to `fvm.exe`, exactly how the bare launcher already runs on Linux/macOS. The zizmor-sensitive `echo "C:\fvm" >> "$GITHUB_PATH"` literal is untouched.

## Verification

- archive sha256 == pin; contents are `fvm.exe` + `src/` only
- `actionlint` clean, YAML valid, no leftover `fvm.bat` refs
- The real Windows proof is a `full-test.yml` run (the `Android (win-x64)` matrix), which I'll trigger once this lands on dev.