### PR TITLE
fix: dart2wasm web build; adopt whuppi/ci v2.0.0 dual-compiler gate

### DIFF
--- a/.github/actions/make-target/action.yml
+++ b/.github/actions/make-target/action.yml
@@ -75,7 +75,7 @@ runs:
     # the native/wasm ones (rust, wasm-cache, wasm-build) are pdf-specific and
     # stay local. The shared capabilities were generalized FROM these, so the
     # behavior is identical — only their home moved.
-    - uses: whuppi/ci/actions/capabilities/fvm@v1.0.8
+    - uses: whuppi/ci/actions/capabilities/fvm@v2.0.0
 
     # ── On demand ──
     # Default on: most jobs build the native/wasm engine. Dart-only static
@@ -85,22 +85,22 @@ runs:
     - uses: ./.github/actions/capabilities/rust
       if: inputs.rust == 'true'
 
-    - uses: whuppi/ci/actions/capabilities/free-disk-space@v1.0.8
+    - uses: whuppi/ci/actions/capabilities/free-disk-space@v2.0.0
       if: inputs.free-disk == 'true'
 
-    - uses: whuppi/ci/actions/capabilities/java@v1.0.8
+    - uses: whuppi/ci/actions/capabilities/java@v2.0.0
       if: inputs.java == 'true'
 
-    - uses: whuppi/ci/actions/capabilities/chrome@v1.0.8
+    - uses: whuppi/ci/actions/capabilities/chrome@v2.0.0
       if: inputs.chrome == 'true'
 
-    - uses: whuppi/ci/actions/capabilities/headless-display@v1.0.8
+    - uses: whuppi/ci/actions/capabilities/headless-display@v2.0.0
       if: inputs.headless-display == 'true'
 
-    - uses: whuppi/ci/actions/capabilities/hw-accel@v1.0.8
+    - uses: whuppi/ci/actions/capabilities/hw-accel@v2.0.0
       if: inputs.hw-accel == 'true'
 
-    - uses: whuppi/ci/actions/capabilities/gradle-cache@v1.0.8
+    - uses: whuppi/ci/actions/capabilities/gradle-cache@v2.0.0
       if: inputs.gradle-cache == 'true'
       with:
         phase: restore
@@ -108,13 +108,13 @@ runs:
     # Forward the pdf_oxide submodule rev (set by the rust step above) as the
     # shared xcode-cache's key-extra, preserving the precise cache key the
     # local xcode-cache read from env directly.
-    - uses: whuppi/ci/actions/capabilities/xcode-cache@v1.0.8
+    - uses: whuppi/ci/actions/capabilities/xcode-cache@v2.0.0
       if: inputs.xcode-cache == 'true'
       with:
         target: ${{ inputs.xcode-cache-target }}
         key-extra: ${{ env.SUBMODULE_PDF_OXIDE }}
 
-    - uses: whuppi/ci/actions/capabilities/pods-cache@v1.0.8
+    - uses: whuppi/ci/actions/capabilities/pods-cache@v2.0.0
       if: inputs.pods-cache == 'true'
 
     - uses: ./.github/actions/capabilities/wasm-cache
@@ -123,7 +123,7 @@ runs:
     - uses: ./.github/actions/capabilities/wasm-build
       if: inputs.wasm-build == 'true'
 
-    - uses: whuppi/ci/actions/capabilities/ios-simulator@v1.0.8
+    - uses: whuppi/ci/actions/capabilities/ios-simulator@v2.0.0
       if: inputs.simulator == 'true'
 
     # ── Run ──
@@ -163,12 +163,12 @@ runs:
     # by the capability's teardown-watchdog wrapper. The shared android-emulator
     # reconciles the machine report at its default path (test-results/
     # int-android.json), which is where the android make target writes.
-    - uses: whuppi/ci/actions/capabilities/android-emulator@v1.0.8
+    - uses: whuppi/ci/actions/capabilities/android-emulator@v2.0.0
       if: inputs.emulator == 'true'
       with:
         script: /tmp/make-run.sh "${{ inputs.make-target }}"
 
-    - uses: whuppi/ci/actions/capabilities/gradle-cache@v1.0.8
+    - uses: whuppi/ci/actions/capabilities/gradle-cache@v2.0.0
       if: always() && inputs.gradle-cache == 'true'
       with:
         phase: save

