### PR TITLE
build: shared strict analyze gate + whuppi/ci pin bump to v1.0.6

### DIFF
--- a/.github/actions/make-target/action.yml
+++ b/.github/actions/make-target/action.yml
@@ -75,7 +75,7 @@ runs:
     # the native/wasm ones (rust, wasm-cache, wasm-build) are pdf-specific and
     # stay local. The shared capabilities were generalized FROM these, so the
     # behavior is identical — only their home moved.
-    - uses: whuppi/ci/actions/capabilities/fvm@v1.0.1
+    - uses: whuppi/ci/actions/capabilities/fvm@v1.0.6
 
     # ── On demand ──
     # Default on: most jobs build the native/wasm engine. Dart-only static
@@ -85,22 +85,22 @@ runs:
     - uses: ./.github/actions/capabilities/rust
       if: inputs.rust == 'true'
 
-    - uses: whuppi/ci/actions/capabilities/free-disk-space@v1.0.1
+    - uses: whuppi/ci/actions/capabilities/free-disk-space@v1.0.6
       if: inputs.free-disk == 'true'
 
-    - uses: whuppi/ci/actions/capabilities/java@v1.0.1
+    - uses: whuppi/ci/actions/capabilities/java@v1.0.6
       if: inputs.java == 'true'
 
-    - uses: whuppi/ci/actions/capabilities/chrome@v1.0.1
+    - uses: whuppi/ci/actions/capabilities/chrome@v1.0.6
       if: inputs.chrome == 'true'
 
-    - uses: whuppi/ci/actions/capabilities/headless-display@v1.0.1
+    - uses: whuppi/ci/actions/capabilities/headless-display@v1.0.6
       if: inputs.headless-display == 'true'
 
-    - uses: whuppi/ci/actions/capabilities/hw-accel@v1.0.1
+    - uses: whuppi/ci/actions/capabilities/hw-accel@v1.0.6
       if: inputs.hw-accel == 'true'
 
-    - uses: whuppi/ci/actions/capabilities/gradle-cache@v1.0.1
+    - uses: whuppi/ci/actions/capabilities/gradle-cache@v1.0.6
       if: inputs.gradle-cache == 'true'
       with:
         phase: restore
@@ -108,13 +108,13 @@ runs:
     # Forward the pdf_oxide submodule rev (set by the rust step above) as the
     # shared xcode-cache's key-extra, preserving the precise cache key the
     # local xcode-cache read from env directly.
-    - uses: whuppi/ci/actions/capabilities/xcode-cache@v1.0.1
+    - uses: whuppi/ci/actions/capabilities/xcode-cache@v1.0.6
       if: inputs.xcode-cache == 'true'
       with:
         target: ${{ inputs.xcode-cache-target }}
         key-extra: ${{ env.SUBMODULE_PDF_OXIDE }}
 
-    - uses: whuppi/ci/actions/capabilities/pods-cache@v1.0.1
+    - uses: whuppi/ci/actions/capabilities/pods-cache@v1.0.6
       if: inputs.pods-cache == 'true'
 
     - uses: ./.github/actions/capabilities/wasm-cache
@@ -123,7 +123,7 @@ runs:
     - uses: ./.github/actions/capabilities/wasm-build
       if: inputs.wasm-build == 'true'
 
-    - uses: whuppi/ci/actions/capabilities/ios-simulator@v1.0.1
+    - uses: whuppi/ci/actions/capabilities/ios-simulator@v1.0.6
       if: inputs.simulator == 'true'
 
     # ── Run ──
@@ -163,12 +163,12 @@ runs:
     # by the capability's teardown-watchdog wrapper. The shared android-emulator
     # reconciles the machine report at its default path (test-results/
     # int-android.json), which is where the android make target writes.
-    - uses: whuppi/ci/actions/capabilities/android-emulator@v1.0.1
+    - uses: whuppi/ci/actions/capabilities/android-emulator@v1.0.6
       if: inputs.emulator == 'true'
       with:
         script: /tmp/make-run.sh "${{ inputs.make-target }}"
 
-    - uses: whuppi/ci/actions/capabilities/gradle-cache@v1.0.1
+    - uses: whuppi/ci/actions/capabilities/gradle-cache@v1.0.6
       if: always() && inputs.gradle-cache == 'true'
       with:
         phase: save

--- a/.github/workflows/auto-close.yml
+++ b/.github/workflows/auto-close.yml
@@ -24,7 +24,7 @@ jobs:
   auto-close:
     permissions:
       issues: write  # label, comment on, and close resolved issues
-    uses: whuppi/ci/.github/workflows/auto-close.yml@v1.0.4
+    uses: whuppi/ci/.github/workflows/auto-close.yml@v1.0.6
     with:
       # Team slug for the humans (managed in the org, same team CODEOWNERS
       # uses) + the slopfairy bot as a fixed automation hook. A maintainer

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -88,14 +88,14 @@ jobs:
       # release a lane whose changelog adds more than one new version.
       # Checks the lane being released (the pushed branch).
       - name: Version sanity
