### PR TITLE
chore: adopt whuppi/ci v1.0.8

### DIFF
--- a/.github/actions/make-target/action.yml
+++ b/.github/actions/make-target/action.yml
@@ -75,7 +75,7 @@ runs:
     # the native/wasm ones (rust, wasm-cache, wasm-build) are pdf-specific and
     # stay local. The shared capabilities were generalized FROM these, so the
     # behavior is identical — only their home moved.
-    - uses: whuppi/ci/actions/capabilities/fvm@v1.0.7
+    - uses: whuppi/ci/actions/capabilities/fvm@v1.0.8
 
     # ── On demand ──
     # Default on: most jobs build the native/wasm engine. Dart-only static
@@ -85,22 +85,22 @@ runs:
     - uses: ./.github/actions/capabilities/rust
       if: inputs.rust == 'true'
 
-    - uses: whuppi/ci/actions/capabilities/free-disk-space@v1.0.7
+    - uses: whuppi/ci/actions/capabilities/free-disk-space@v1.0.8
       if: inputs.free-disk == 'true'
 
-    - uses: whuppi/ci/actions/capabilities/java@v1.0.7
+    - uses: whuppi/ci/actions/capabilities/java@v1.0.8
       if: inputs.java == 'true'
 
-    - uses: whuppi/ci/actions/capabilities/chrome@v1.0.7
+    - uses: whuppi/ci/actions/capabilities/chrome@v1.0.8
       if: inputs.chrome == 'true'
 
-    - uses: whuppi/ci/actions/capabilities/headless-display@v1.0.7
+    - uses: whuppi/ci/actions/capabilities/headless-display@v1.0.8
       if: inputs.headless-display == 'true'
 
-    - uses: whuppi/ci/actions/capabilities/hw-accel@v1.0.7
+    - uses: whuppi/ci/actions/capabilities/hw-accel@v1.0.8
       if: inputs.hw-accel == 'true'
 
-    - uses: whuppi/ci/actions/capabilities/gradle-cache@v1.0.7
+    - uses: whuppi/ci/actions/capabilities/gradle-cache@v1.0.8
       if: inputs.gradle-cache == 'true'
       with:
         phase: restore
@@ -108,13 +108,13 @@ runs:
     # Forward the pdf_oxide submodule rev (set by the rust step above) as the
     # shared xcode-cache's key-extra, preserving the precise cache key the
     # local xcode-cache read from env directly.
-    - uses: whuppi/ci/actions/capabilities/xcode-cache@v1.0.7
+    - uses: whuppi/ci/actions/capabilities/xcode-cache@v1.0.8
       if: inputs.xcode-cache == 'true'
       with:
         target: ${{ inputs.xcode-cache-target }}
         key-extra: ${{ env.SUBMODULE_PDF_OXIDE }}
 
-    - uses: whuppi/ci/actions/capabilities/pods-cache@v1.0.7
+    - uses: whuppi/ci/actions/capabilities/pods-cache@v1.0.8
       if: inputs.pods-cache == 'true'
 
     - uses: ./.github/actions/capabilities/wasm-cache
@@ -123,7 +123,7 @@ runs:
     - uses: ./.github/actions/capabilities/wasm-build
       if: inputs.wasm-build == 'true'
 
-    - uses: whuppi/ci/actions/capabilities/ios-simulator@v1.0.7
+    - uses: whuppi/ci/actions/capabilities/ios-simulator@v1.0.8
       if: inputs.simulator == 'true'
 
     # ── Run ──
@@ -163,12 +163,12 @@ runs:
     # by the capability's teardown-watchdog wrapper. The shared android-emulator
     # reconciles the machine report at its default path (test-results/
     # int-android.json), which is where the android make target writes.
-    - uses: whuppi/ci/actions/capabilities/android-emulator@v1.0.7
+    - uses: whuppi/ci/actions/capabilities/android-emulator@v1.0.8
       if: inputs.emulator == 'true'
       with:
         script: /tmp/make-run.sh "${{ inputs.make-target }}"
 
-    - uses: whuppi/ci/actions/capabilities/gradle-cache@v1.0.7
+    - uses: whuppi/ci/actions/capabilities/gradle-cache@v1.0.8
       if: always() && inputs.gradle-cache == 'true'
       with:
         phase: save

--- a/.github/workflows/auto-close.yml
+++ b/.github/workflows/auto-close.yml
@@ -24,7 +24,7 @@ jobs:
   auto-close:
     permissions:
       issues: write  # label, comment on, and close resolved issues
