### PR TITLE
ci: bump whuppi/ci to v2.0.2

### DIFF
--- a/.github/actions/make-target/action.yml
+++ b/.github/actions/make-target/action.yml
@@ -75,7 +75,7 @@ runs:
     # the native/wasm ones (rust, wasm-cache, wasm-build) are pdf-specific and
     # stay local. The shared capabilities were generalized FROM these, so the
     # behavior is identical — only their home moved.
-    - uses: whuppi/ci/actions/capabilities/fvm@v2.0.1
+    - uses: whuppi/ci/actions/capabilities/fvm@v2.0.2
 
     # ── On demand ──
     # Default on: most jobs build the native/wasm engine. Dart-only static
@@ -85,22 +85,22 @@ runs:
     - uses: ./.github/actions/capabilities/rust
       if: inputs.rust == 'true'
 
-    - uses: whuppi/ci/actions/capabilities/free-disk-space@v2.0.1
+    - uses: whuppi/ci/actions/capabilities/free-disk-space@v2.0.2
       if: inputs.free-disk == 'true'
 
-    - uses: whuppi/ci/actions/capabilities/java@v2.0.1
+    - uses: whuppi/ci/actions/capabilities/java@v2.0.2
       if: inputs.java == 'true'
 
-    - uses: whuppi/ci/actions/capabilities/chrome@v2.0.1
+    - uses: whuppi/ci/actions/capabilities/chrome@v2.0.2
       if: inputs.chrome == 'true'
 
-    - uses: whuppi/ci/actions/capabilities/headless-display@v2.0.1
+    - uses: whuppi/ci/actions/capabilities/headless-display@v2.0.2
       if: inputs.headless-display == 'true'
 
-    - uses: whuppi/ci/actions/capabilities/hw-accel@v2.0.1
+    - uses: whuppi/ci/actions/capabilities/hw-accel@v2.0.2
       if: inputs.hw-accel == 'true'
 
-    - uses: whuppi/ci/actions/capabilities/gradle-cache@v2.0.1
+    - uses: whuppi/ci/actions/capabilities/gradle-cache@v2.0.2
       if: inputs.gradle-cache == 'true'
       with:
         phase: restore
@@ -108,13 +108,13 @@ runs:
     # Forward the pdf_oxide submodule rev (set by the rust step above) as the
     # shared xcode-cache's key-extra, preserving the precise cache key the
     # local xcode-cache read from env directly.
-    - uses: whuppi/ci/actions/capabilities/xcode-cache@v2.0.1
+    - uses: whuppi/ci/actions/capabilities/xcode-cache@v2.0.2
       if: inputs.xcode-cache == 'true'
       with:
         target: ${{ inputs.xcode-cache-target }}
         key-extra: ${{ env.SUBMODULE_PDF_OXIDE }}
 
-    - uses: whuppi/ci/actions/capabilities/pods-cache@v2.0.1
+    - uses: whuppi/ci/actions/capabilities/pods-cache@v2.0.2
       if: inputs.pods-cache == 'true'
 
     - uses: ./.github/actions/capabilities/wasm-cache
@@ -123,7 +123,7 @@ runs:
     - uses: ./.github/actions/capabilities/wasm-build
       if: inputs.wasm-build == 'true'
 
-    - uses: whuppi/ci/actions/capabilities/ios-simulator@v2.0.1
+    - uses: whuppi/ci/actions/capabilities/ios-simulator@v2.0.2
       if: inputs.simulator == 'true'
 
     # ── Run ──
@@ -163,12 +163,12 @@ runs:
     # by the capability's teardown-watchdog wrapper. The shared android-emulator
     # reconciles the machine report at its default path (test-results/
     # int-android.json), which is where the android make target writes.
-    - uses: whuppi/ci/actions/capabilities/android-emulator@v2.0.1
+    - uses: whuppi/ci/actions/capabilities/android-emulator@v2.0.2
       if: inputs.emulator == 'true'
       with:
         script: /tmp/make-run.sh "${{ inputs.make-target }}"
 
-    - uses: whuppi/ci/actions/capabilities/gradle-cache@v2.0.1
+    - uses: whuppi/ci/actions/capabilities/gradle-cache@v2.0.2
       if: always() && inputs.gradle-cache == 'true'
       with:
         phase: save

--- a/.github/workflows/auto-close.yml
+++ b/.github/workflows/auto-close.yml
@@ -24,7 +24,7 @@ jobs:
   auto-close:
     permissions:
       issues: write  # label, comment on, and close resolved issues
-    uses: whuppi/ci/.github/workflows/auto-close.yml@v2.0.1
+    uses: whuppi/ci/.github/workflows/auto-close.yml@v2.0.2
     with:
       # Team slug for the humans (managed in the org, same team CODEOWNERS
       # uses) + the slopfairy bot as a fixed automation hook. A maintainer

--- a/.github/workflows/debug-ssh.yml
+++ b/.github/workflows/debug-ssh.yml
@@ -65,7 +65,7 @@ jobs:
           submodules: recursive
           persist-credentials: false
 
-      - uses: whuppi/ci/actions/debug-ssh@v2.0.1
+      - uses: whuppi/ci/actions/debug-ssh@v2.0.2
 
       - name: Keep alive (touch /tmp/stop to end)
         shell: bash

--- a/.github/workflows/full-test.yml
+++ b/.github/workflows/full-test.yml
@@ -128,7 +128,7 @@ jobs:
     steps:
       - name: Check filter
         id: filter
