### PR TITLE
docs: 2.1.2 — dart2wasm web fix + web platform on pub.dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,11 @@ CONTENT RULES (never change)
 
 <!-- Add new versions below, newest first. -->
 
+## 2.1.2
+
+- Fixed a Flutter Web WASM (`dart2wasm`) compile failure — the `_post` switch over `Object?` was non-exhaustive under dart2wasm (dart2js treats `JSAny` as a catch-all, dart2wasm doesn't), now converted with `jsify()` ([#145](https://github.com/whuppi/pdf_manipulator/issues/145) reported by [@DarkWingMcQuack](https://github.com/DarkWingMcQuack), [PR #146](https://github.com/whuppi/pdf_manipulator/pull/146))
+- Fixed pub.dev not advertising Flutter Web support — the web runtime now resolves to a stub default that `pana` can analyze, so the package shows web (dart2js) support ([PR #133](https://github.com/whuppi/pdf_manipulator/pull/133))
+
 ## 2.1.1
 
 - Fixed the README banner not rendering on pub.dev — the `<picture>` element is flattened to a plain image in the published package ([PR #111](https://github.com/whuppi/pdf_manipulator/pull/111))

--- a/CHANGELOG.pre.md
+++ b/CHANGELOG.pre.md
@@ -60,6 +60,11 @@ CONTENT RULES (never change)
 
 <!-- Add new versions below, newest first. -->
 
+## 2.1.2-dev.0
+
+- Fixed a Flutter Web WASM (`dart2wasm`) compile failure — the `_post` switch over `Object?` was non-exhaustive under dart2wasm (dart2js treats `JSAny` as a catch-all, dart2wasm doesn't), now converted with `jsify()` ([#145](https://github.com/whuppi/pdf_manipulator/issues/145) reported by [@DarkWingMcQuack](https://github.com/DarkWingMcQuack), [PR #146](https://github.com/whuppi/pdf_manipulator/pull/146))
+- Fixed pub.dev not advertising Flutter Web support — the web runtime now resolves to a stub default that `pana` can analyze, so the package shows web (dart2js) support ([PR #133](https://github.com/whuppi/pdf_manipulator/pull/133))
+
 ## 2.1.1-dev.0
 
 - Fixed the README banner not rendering on pub.dev — the `<picture>` element is flattened to a plain image in the published package ([PR #111](https://github.com/whuppi/pdf_manipulator/pull/111))


### PR DESCRIPTION
Release PR for **2.1.2** — both changelog lanes updated. **Not merging — yours to handle.**

## What's in 2.1.2
Two user-facing fixes since v2.1.1 (curated from 21 commits; the other 19 are CI / chore / build — whuppi/ci v2.0.0 adoption, pin bumps, lockfile refreshes — excluded per the changelog discipline):
- **dart2wasm web compile failure** — the `_post` switch was non-exhaustive under dart2wasm; now `jsify()`. Reported #145, fixed PR #146.
- **pub.dev now advertising web support** — the web runtime resolves to a pana-analyzable stub default (PR #133).

## Lanes
- `CHANGELOG.pre.md` → `## 2.1.2-dev.0`
- `CHANGELOG.md` → `## 2.1.2`
Same prose, independent version sequences (not mirrored). Both are the sole untagged top entry; `v2.1.1` / `v2.1.1-dev.0` below are tagged.

## Flow (per docs/UPDATING.md)
Merge to **dev** → cuts the **2.1.2-dev.0 prerelease** (approve publish). Then a **dev → prod merge commit** → cuts the **2.1.2 stable**.

## One judgment call for your review
I included **#133** (web-on-pub.dev). It's a pana/pub.dev *detection* fix, not a runtime behavior change — borderline against "only what changed." Say the word and I'll drop it to leave 2.1.2 as the single dart2wasm fix.