-    uses: whuppi/ci/.github/workflows/auto-close.yml@v1.0.7
+    uses: whuppi/ci/.github/workflows/auto-close.yml@v1.0.8
     with:
       # Team slug for the humans (managed in the org, same team CODEOWNERS
       # uses) + the slopfairy bot as a fixed automation hook. A maintainer

--- a/.github/workflows/debug-ssh.yml
+++ b/.github/workflows/debug-ssh.yml
@@ -65,7 +65,7 @@ jobs:
           submodules: recursive
           persist-credentials: false
 
-      - uses: whuppi/ci/actions/debug-ssh@v1.0.7
+      - uses: whuppi/ci/actions/debug-ssh@v1.0.8
 
       - name: Keep alive (touch /tmp/stop to end)
         shell: bash

--- a/.github/workflows/full-test.yml
+++ b/.github/workflows/full-test.yml
@@ -128,7 +128,7 @@ jobs:
     steps:
       - name: Check filter
         id: filter
-        uses: whuppi/ci/actions/matrix-filter@v1.0.7
+        uses: whuppi/ci/actions/matrix-filter@v1.0.8
         with:
           name: ${{ matrix.name }}
           filter: ${{ needs.inputs.outputs.filter }}

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -23,4 +23,4 @@ jobs:
     permissions:
       contents: read  # checkout reads .github/labels.json
       issues: write   # labels are managed through the Issues API
-    uses: whuppi/ci/.github/workflows/labels.yml@v1.0.7
+    uses: whuppi/ci/.github/workflows/labels.yml@v1.0.8

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -22,7 +22,7 @@ jobs:
   checks:
     permissions:
       contents: read  # the reusable jobs only checkout + lint, read-only
-    uses: whuppi/ci/.github/workflows/pr-checks.yml@v1.0.7
+    uses: whuppi/ci/.github/workflows/pr-checks.yml@v1.0.8
 
   # Runs on PR activity (not just the daily cron, which GitHub disables after
   # ~60 idle days): HEADs every locally-pinned asset so a pruned pin fails the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,14 +88,14 @@ jobs:
       # release a lane whose changelog adds more than one new version.
       # Checks the lane being released (the pushed branch).
       - name: Version sanity
-        uses: whuppi/ci/actions/release-tool@v1.0.7
+        uses: whuppi/ci/actions/release-tool@v1.0.8
         env:
           BRANCH: ${{ inputs.branch || github.ref_name }}
         with:
           mode: --check-versions
       - name: Check changelog relevance
         id: check
-        uses: whuppi/ci/actions/release-tool@v1.0.7
+        uses: whuppi/ci/actions/release-tool@v1.0.8
         env:
           BRANCH: ${{ inputs.branch || github.ref_name }}
           BEFORE: ${{ github.event.before }}
@@ -128,7 +128,7 @@ jobs:
           persist-credentials: false
       - name: Find + create release
         id: find
-        uses: whuppi/ci/actions/release-tool@v1.0.7
+        uses: whuppi/ci/actions/release-tool@v1.0.8
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: ${{ inputs.branch || github.ref_name }}
@@ -244,21 +244,21 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Add git install snippet
-        uses: whuppi/ci/actions/release-tool@v1.0.7
+        uses: whuppi/ci/actions/release-tool@v1.0.8
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           mode: --add-git-install
           tag: ${{ needs.discover.outputs.tag }}
       - name: Stamp asset hashes into tag
-        uses: whuppi/ci/actions/release-tool@v1.0.7
+        uses: whuppi/ci/actions/release-tool@v1.0.8
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           mode: --update-tag-hashes
           tag: ${{ needs.discover.outputs.tag }}
       - name: Build pub.dev changelog for preview
-        uses: whuppi/ci/actions/release-tool@v1.0.7
+        uses: whuppi/ci/actions/release-tool@v1.0.8
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -290,16 +290,16 @@ jobs:
           persist-credentials: false
       # Use the verified fvm capability, not an unverified pub global activate:
       # this job holds the pub.dev credentials, so don't weaken its tooling path.
-      - uses: whuppi/ci/actions/capabilities/fvm@v1.0.7
+      - uses: whuppi/ci/actions/capabilities/fvm@v1.0.8
       - name: Build filtered changelog
-        uses: whuppi/ci/actions/release-tool@v1.0.7
+        uses: whuppi/ci/actions/release-tool@v1.0.8
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           mode: --stamp-changelog
           tag: ${{ needs.discover.outputs.tag }}
       - name: Flatten README banner for pub.dev
-        uses: whuppi/ci/actions/release-tool@v1.0.7
+        uses: whuppi/ci/actions/release-tool@v1.0.8
         with:
           mode: --stamp-readme
       - name: Ephemeral commit (clean git for pub publish)