-        uses: whuppi/ci/actions/release-tool@v1.0.4
+        uses: whuppi/ci/actions/release-tool@v1.0.6
         env:
           BRANCH: ${{ inputs.branch || github.ref_name }}
         with:
           mode: --check-versions
       - name: Check changelog relevance
         id: check
-        uses: whuppi/ci/actions/release-tool@v1.0.4
+        uses: whuppi/ci/actions/release-tool@v1.0.6
         env:
           BRANCH: ${{ inputs.branch || github.ref_name }}
           BEFORE: ${{ github.event.before }}
@@ -128,7 +128,7 @@ jobs:
           persist-credentials: false
       - name: Find + create release
         id: find
-        uses: whuppi/ci/actions/release-tool@v1.0.4
+        uses: whuppi/ci/actions/release-tool@v1.0.6
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: ${{ inputs.branch || github.ref_name }}
@@ -244,21 +244,21 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Add git install snippet
-        uses: whuppi/ci/actions/release-tool@v1.0.4
+        uses: whuppi/ci/actions/release-tool@v1.0.6
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           mode: --add-git-install
           tag: ${{ needs.discover.outputs.tag }}
       - name: Stamp asset hashes into tag
-        uses: whuppi/ci/actions/release-tool@v1.0.4
+        uses: whuppi/ci/actions/release-tool@v1.0.6
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           mode: --update-tag-hashes
           tag: ${{ needs.discover.outputs.tag }}
       - name: Build pub.dev changelog for preview
-        uses: whuppi/ci/actions/release-tool@v1.0.4
+        uses: whuppi/ci/actions/release-tool@v1.0.6
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -290,16 +290,16 @@ jobs:
           persist-credentials: false
       # Use the verified fvm capability, not an unverified pub global activate:
       # this job holds the pub.dev credentials, so don't weaken its tooling path.
-      - uses: whuppi/ci/actions/capabilities/fvm@v1.0.4
+      - uses: whuppi/ci/actions/capabilities/fvm@v1.0.6
       - name: Build filtered changelog
-        uses: whuppi/ci/actions/release-tool@v1.0.4
+        uses: whuppi/ci/actions/release-tool@v1.0.6
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           mode: --stamp-changelog
           tag: ${{ needs.discover.outputs.tag }}
       - name: Flatten README banner for pub.dev
-        uses: whuppi/ci/actions/release-tool@v1.0.4
+        uses: whuppi/ci/actions/release-tool@v1.0.6
         with:
           mode: --stamp-readme
       - name: Ephemeral commit (clean git for pub publish)
@@ -319,7 +319,7 @@ jobs:
       - run: fvm dart pub get --no-example
       - run: fvm dart pub publish --force
       - name: Add pub.dev install snippet
-        uses: whuppi/ci/actions/release-tool@v1.0.4
+        uses: whuppi/ci/actions/release-tool@v1.0.6
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/debug-ssh.yml
+++ b/.github/workflows/debug-ssh.yml
@@ -65,7 +65,7 @@ jobs:
           submodules: recursive
           persist-credentials: false
 
-      - uses: whuppi/ci/actions/debug-ssh@v1.0.4
+      - uses: whuppi/ci/actions/debug-ssh@v1.0.6
 
       - name: Keep alive (touch /tmp/stop to end)
         shell: bash

--- a/.github/workflows/full-test.yml
+++ b/.github/workflows/full-test.yml
@@ -128,7 +128,7 @@ jobs:
     steps:
       - name: Check filter
         id: filter
-        uses: whuppi/ci/actions/matrix-filter@v1.0.4
+        uses: whuppi/ci/actions/matrix-filter@v1.0.6
         with:
           name: ${{ matrix.name }}
           filter: ${{ needs.inputs.outputs.filter }}

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -23,4 +23,4 @@ jobs:
     permissions:
       contents: read  # checkout reads .github/labels.json
       issues: write   # labels are managed through the Issues API
-    uses: whuppi/ci/.github/workflows/labels.yml@v1.0.4
+    uses: whuppi/ci/.github/workflows/labels.yml@v1.0.6

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -22,7 +22,7 @@ jobs:
   checks:
     permissions:
       contents: read  # the reusable jobs only checkout + lint, read-only
-    uses: whuppi/ci/.github/workflows/pr-checks.yml@v1.0.4
+    uses: whuppi/ci/.github/workflows/pr-checks.yml@v1.0.6
 
   # Runs on PR activity (not just the daily cron, which GitHub disables after
   # ~60 idle days): HEADs every locally-pinned asset so a pruned pin fails the

