### PR TITLE
ci: align dependabot/labels/upgrade-body with the workspace shape

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,8 +2,28 @@
 # automated-security-fixes (enabled in settings), not from this file.
 version: 2
 updates:
+  # pub — the root package and the example app. Grouped so a batch of bumps is
+  # a single review PR; prefixed so the title passes the conventional-commit
+  # lint (an unprefixed "Bump foo" title fails it).
   - package-ecosystem: "pub"
     directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    target-branch: "dev"
+    commit-message:
+      prefix: "chore"
+    labels:
+      - "dependencies"
+    groups:
+      deps:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+  - package-ecosystem: "pub"
+    directory: "/example"
     schedule:
       interval: "weekly"
       day: "monday"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,6 +6,14 @@ ci:
       - any-glob-to-any-file:
           - .github/**
           - .githooks/**
+          - Makefile
+          - tool/**
+
+docs:
+  - changed-files:
+      - any-glob-to-any-file:
+          - docs/**
+          - '**/*.md'
 
 web:
   - changed-files:

--- a/.github/labels.json
+++ b/.github/labels.json
@@ -1,6 +1,7 @@
 [
   { "name": "bug",              "color": "D93F0B", "description": "Broken behavior (auto)" },
   { "name": "feature",          "color": "0E8A16", "description": "New capability (auto)" },
+  { "name": "docs",             "color": "0075CA", "description": "Documentation change (auto)" },
   { "name": "ci",               "color": "BFD4F2", "description": "Build, CI, or workflow change (auto)" },
   { "name": "web",              "color": "1D76DB", "description": "Web or WASM specific (auto)" },
   { "name": "upstream",         "color": "5319E7", "description": "Needs a pdf_oxide change (auto)" },

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -40,3 +40,16 @@ jobs:
       - name: Pinned assets still reachable
         shell: bash
         run: bash tool/ci/upgrade.sh check-availability
+      # The vendored make-target fork pins whuppi/ci capabilities separately
+      # from the workflows and dependabot's whuppi-ci group does NOT reach
+      # inside it — so it has drifted (v1.0.1 vs v1.0.4) before. Fail the PR if
+      # any whuppi/ci ref across .github is on a different version than the rest.
+      - name: whuppi/ci refs share one version
+        shell: bash
+        run: |
+          v=$(grep -rhoE 'whuppi/ci/[^@[:space:]]*@v[0-9.]+' .github | grep -oE 'v[0-9.]+' | sort -u | tr '\n' ' ')
+          if [ "$(printf '%s' "$v" | wc -w)" -gt 1 ]; then
+            echo "::error::whuppi/ci refs span multiple versions: $v"
+            exit 1
+          fi
+          echo "whuppi/ci refs all on: $v"

--- a/.github/workflows/upgrade-check.yml
+++ b/.github/workflows/upgrade-check.yml
@@ -105,9 +105,10 @@ jobs:
           PR_BODY="$(cat <<'EOF'
           Supply-chain pin bump — review the recomputed hashes in the diff:
 
-          - **binaryen + pana** (`tool/versions.env`) — this repo's own build +
+          - **Pinned assets in `tool/versions.env`**: this repo's own build +
             gate pins; sha256s recomputed from the upstream release assets,
-            re-verified by `fetch_verified` on every build.
+            re-verified by `fetch_verified` on every build. See the diff for
+            which versions moved.
 
           The already-pinned assets were re-hashed before this bump (repoint alarm).
           Add `ready-to-test` for the full cross-target run, then merge once green.


### PR DESCRIPTION
Aligns pdf's dependabot/labels/labeler with the workspace shape, fixes the pdf#139 auto-body over-claim, and adds a fork-drift guard.

- **dependabot**: adds the missing `/example` pub entry — its example-app deps were never being bumped — and adopts the canonical shape now byte-identical to device_io's.
- **labeler + labels**: `Makefile` + `tool/**` added to the `ci` rule, a `docs` rule + label added (both match device_io; the `web`/`upstream` rules stay pdf-specific).
- **upgrade-check.yml**: the pins-PR body hardcoded "binaryen + pana … recomputed sha256s" even when only pana moved (the pdf#139 report). Now generic — points at the diff for which versions moved.
- **pr-lint**: new check fails the PR if `whuppi/ci` refs across `.github` span versions. The vendored `make-target` fork drifted to v1.0.1 while workflows were v1.0.4, and dependabot's `whuppi-ci` group doesn't reach inside `.github/actions/` — this catches a recurrence.

Config/workflow only. YAML+JSON verified, `make lint-shell` green. Part of the device_io↔pdf↔ci consistency streamlining.

_Note: the cosmetic workflow renames (pr-lint→pr-checks, create-release→release) are held for a separate review — they touch the release pipeline + branch protection._