--- a/.github/workflows/auto-close.yml
+++ b/.github/workflows/auto-close.yml
@@ -24,7 +24,7 @@ jobs:
   auto-close:
     permissions:
       issues: write  # label, comment on, and close resolved issues
-    uses: whuppi/ci/.github/workflows/auto-close.yml@v1.0.8
+    uses: whuppi/ci/.github/workflows/auto-close.yml@v2.0.0
     with:
       # Team slug for the humans (managed in the org, same team CODEOWNERS
       # uses) + the slopfairy bot as a fixed automation hook. A maintainer

--- a/.github/workflows/debug-ssh.yml
+++ b/.github/workflows/debug-ssh.yml
@@ -65,7 +65,7 @@ jobs:
           submodules: recursive
           persist-credentials: false
 
-      - uses: whuppi/ci/actions/debug-ssh@v1.0.8
+      - uses: whuppi/ci/actions/debug-ssh@v2.0.0
 
       - name: Keep alive (touch /tmp/stop to end)
         shell: bash

--- a/.github/workflows/full-test.yml
+++ b/.github/workflows/full-test.yml
@@ -128,7 +128,7 @@ jobs:
     steps:
       - name: Check filter
         id: filter
-        uses: whuppi/ci/actions/matrix-filter@v1.0.8
+        uses: whuppi/ci/actions/matrix-filter@v2.0.0
         with:
           name: ${{ matrix.name }}
           filter: ${{ needs.inputs.outputs.filter }}

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -23,4 +23,4 @@ jobs:
     permissions:
       contents: read  # checkout reads .github/labels.json
       issues: write   # labels are managed through the Issues API
-    uses: whuppi/ci/.github/workflows/labels.yml@v1.0.8
+    uses: whuppi/ci/.github/workflows/labels.yml@v2.0.0

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -22,7 +22,7 @@ jobs:
   checks:
     permissions:
       contents: read  # the reusable jobs only checkout + lint, read-only
-    uses: whuppi/ci/.github/workflows/pr-checks.yml@v1.0.8
+    uses: whuppi/ci/.github/workflows/pr-checks.yml@v2.0.0
 
   # Runs on PR activity (not just the daily cron, which GitHub disables after
   # ~60 idle days): HEADs every locally-pinned asset so a pruned pin fails the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,14 +88,14 @@ jobs:
       # release a lane whose changelog adds more than one new version.
       # Checks the lane being released (the pushed branch).
       - name: Version sanity
-        uses: whuppi/ci/actions/release-tool@v1.0.8
+        uses: whuppi/ci/actions/release-tool@v2.0.0
         env:
           BRANCH: ${{ inputs.branch || github.ref_name }}
         with:
           mode: --check-versions
       - name: Check changelog relevance
         id: check
-        uses: whuppi/ci/actions/release-tool@v1.0.8
+        uses: whuppi/ci/actions/release-tool@v2.0.0
         env:
           BRANCH: ${{ inputs.branch || github.ref_name }}
           BEFORE: ${{ github.event.before }}
@@ -128,7 +128,7 @@ jobs:
           persist-credentials: false
       - name: Find + create release
         id: find
-        uses: whuppi/ci/actions/release-tool@v1.0.8
+        uses: whuppi/ci/actions/release-tool@v2.0.0
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: ${{ inputs.branch || github.ref_name }}
@@ -244,21 +244,21 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Add git install snippet
-        uses: whuppi/ci/actions/release-tool@v1.0.8
+        uses: whuppi/ci/actions/release-tool@v2.0.0
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           mode: --add-git-install
           tag: ${{ needs.discover.outputs.tag }}
       - name: Stamp asset hashes into tag
-        uses: whuppi/ci/actions/release-tool@v1.0.8
+        uses: whuppi/ci/actions/release-tool@v2.0.0
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           mode: --update-tag-hashes
           tag: ${{ needs.discover.outputs.tag }}
       - name: Build pub.dev changelog for preview
-        uses: whuppi/ci/actions/release-tool@v1.0.8
+        uses: whuppi/ci/actions/release-tool@v2.0.0
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -290,16 +290,16 @@ jobs:
           persist-credentials: false
       # Use the verified fvm capability, not an unverified pub global activate:
       # this job holds the pub.dev credentials, so don't weaken its tooling path.