@@ -319,7 +319,7 @@ jobs:
       - run: fvm dart pub get --no-example
       - run: fvm dart pub publish --force
       - name: Add pub.dev install snippet
-        uses: whuppi/ci/actions/release-tool@v1.0.7
+        uses: whuppi/ci/actions/release-tool@v1.0.8
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/retry.yml
+++ b/.github/workflows/retry.yml
@@ -27,4 +27,4 @@ jobs:
   retry:
     permissions:
       actions: write  # gh run rerun re-runs the failed jobs of the run
-    uses: whuppi/ci/.github/workflows/retry.yml@v1.0.7
+    uses: whuppi/ci/.github/workflows/retry.yml@v1.0.8

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -29,4 +29,4 @@ jobs:
       contents: read        # labeler reads .github/labeler.yml + the PR file list
       issues: write         # assign maintainer on issue-opened events
       pull-requests: write  # apply labels, revoke ready-to-test, post notices
-    uses: whuppi/ci/.github/workflows/triage.yml@v1.0.7
+    uses: whuppi/ci/.github/workflows/triage.yml@v1.0.8

--- a/.github/workflows/upgrade-check.yml
+++ b/.github/workflows/upgrade-check.yml
@@ -30,7 +30,7 @@ jobs:
     permissions:
       contents: write       # pushes the chore/flutter-sdk + chore/lockfiles branches
       pull-requests: write  # opens / edits the upgrade PRs
-    uses: whuppi/ci/.github/workflows/upgrade-check.yml@v1.0.7
+    uses: whuppi/ci/.github/workflows/upgrade-check.yml@v1.0.8
     with:
       branch: dev
 

--- a/tool/analyze_core.sh
+++ b/tool/analyze_core.sh
@@ -3,9 +3,9 @@
 # ────────────────────────────────────────────────────────────────────
 # analyze_core.sh — the ONE Dart static-analysis gate, shared verbatim.
 #
-# Canonical copy: whuppi/ci/tool/analyze_core.sh. Stamped into each
-# package as tool/analyze_core.sh by .claude/scripts/stamp-analyze.sh —
-# DO NOT edit the stamped copy; edit the canonical one and re-stamp.
+# Canonical: whuppi/ci/tool/analyze_core.sh; the workspace stamper copies it
+# verbatim into each consumer's tool/. Edit the canonical + re-stamp — never a
+# stamped copy. pr-checks fails a consumer PR whose stamped copy drifted.
 #
 # What it enforces, identically in every package, locally and in CI:
 #   1. No suppression comments in the analyzed source ("// " then

--- a/tool/lint_shell.sh
+++ b/tool/lint_shell.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 # shellcheck shell=bash
+# Canonical: whuppi/ci/tool/lint_shell.sh; the workspace stamper copies it
+# verbatim into each consumer's tool/. Edit the canonical + re-stamp — never a
+# stamped copy. pr-checks fails a consumer PR whose stamped copy drifted.
+#
 # Shell portability + correctness gate — the "zizmor for shell". It lints the
 # git repo at the CURRENT directory, so it runs both ways: `make check` in
 # whuppi/ci (linting itself) and the reusable pr-checks workflow (cd'd into the

--- a/tool/platforms_gate.sh
+++ b/tool/platforms_gate.sh
@@ -3,8 +3,9 @@
 # ────────────────────────────────────────────────────────────────────
 # platforms_gate.sh — the ONE pub.dev platform-support gate, shared verbatim.
 #
-# Canonical copy: whuppi/ci/tool/platforms_gate.sh. Stamped into each package's
-# tool/ — DO NOT edit the stamped copy; edit the canonical one and re-stamp.
+# Canonical: whuppi/ci/tool/platforms_gate.sh; the workspace stamper copies it
+# verbatim into each consumer's tool/. Edit the canonical + re-stamp — never a
+# stamped copy. pr-checks fails a consumer PR whose stamped copy drifted.
 #
 # Runs pana (pinned to PANA_VERSION, the exact analyzer pub.dev runs) on a lean
 # snapshot of the working tree and fails if the package no longer resolves to


### PR DESCRIPTION
Adopts whuppi/ci v1.0.8 (the stamp-quadrant hardening).

- Bumps every whuppi/ci pin v1.0.7 → v1.0.8.
- Re-stamps the tool/ gates (analyze_core, lint_shell, platforms_gate) from the v1.0.8 canonical — the standardized do-not-edit headers.

Both together in one commit: v1.0.8's new drift guard fails a pin bump whose stamped gates weren't re-stamped to match. All refs are consistent at v1.0.8; the gates byte-match the canonical, so the guard passes.