--- a/.github/workflows/retry.yml
+++ b/.github/workflows/retry.yml
@@ -27,4 +27,4 @@ jobs:
   retry:
     permissions:
       actions: write  # gh run rerun re-runs the failed jobs of the run
-    uses: whuppi/ci/.github/workflows/retry.yml@v1.0.4
+    uses: whuppi/ci/.github/workflows/retry.yml@v1.0.6

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -29,4 +29,4 @@ jobs:
       contents: read        # labeler reads .github/labeler.yml + the PR file list
       issues: write         # assign maintainer on issue-opened events
       pull-requests: write  # apply labels, revoke ready-to-test, post notices
-    uses: whuppi/ci/.github/workflows/triage.yml@v1.0.4
+    uses: whuppi/ci/.github/workflows/triage.yml@v1.0.6

--- a/.github/workflows/upgrade-check.yml
+++ b/.github/workflows/upgrade-check.yml
@@ -30,7 +30,7 @@ jobs:
     permissions:
       contents: write       # pushes the chore/flutter-sdk + chore/lockfiles branches
       pull-requests: write  # opens / edits the upgrade PRs
-    uses: whuppi/ci/.github/workflows/upgrade-check.yml@v1.0.4
+    uses: whuppi/ci/.github/workflows/upgrade-check.yml@v1.0.6
     with:
       branch: dev
 

--- a/tool/analyze.sh
+++ b/tool/analyze.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# Run all static analysis: banned ignores check + Dart + Rust warnings.
+# Run all static analysis: format + the shared Dart core (stamped from
+# whuppi/ci) + Rust warnings.
 # Called by: make analyze
 # Run from package root.
 set -euo pipefail
@@ -10,19 +11,6 @@ PKG_ROOT="$(dirname "$SCRIPT_DIR")"
 # SDK commands (overridable via env for non-FVM setups)
 DART="${DART:-fvm dart}"
 FLUTTER="${FLUTTER:-fvm flutter}"
-
-# ── Ban // ignore: comments ─────────────────────────────────────────
-# Dart has no built-in way to prevent ignore comments in analysis_options.
-# Enforce via grep. Every lint must be fixed for real — no suppressions.
-
-echo "=== Dart: check for banned // ignore: comments ==="
-IGNORES=$(grep -rnE '// ignore:|// ignore_for_file:' "$PKG_ROOT/lib/" "$PKG_ROOT/bin/" "$PKG_ROOT/test/" "$PKG_ROOT/hook/" 2>/dev/null | grep -v '\.g\.dart' || true)
-if [ -n "$IGNORES" ]; then
-  echo "BANNED: // ignore: comments found. Fix the lint, don't suppress it."
-  echo "$IGNORES"
-  exit 1
-fi
-echo "  No // ignore: comments found. Clean."
 
 # ── Resolve BEFORE formatting ───────────────────────────────────────
 # `dart format`'s output depends on the file's resolved LANGUAGE