-        uses: whuppi/ci/actions/matrix-filter@v2.0.1
+        uses: whuppi/ci/actions/matrix-filter@v2.0.2
         with:
           name: ${{ matrix.name }}
           filter: ${{ needs.inputs.outputs.filter }}

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -23,4 +23,4 @@ jobs:
     permissions:
       contents: read  # checkout reads .github/labels.json
       issues: write   # labels are managed through the Issues API
-    uses: whuppi/ci/.github/workflows/labels.yml@v2.0.1
+    uses: whuppi/ci/.github/workflows/labels.yml@v2.0.2

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -22,7 +22,7 @@ jobs:
   checks:
     permissions:
       contents: read  # the reusable jobs only checkout + lint, read-only
-    uses: whuppi/ci/.github/workflows/pr-checks.yml@v2.0.1
+    uses: whuppi/ci/.github/workflows/pr-checks.yml@v2.0.2
 
   # Runs on PR activity (not just the daily cron, which GitHub disables after
   # ~60 idle days): HEADs every locally-pinned asset so a pruned pin fails the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,14 +88,14 @@ jobs:
       # release a lane whose changelog adds more than one new version.
       # Checks the lane being released (the pushed branch).
       - name: Version sanity
-        uses: whuppi/ci/actions/release-tool@v2.0.1
+        uses: whuppi/ci/actions/release-tool@v2.0.2
         env:
           BRANCH: ${{ inputs.branch || github.ref_name }}
         with:
           mode: --check-versions
       - name: Check changelog relevance
         id: check
-        uses: whuppi/ci/actions/release-tool@v2.0.1
+        uses: whuppi/ci/actions/release-tool@v2.0.2
         env:
           BRANCH: ${{ inputs.branch || github.ref_name }}
           BEFORE: ${{ github.event.before }}
@@ -128,7 +128,7 @@ jobs:
           persist-credentials: false
       - name: Find + create release
         id: find
-        uses: whuppi/ci/actions/release-tool@v2.0.1
+        uses: whuppi/ci/actions/release-tool@v2.0.2
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: ${{ inputs.branch || github.ref_name }}
@@ -244,21 +244,21 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Add git install snippet
-        uses: whuppi/ci/actions/release-tool@v2.0.1
+        uses: whuppi/ci/actions/release-tool@v2.0.2
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           mode: --add-git-install
           tag: ${{ needs.discover.outputs.tag }}
       - name: Stamp asset hashes into tag
-        uses: whuppi/ci/actions/release-tool@v2.0.1
+        uses: whuppi/ci/actions/release-tool@v2.0.2
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           mode: --update-tag-hashes
           tag: ${{ needs.discover.outputs.tag }}
       - name: Build pub.dev changelog for preview
-        uses: whuppi/ci/actions/release-tool@v2.0.1
+        uses: whuppi/ci/actions/release-tool@v2.0.2
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -290,16 +290,16 @@ jobs:
           persist-credentials: false
       # Use the verified fvm capability, not an unverified pub global activate:
       # this job holds the pub.dev credentials, so don't weaken its tooling path.
-      - uses: whuppi/ci/actions/capabilities/fvm@v2.0.1
+      - uses: whuppi/ci/actions/capabilities/fvm@v2.0.2
       - name: Build filtered changelog
-        uses: whuppi/ci/actions/release-tool@v2.0.1
+        uses: whuppi/ci/actions/release-tool@v2.0.2
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           mode: --stamp-changelog
           tag: ${{ needs.discover.outputs.tag }}
       - name: Flatten README banner for pub.dev
-        uses: whuppi/ci/actions/release-tool@v2.0.1
+        uses: whuppi/ci/actions/release-tool@v2.0.2
         with:
           mode: --stamp-readme
       - name: Ephemeral commit (clean git for pub publish)
@@ -319,7 +319,7 @@ jobs:
       - run: fvm dart pub get --no-example
       - run: fvm dart pub publish --force
       - name: Add pub.dev install snippet
-        uses: whuppi/ci/actions/release-tool@v2.0.1
+        uses: whuppi/ci/actions/release-tool@v2.0.2
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/retry.yml
+++ b/.github/workflows/retry.yml
@@ -27,4 +27,4 @@ jobs:
   retry:
     permissions:
       actions: write  # gh run rerun re-runs the failed jobs of the run
-    uses: whuppi/ci/.github/workflows/retry.yml@v2.0.1
+    uses: whuppi/ci/.github/workflows/retry.yml@v2.0.2

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -29,4 +29,4 @@ jobs:
       contents: read        # labeler reads .github/labeler.yml + the PR file list
       issues: write         # assign maintainer on issue-opened events
       pull-requests: write  # apply labels, revoke ready-to-test, post notices
-    uses: whuppi/ci/.github/workflows/triage.yml@v2.0.1
+    uses: whuppi/ci/.github/workflows/triage.yml@v2.0.2

--- a/.github/workflows/upgrade-check.yml
+++ b/.github/workflows/upgrade-check.yml
@@ -30,7 +30,7 @@ jobs:
     permissions:
       contents: write       # pushes the chore/flutter-sdk + chore/lockfiles branches
       pull-requests: write  # opens / edits the upgrade PRs
-    uses: whuppi/ci/.github/workflows/upgrade-check.yml@v2.0.1
+    uses: whuppi/ci/.github/workflows/upgrade-check.yml@v2.0.2
     with:
       branch: dev
 


### PR DESCRIPTION
Bumps every whuppi/ci ref from v2.0.1 to v2.0.2, picking up the release-notes mention escape: commit subjects containing a bare @word (@immutable, @override, ...) no longer become GitHub mentions that credit random accounts as release contributors.