-      - uses: whuppi/ci/actions/capabilities/fvm@v1.0.8
+      - uses: whuppi/ci/actions/capabilities/fvm@v2.0.0
       - name: Build filtered changelog
-        uses: whuppi/ci/actions/release-tool@v1.0.8
+        uses: whuppi/ci/actions/release-tool@v2.0.0
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           mode: --stamp-changelog
           tag: ${{ needs.discover.outputs.tag }}
       - name: Flatten README banner for pub.dev
-        uses: whuppi/ci/actions/release-tool@v1.0.8
+        uses: whuppi/ci/actions/release-tool@v2.0.0
         with:
           mode: --stamp-readme
       - name: Ephemeral commit (clean git for pub publish)
@@ -319,7 +319,7 @@ jobs:
       - run: fvm dart pub get --no-example
       - run: fvm dart pub publish --force
       - name: Add pub.dev install snippet
-        uses: whuppi/ci/actions/release-tool@v1.0.8
+        uses: whuppi/ci/actions/release-tool@v2.0.0
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/retry.yml
+++ b/.github/workflows/retry.yml
@@ -27,4 +27,4 @@ jobs:
   retry:
     permissions:
       actions: write  # gh run rerun re-runs the failed jobs of the run
-    uses: whuppi/ci/.github/workflows/retry.yml@v1.0.8
+    uses: whuppi/ci/.github/workflows/retry.yml@v2.0.0

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -29,4 +29,4 @@ jobs:
       contents: read        # labeler reads .github/labeler.yml + the PR file list
       issues: write         # assign maintainer on issue-opened events
       pull-requests: write  # apply labels, revoke ready-to-test, post notices
-    uses: whuppi/ci/.github/workflows/triage.yml@v1.0.8
+    uses: whuppi/ci/.github/workflows/triage.yml@v2.0.0

--- a/.github/workflows/upgrade-check.yml
+++ b/.github/workflows/upgrade-check.yml
@@ -30,7 +30,7 @@ jobs:
     permissions:
       contents: write       # pushes the chore/flutter-sdk + chore/lockfiles branches
       pull-requests: write  # opens / edits the upgrade PRs
-    uses: whuppi/ci/.github/workflows/upgrade-check.yml@v1.0.8
+    uses: whuppi/ci/.github/workflows/upgrade-check.yml@v2.0.0
     with:
       branch: dev
 

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ analyze-floor:
 #                 (canonical in whuppi/ci, stamped into tool/); PANA_VERSION
 #                 comes from this repo's tool/versions.env.
 platforms:
-	@DART="$(DART)" bash tool/platforms_gate.sh
+	@DART="$(DART)" EXPECTED_PLATFORMS="android ios linux macos windows web" bash tool/platforms_gate.sh
 
 # make lint-shell  Shell portability gate: shellcheck + a bash 4.0+ scan
 #                  that catches macOS bash 3.2 breaks in scripts and in
@@ -403,7 +403,7 @@ verify-windows:
 verify-web:
 	$(call setup_example_web)
 	@echo "=== Verify: Web ==="
-	cd example && $(FLUTTER) build web --release $(VERBOSE)
+	@FLUTTER="$(FLUTTER)" bash tool/verify_web_gate.sh
 
 # ═══════════════════════════════════════════════════════════════════
 # § 8 — Clean