@@ -64,13 +52,12 @@ format_pkg() {
 format_pkg "$PKG_ROOT" lib bin test tool hook
 format_pkg "$PKG_ROOT/example" lib integration_test
 
-# ── Dart analysis ───────────────────────────────────────────────────
-
-echo "=== Dart: analyze lib/ bin/ test/ hook/ ==="
-$DART analyze --fatal-infos lib/ bin/ test/ hook/
-
-echo "=== Dart: analyze example/ ==="
-( cd "$PKG_ROOT/example" && $FLUTTER analyze --fatal-infos )
+# ── Shared Dart analysis core (stamped from whuppi/ci) ──────────────
+# Suppression-comment ban + dart/flutter analyze --fatal-infos over the
+# package dirs and example. Canonical script lives in whuppi/ci; a gate
+# change lands here through a re-stamp, never an edit to this copy.
+ANALYZE_DIRS="lib bin test hook" EXAMPLE_DIR="example" \
+  DART="$DART" FLUTTER="$FLUTTER" bash "$SCRIPT_DIR/analyze_core.sh"
 
 # ── Rust analysis (warnings in our patched lines only) ──────────────
 

--- a/tool/analyze_core.sh
+++ b/tool/analyze_core.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# ────────────────────────────────────────────────────────────────────
+# analyze_core.sh — the ONE Dart static-analysis gate, shared verbatim.
+#
+# Canonical copy: whuppi/ci/tool/analyze_core.sh. Stamped into each
+# package as tool/analyze_core.sh by .claude/scripts/stamp-analyze.sh —
+# DO NOT edit the stamped copy; edit the canonical one and re-stamp.
+#
+# What it enforces, identically in every package, locally and in CI:
+#   1. No suppression comments in the analyzed source ("// " then
+#      "ignore:" / "ignore_for_file:") — every lint is fixed for real.
+#   2. `dart analyze --fatal-infos` over the package's root dirs — an
+#      INFO (deprecated_member_use, anything) fails, same as an error.
+#   3. `flutter analyze --fatal-infos` over example/ when present.
+#
+# It deliberately does NOT format (packages own their format step) and
+# does NOT hard-code package layout: the analyzable root dirs are
+# auto-detected, example is auto-detected, and package-only steps
+# (Rust, fixtures) live in the package's own wrapper AROUND this core.
+#
+# Env (all optional):
+#   DART / FLUTTER   SDK commands            (default: fvm dart / fvm flutter)
+#   ANALYZE_DIRS     root dirs to analyze    (default: the ones that exist
+#                    among lib bin test tool hook)
+#   EXAMPLE_DIR      example app dir          (default: example if present;
+#                    set to "" to skip)
+# Run from the package root.
+# ────────────────────────────────────────────────────────────────────
+set -euo pipefail
+
+DART="${DART:-fvm dart}"
+FLUTTER="${FLUTTER:-fvm flutter}"
+
+# Auto-detect the analyzable root dirs so one script fits every package
+# shape. example/ is deliberately NOT in this list: it is a separate
+# Flutter package and gets its own `flutter analyze` pass below (using
+# its own resolution), never a root-package `dart analyze`.
+if [ -z "${ANALYZE_DIRS:-}" ]; then
+  ANALYZE_DIRS=""
+  for d in lib bin test tool hook; do
+    [ -d "$d" ] && ANALYZE_DIRS="${ANALYZE_DIRS:+$ANALYZE_DIRS }$d"
+  done
+fi
+# ANALYZE_DIRS is a space-separated dir list meant to word-split into args.
+# shellcheck disable=SC2086
+set -- $ANALYZE_DIRS
+if [ "$#" -eq 0 ]; then
+  echo "analyze_core: no analyzable dirs found — run from the package root." >&2
+  exit 2
+fi
+
+if [ -z "${EXAMPLE_DIR+x}" ] && [ -d example ]; then
+  EXAMPLE_DIR="example"
+fi
+EXAMPLE_DIR="${EXAMPLE_DIR:-}"
+
+# ── 1. Ban suppression comments ─────────────────────────────────────
+# Dart has no built-in way to forbid suppressions; enforce via grep.
+# Silencing one lint is how strictness drifts, so none are allowed.
+# The pattern is split so this script never matches itself.
+echo "=== analyze_core: banned suppression comments ==="
+BANNED=$(grep -rnE "// ""ignore:|// ""ignore_for_file:" "$@" 2>/dev/null \
+  | grep -v '\.g\.dart' || true)
+if [ -n "$BANNED" ]; then
+  echo "BANNED: suppression comments found. Fix the lint, don't silence it."
+  echo "$BANNED"
+  exit 1
+fi
+echo "  clean"
+
+# ── 2. Resolve, then analyze — infos are fatal ──────────────────────
+echo "=== analyze_core: pub get ==="
+$DART pub get --no-example
+if [ -n "$EXAMPLE_DIR" ]; then
+  ( cd "$EXAMPLE_DIR" && $FLUTTER pub get )
+fi
+
+echo "=== analyze_core: dart analyze --fatal-infos $* ==="
+$DART analyze --fatal-infos "$@"
+
+if [ -n "$EXAMPLE_DIR" ]; then
+  echo "=== analyze_core: example ($EXAMPLE_DIR) analyze --fatal-infos ==="
+  ( cd "$EXAMPLE_DIR" && $FLUTTER analyze --fatal-infos )
+fi
+
+echo "=== analyze_core: passed ==="


### PR DESCRIPTION
Puts pdf on the shared strict analyze gate, and fixes a pin-drift bug found along the way.

**Analyze gate** — `tool/analyze.sh` now delegates its Dart analysis to `tool/analyze_core.sh` (the shared script stamped from whuppi/ci): a suppression-comment ban + `dart/flutter analyze --fatal-infos` over `lib bin test hook` and `example`. It keeps its own pub-get, format, and Rust-warning steps around that core. The inline ignore-ban + analyze block are removed — the Dart gate is now byte-identical to device_io's.

**Pin drift fix** — every `whuppi/ci` ref bumped to v1.0.6. The workflows were at v1.0.4; the vendored `make-target` fork's generic capability pins had drifted to **v1.0.1** (behind the workflows). All now track the same shared release, as the fork's own comment intends. Additive release; also picks up v1.0.5's Windows PUB_CACHE fix. The local `rust` / `wasm-cache` / `wasm-build` capabilities are pdf-specific and unversioned — untouched.

Verified locally: `make lint-shell` green (wrapper + stamped core), and `analyze_core.sh` runs clean on pdf's dirs (`--fatal-infos`, 0 issues). The full `make analyze` (core + Rust) runs in CI.