--- a/lib/src/runtime/web/lane.dart
+++ b/lib/src/runtime/web/lane.dart
@@ -611,17 +611,9 @@ class WebLane implements Lane {
 
   void _post(Map<String, Object?> fields) {
     final obj = JSObject();
-    fields.forEach((k, v) {
-      obj[k] = switch (v) {
-        null => null,
-        final String s => s.toJS,
-        final int n => n.toJS,
-        final bool b => b.toJS,
-        // JSAny is an erased extension type — this arm absorbs every
-        // remaining value; senders only pass JS-safe types.
-        final JSAny js => js,
-      };
-    });
+    // jsify: canonical Dart->JS conversion, identical on dart2js and dart2wasm.
+    // Already-JS values (buffers, ports) go through _postRaw, not here.
+    fields.forEach((k, v) => obj[k] = v.jsify());
     _worker?.js.postMessage(obj);
   }
 

--- a/tool/analyze.sh
+++ b/tool/analyze.sh
@@ -8,9 +8,10 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PKG_ROOT="$(dirname "$SCRIPT_DIR")"
 
-# SDK commands (overridable via env for non-FVM setups)
-DART="${DART:-fvm dart}"
-FLUTTER="${FLUTTER:-fvm flutter}"
+# SDK commands — REQUIRED, no fallback. The caller (the Makefile) passes them;
+# a missing one fails loud, never guesses.
+: "${DART:?analyze: DART must be set by the caller, e.g. fvm dart}"
+: "${FLUTTER:?analyze: FLUTTER must be set by the caller, e.g. fvm flutter}"
 
 # ── Resolve BEFORE formatting ───────────────────────────────────────
 # `dart format`'s output depends on the file's resolved LANGUAGE

--- a/tool/analyze_core.sh
+++ b/tool/analyze_core.sh
@@ -19,18 +19,19 @@
 # auto-detected, example is auto-detected, and package-only steps
 # (Rust, fixtures) live in the package's own wrapper AROUND this core.
 #
-# Env (all optional):
-#   DART / FLUTTER   SDK commands            (default: fvm dart / fvm flutter)
-#   ANALYZE_DIRS     root dirs to analyze    (default: the ones that exist
-#                    among lib bin test tool hook)
-#   EXAMPLE_DIR      example app dir          (default: example if present;
+# Env:
+#   DART / FLUTTER   SDK commands — REQUIRED, no fallback. The caller passes
+#                    them; a missing one fails loud, never guesses.
+#   ANALYZE_DIRS     root dirs to analyze — auto-detected from the package shape
+#                    (the ones that exist among lib bin test tool hook)
+#   EXAMPLE_DIR      example app dir — auto-detected (example/ if present;
 #                    set to "" to skip)
 # Run from the package root.
 # ────────────────────────────────────────────────────────────────────
 set -euo pipefail
 
-DART="${DART:-fvm dart}"
-FLUTTER="${FLUTTER:-fvm flutter}"
+: "${DART:?analyze_core: DART must be set by the caller, e.g. fvm dart}"
+: "${FLUTTER:?analyze_core: FLUTTER must be set by the caller, e.g. fvm flutter}"
 
 # Auto-detect the analyzable root dirs so one script fits every package
 # shape. example/ is deliberately NOT in this list: it is a separate

--- a/tool/platforms_gate.sh
+++ b/tool/platforms_gate.sh
@@ -18,21 +18,21 @@
 # can't satisfy pana's floor, so `activate` fails loudly rather than silently
 # resolving an OLDER pana (a false green that hides the regression).
 #
-# Env:
-#   DART                 SDK command       (default: fvm dart) — a STABLE sdk
-#   PANA_VERSION         required — read from the caller's tool/versions.env
-#   EXPECTED_PLATFORMS   space-separated   (default: android ios linux macos
-#                                            windows web)
+# Env (all REQUIRED, no fallback — the caller passes them; a missing one fails
+# loud, never guesses):
+#   DART                 SDK command — a STABLE sdk
+#   PANA_VERSION         read from the caller's tool/versions.env
+#   EXPECTED_PLATFORMS   space-separated, e.g. android ios linux macos windows web
 # Run from the package root. Needs jq + rsync (both preinstalled on CI runners).
 # ────────────────────────────────────────────────────────────────────
 set -euo pipefail
 
+: "${DART:?platforms_gate: DART must be set by the caller, e.g. fvm dart}"
+: "${EXPECTED_PLATFORMS:?platforms_gate: EXPECTED_PLATFORMS must be set by the caller, e.g. android ios linux macos windows web}"
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PKG_ROOT="$(dirname "$SCRIPT_DIR")"
 cd "$PKG_ROOT"
-
-DART="${DART:-fvm dart}"
-EXPECTED_PLATFORMS="${EXPECTED_PLATFORMS:-android ios linux macos windows web}"
 
 command -v jq >/dev/null 2>&1 || {
   echo "platforms_gate: jq not found (needed to parse pana output)" >&2

--- a/tool/stamped-files.txt
+++ b/tool/stamped-files.txt
@@ -1,0 +1,11 @@
+# The tool/*.sh gates stamped verbatim from whuppi/ci into each consumer's tool/.
+# Single source of truth for "what is stamped": the workspace stamper writes
+# exactly this list, and pr-checks fails a consumer PR whose stamped copy drifted
+# from the whuppi/ci version it pins. Blank lines and # comments are ignored.
+#
+# NOT here: commit-types.txt (a consumer override is allowed) and versions.env
+# (legitimately per-repo). Only files that must byte-match the canonical.
+analyze_core.sh
+lint_shell.sh
+platforms_gate.sh
+verify_web_gate.sh

--- a/tool/verify_web_gate.sh
+++ b/tool/verify_web_gate.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# ────────────────────────────────────────────────────────────────────
+# verify_web_gate.sh — compile the example under BOTH web compilers, shared verbatim.
+#
+# Canonical: whuppi/ci/tool/verify_web_gate.sh; the workspace stamper copies it
+# verbatim into each consumer's tool/. Edit the canonical + re-stamp — never a
+# stamped copy. pr-checks fails a consumer PR whose stamped copy drifted.
+#
+# "Web support" is two compilers, not one. dart2js (the default JS build) and
+# dart2wasm (`--wasm`) have different type models: a js-interop switch or cast
+# that dart2js accepts, dart2wasm can reject (a non-exhaustive JSAny switch,
+# an unsound interop `as`, etc.). Neither the analyzer nor pana's wasm heuristic
+# actually compiles wasm, so a JS-only build is a false green — the package
+# advertises web, but a wasm-mode Flutter app can't compile it. This gate
+# compiles the example under both compilers so that gap fails at PR time, not
+# in a user's build.
+#
+# Env:
+#   FLUTTER   Flutter command — REQUIRED, no fallback. The caller (the Makefile
+#             target) passes it; a missing one fails loud, never guesses.
+# The example dir is fixed at "example" (the Flutter package convention).
+# Run from the package root; builds example/ under both compilers.
+# ────────────────────────────────────────────────────────────────────
+set -euo pipefail
+
+: "${FLUTTER:?verify_web_gate: FLUTTER must be set by the caller, e.g. fvm flutter}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PKG_ROOT="$(dirname "$SCRIPT_DIR")"
+
+cd "$PKG_ROOT/example"
+
+echo "verify_web_gate: dart2js   — $FLUTTER build web"
+# FLUTTER is intentionally word-split (e.g. "fvm flutter").
+# shellcheck disable=SC2086
+$FLUTTER build web --release
+
+echo "verify_web_gate: dart2wasm — $FLUTTER build web --wasm"
+# shellcheck disable=SC2086
+$FLUTTER build web --wasm --release
+
+echo "verify_web_gate: OK — example compiles under dart2js and dart2wasm"


### PR DESCRIPTION
## The fix (closes #145)
`lane.dart`'s `_post` switched over `Object?` with a `JSAny` arm. **dart2js treats `JSAny` as a catch-all (exhaustive); dart2wasm doesn't (non-exhaustive)** — so 2.1.0 fails a Flutter Web WASM / `dart2wasm` build while every CI check stayed green. Replaced the switch with `v.jsify()`, the canonical Dart→JS conversion that's identical on both compilers.

## Why CI missed it
Nothing in the toolchain actually compiles wasm: the analyzer + dart2js use the JS type model (switch looks exhaustive), the `invalid_runtime_check_with_js_interop_types` lint covers `is`/`as` but not switch patterns, and pana's wasm tag is an import heuristic. This adopts whuppi/ci **v2.0.0**, whose new `verify_web_gate.sh` compiles the example under **both** `flutter build web` and `--wasm` — the only honest check.

## Adoption (v2.0.0 is MAJOR — gates now require inputs)
- Pins v1.0.8 → v2.0.0; re-stamped all gates + manifest.
- Makefile: `make platforms` passes `EXPECTED_PLATFORMS`; `make verify-web` calls the new gate.
- `analyze.sh` requires DART/FLUTTER (no `${VAR:-…}` fallback).

Verified: `make analyze` / `platforms` / `verify-web` all green — both compilers, all 6 platforms.