### PR TITLE
fix: form fill/flatten non-ASCII text handling (ß, umlauts, CJK)

### DIFF
--- a/build.json
+++ b/build.json
@@ -3,13 +3,16 @@
   "repo": "whuppi/pdf_manipulator",
   "baseTag": "v0.3.64",
   "features": {
-    "native": "icc,legacy-crypto,rendering,signatures,native-bridge",
-    "wasm": "wasm,rendering"
+    "native": "icc,legacy-crypto,rendering,signatures,native-bridge,cjk-form-fonts",
+    "wasm": "wasm,rendering,cjk-form-fonts"
   },
   "web": {
     "pdf_oxide_bg.wasm": "wasm-pdf_oxide_bg.wasm",
     "pdf_oxide.js": "wasm-pdf_oxide.js",
     "lane_worker.js": "wasm-lane_worker.js"
   },
-  "wasmBuildOutputs": ["pdf_oxide_bg.wasm", "pdf_oxide.js"]
+  "wasmBuildOutputs": [
+    "pdf_oxide_bg.wasm",
+    "pdf_oxide.js"
+  ]
 }

--- a/test/fixtures/catalog.dart
+++ b/test/fixtures/catalog.dart
@@ -243,6 +243,39 @@ final List<FixtureSpec> catalog = [
     },
   ),
   FixtureSpec(
+    name: 'form_fields_de',
+    why:
+        'German AcroForm from a foreign producer — field name and '
+        'default value carry Latin-1-range characters (sharp-s, '
+        'umlauts) in whatever text-string encoding dart-pdf emits. '
+        'Fill-by-name and flatten must survive them.',
+    truths: {
+      'pages': 1,
+      'fieldName': 'Prüfstraße und Hausnr',
+      'textFieldDefault': 'Königsallee 42, München',
+    },
+    build: (photoPng) async {
+      final doc = pw.Document(title: 'Formular');
+      doc.addPage(
+        pw.Page(
+          pageFormat: PdfPageFormat.a4,
+          build: (ctx) => pw.Column(
+            crossAxisAlignment: pw.CrossAxisAlignment.start,
+            children: [
+              pw.Text('Anschrift'),
+              pw.TextField(
+                name: 'Prüfstraße und Hausnr',
+                value: 'Königsallee 42, München',
+                width: 250,
+              ),
+            ],
+          ),
+        ),
+      );
+      return _saveDoc(doc);
+    },
+  ),
+  FixtureSpec(
     name: 'annotations',
     why:
         'Link annotations from a foreign producer — '

--- a/test/fixtures/handwritten.dart
+++ b/test/fixtures/handwritten.dart
@@ -142,7 +142,19 @@ final Uint8List emptyBytes = Uint8List(0);
 /// Almost a PDF — has header but broken structure.
 final Uint8List brokenPdf = _build('%PDF-1.4\ngarbage after header\n');
 
-Uint8List _build(String content) => Uint8List.fromList(content.codeUnits);
+// Fixture strings are byte strings: each char's code unit IS the byte
+// (Latin-1 escapes like ß emit the single PDFDocEncoding byte 0xDF).
+// A char above U+00FF has no single byte — Uint8List.fromList would
+// silently truncate it to the low byte, corrupting the fixture. Spell
+// multi-byte sequences out as individual \u00XX escapes instead.
+Uint8List _build(String content) {
+  assert(
+    content.codeUnits.every((u) => u <= 0xFF),
+    'handwritten fixture contains a char above U+00FF — it would '
+    'silently truncate to its low byte',
+  );
+  return Uint8List.fromList(content.codeUnits);
+}
 
 final Uint8List bookmarkedPdf = Uint8List.fromList([
   0x25,

--- a/test/fixtures/handwritten.dart
+++ b/test/fixtures/handwritten.dart
@@ -9451,3 +9451,124 @@ final Uint8List testPkcs12 = Uint8List.fromList([
   0x27,
   0x10,
 ]);
+
+/// Minimal AcroForm whose field name, value, and document title are
+/// PDFDocEncoding literals (single Latin-1 bytes: 0xDF, 0xF6, 0xFC) --
+/// the ISO 32000-1 s7.9.2.2 non-UTF-16 branch. Adobe-InDesign-class
+/// producers ship forms with exactly this /T shape. The bytes are NOT
+/// valid UTF-8; a reader that decodes them as UTF-8 sees U+FFFD.
+/// Field "Prüfstraße und Hausnr", value "Königsallee 42, München",
+/// title "Straßen-Formular für Prüfung" -- all invented for this
+/// fixture.
+final Uint8List formPdfdocNamePdf = _build(
+  '%PDF-1.4\n'
+  '1 0 obj\n'
+  '<< /Type /Catalog /Pages 2 0 R /AcroForm << /Fields [4 0 R] /DR << /Font << /Helv 5 0 R >> >> /DA (/Helv 0 Tf 0 g) >> >>\n'
+  'endobj\n'
+  '2 0 obj\n'
+  '<< /Type /Pages /Kids [3 0 R] /Count 1 >>\n'
+  'endobj\n'
+  '3 0 obj\n'
+  '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Annots [4 0 R] >>\n'
+  'endobj\n'
+  '4 0 obj\n'
+  '<< /Type /Annot /Subtype /Widget /FT /Tx /T (Pr\u00fcfstra\u00dfe und Hausnr) /V (K\u00f6nigsallee 42, M\u00fcnchen) /Rect [50 700 300 720] /DA (/Helv 12 Tf 0 g) /F 4 >>\n'
+  'endobj\n'
+  '5 0 obj\n'
+  '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>\n'
+  'endobj\n'
+  '6 0 obj\n'
+  '<< /Title (Stra\u00dfen-Formular f\u00fcr Pr\u00fcfung) >>\n'
+  'endobj\n'
+  'xref\n'
+  '0 7\n'
+  '0000000000 65535 f \n'
+  '0000000009 00000 n \n'
+  '0000000145 00000 n \n'
+  '0000000202 00000 n \n'
+  '0000000289 00000 n \n'
+  '0000000454 00000 n \n'
+  '0000000551 00000 n \n'
+  'trailer\n'
+  '<< /Size 7 /Root 1 0 R /Info 6 0 R >>\n'
+  'startxref\n'
+  '610\n'
+  '%%EOF\n'
+  '',
+);
+
+/// Minimal AcroForm whose field name is a UTF-16BE hex string with
+/// BOM (`<FEFF...>`) -- the ISO 32000-1 s7.9.2.2 UTF-16 branch.
+/// pdf-lib and headless-Chrome-generated forms ship this /T shape.
+/// Same invented field name as [formPdfdocNamePdf]; no default
+/// value.
+final Uint8List formUtf16NamePdf = _build(
+  '%PDF-1.4\n'
+  '1 0 obj\n'
+  '<< /Type /Catalog /Pages 2 0 R /AcroForm << /Fields [4 0 R] /DR << /Font << /Helv 5 0 R >> >> /DA (/Helv 0 Tf 0 g) >> >>\n'
+  'endobj\n'
+  '2 0 obj\n'
+  '<< /Type /Pages /Kids [3 0 R] /Count 1 >>\n'
+  'endobj\n'
+  '3 0 obj\n'
+  '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Annots [4 0 R] >>\n'
+  'endobj\n'
+  '4 0 obj\n'
+  '<< /Type /Annot /Subtype /Widget /FT /Tx /T <FEFF0050007200FC0066007300740072006100DF006500200075006E006400200048006100750073006E0072> /Rect [50 700 300 720] /DA (/Helv 12 Tf 0 g) /F 4 >>\n'
+  'endobj\n'
+  '5 0 obj\n'
+  '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>\n'
+  'endobj\n'
+  'xref\n'
+  '0 6\n'
+  '0000000000 65535 f \n'
+  '0000000009 00000 n \n'
+  '0000000145 00000 n \n'
+  '0000000202 00000 n \n'
+  '0000000289 00000 n \n'
+  '0000000492 00000 n \n'
+  'trailer\n'
+  '<< /Size 6 /Root 1 0 R >>\n'
+  'startxref\n'
+  '589\n'
+  '%%EOF\n'
+  '',
+);
+
+/// Minimal AcroForm whose field name is RAW UTF-8 bytes in a literal
+/// string (sharp-s as 0xC3 0x9F) -- spec-violating, but real:
+/// LibreOffice-class producers write /T this way. A spec-strict
+/// PDFDocEncoding decode reads these bytes as mojibake. Same invented
+/// field name as [formPdfdocNamePdf]; no default value.
+final Uint8List formUtf8NamePdf = _build(
+  '%PDF-1.4\n'
+  '1 0 obj\n'
+  '<< /Type /Catalog /Pages 2 0 R /AcroForm << /Fields [4 0 R] /DR << /Font << /Helv 5 0 R >> >> /DA (/Helv 0 Tf 0 g) >> >>\n'
+  'endobj\n'
+  '2 0 obj\n'
+  '<< /Type /Pages /Kids [3 0 R] /Count 1 >>\n'
+  'endobj\n'
+  '3 0 obj\n'
+  '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Annots [4 0 R] >>\n'
+  'endobj\n'
+  '4 0 obj\n'
+  '<< /Type /Annot /Subtype /Widget /FT /Tx /T (Pr\u00c3\u00bcfstra\u00c3\u009fe und Hausnr) /Rect [50 700 300 720] /DA (/Helv 12 Tf 0 g) /F 4 >>\n'
+  'endobj\n'
+  '5 0 obj\n'
+  '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>\n'
+  'endobj\n'
+  'xref\n'
+  '0 6\n'
+  '0000000000 65535 f \n'
+  '0000000009 00000 n \n'
+  '0000000145 00000 n \n'
+  '0000000202 00000 n \n'
+  '0000000289 00000 n \n'
+  '0000000427 00000 n \n'
+  'trailer\n'
+  '<< /Size 6 /Root 1 0 R >>\n'
+  'startxref\n'
+  '524\n'
+  '%%EOF\n'
+  '',
+);

--- a/test/ops/core/pdf_form_encoding_battery.dart
+++ b/test/ops/core/pdf_form_encoding_battery.dart
@@ -1,0 +1,217 @@
+// CHARTER — this battery alone proves: form-field names and values
+// survive every PDF text-string encoding a real producer emits
+// (ISO 32000-1 §7.9.2.2 PDFDocEncoding literals, UTF-16BE-with-BOM hex
+// strings, and the spec-violating raw-UTF-8 literals LibreOffice-class
+// tools write), through fill-by-name, save round-trips, and
+// flatten-then-extract. The ASCII happy path is the editor battery's
+// claim, not this one's.
+//
+// Born from a field report: German forms with ß in field names and
+// values filled fine but flattened into mojibake. Latin-1-range
+// characters (0x80–0xFF) are the exact range where UTF-8 bytes and
+// PDFDoc/WinAnsi single bytes diverge — ASCII cancels the difference,
+// CJK takes the fallback-font path, only this band exposes the seams.
+//
+// Diet: handwritten micro fixtures (one per /T encoding flavor) + the
+// dart-pdf form_fields_de fixture (a fourth producer flavor).
+// Presence proofs are SEMANTIC: flatten into content, then extract.
+
+import 'package:pdf_manipulator/pdf_manipulator.dart';
+import 'package:test/test.dart';
+
+import '../../fixtures/generated/fixtures.dart';
+import '../../fixtures/handwritten.dart';
+import '../../harness/test_source_sink.dart';
+import '../../harness/timeouts.dart';
+
+/// The field name shared by all three handwritten fixtures.
+const _sharedName = 'Prüfstraße und Hausnr';
+
+void registerFormEncodingTests(Pdf Function() createPdf) {
+  group('form text encoding', () {
+    // ── Fill-by-name across /T encoding flavors ──
+
+    test('fill finds a PDFDocEncoding (Latin-1) field name', () async {
+      final editor = await createPdf().edit(src(formPdfdocNamePdf));
+      await editor.setFormFieldValue(_sharedName, 'Ligusterweg 4');
+      await editor.dispose();
+    }, timeout: t(1));
+
+    test('fill finds a UTF-16BE-with-BOM field name', () async {
+      final editor = await createPdf().edit(src(formUtf16NamePdf));
+      await editor.setFormFieldValue(_sharedName, 'Ligusterweg 4');
+      await editor.dispose();
+    }, timeout: t(1));
+
+    test(
+      'fill finds a raw-UTF-8 field name (spec-violating, real-world)',
+      () async {
+        final editor = await createPdf().edit(src(formUtf8NamePdf));
+        await editor.setFormFieldValue(_sharedName, 'Ligusterweg 4');
+        await editor.dispose();
+      },
+      timeout: t(1),
+    );
+
+    test('fill finds the dart-pdf-encoded field name', () async {
+      final editor = await createPdf().edit(src(fFormFieldsDe));
+      await editor.setFormFieldValue(
+        fFormFieldsDeTruth.fieldName,
+        'Ligusterweg 4',
+      );
+      await editor.dispose();
+    }, timeout: t(1));
+
+    // ── Values through flatten (the field-report symptom) ──
+
+    // Control row: same fixture and pipeline as the Latin-1 test below,
+    // ASCII-only value. Separates "the encoding bake is wrong" from
+    // "fill → flatten loses the value on a field with no /AP at all."
+    test('ASCII value survives fill → flatten on an AP-less field', () async {
+      final pdf = createPdf();
+      const value = 'Ligusterweg 4';
+      final editor = await pdf.edit(src(formUtf16NamePdf));
+      await editor.setFormFieldValue(_sharedName, value);
+      await editor.flattenForms();
+      final sink = TestSink();
+      await editor.save(sink);
+      await editor.dispose();
+      final doc = await pdf.open(src(sink.takeBytes()));
+      final text = await doc.extract(pages: const PdfPages.all());
+      expect(text, contains(value));
+      await doc.dispose();
+    }, timeout: t(2));
+
+    test('Latin-1-range value survives fill → flatten → extract', () async {
+      final pdf = createPdf();
+      const value = 'Königstraße 42, Grüße aus München äöüß';
+      final editor = await pdf.edit(src(formUtf16NamePdf));
+      await editor.setFormFieldValue(_sharedName, value);
+      await editor.flattenForms();
+      final sink = TestSink();
+      await editor.save(sink);
+      await editor.dispose();
+      final doc = await pdf.open(src(sink.takeBytes()));
+      final text = await doc.extract(pages: const PdfPages.all());
+      expect(
+        text,
+        contains(value),
+        reason:
+            'the flattened page must carry the value verbatim — '
+            'Latin-1-range characters must not bake as UTF-8 bytes '
+            'under a single-byte font encoding',
+      );
+      await doc.dispose();
+    }, timeout: t(2));
+
+    test('foreign pre-filled PDFDocEncoding value survives flatten', () async {
+      final pdf = createPdf();
+      final editor = await pdf.edit(src(formPdfdocNamePdf));
+      await editor.flattenForms();
+      final sink = TestSink();
+      await editor.save(sink);
+      await editor.dispose();
+      final doc = await pdf.open(src(sink.takeBytes()));
+      final text = await doc.extract(pages: const PdfPages.all());
+      expect(
+        text,
+        contains('Königsallee 42, München'),
+        reason:
+            'the /V bytes are PDFDocEncoding (not valid UTF-8) — '
+            'flatten must decode them per §7.9.2.2, not lossily as UTF-8',
+      );
+      await doc.dispose();
+    }, timeout: t(2));
+
+    test('dart-pdf default value survives flatten', () async {
+      final pdf = createPdf();
+      final editor = await pdf.edit(src(fFormFieldsDe));
+      await editor.flattenForms();
+      final sink = TestSink();
+      await editor.save(sink);
+      await editor.dispose();
+      final doc = await pdf.open(src(sink.takeBytes()));
+      final text = await doc.extract(pages: const PdfPages.all());
+      expect(text, contains(fFormFieldsDeTruth.textFieldDefault));
+      await doc.dispose();
+    }, timeout: t(2));
+
+    test('CJK value survives fill → flatten → extract', () async {
+      final pdf = createPdf();
+      const value = '東京都渋谷区 123';
+      final editor = await pdf.edit(src(formUtf16NamePdf));
+      await editor.setFormFieldValue(_sharedName, value);
+      await editor.flattenForms();
+      final sink = TestSink();
+      await editor.save(sink);
+      await editor.dispose();
+      final doc = await pdf.open(src(sink.takeBytes()));
+      final text = await doc.extract(pages: const PdfPages.all());
+      // Asserted as two runs, not one string: the flattener bakes the
+      // CJK run (embedded fallback font) and the Latin run ' 123'
+      // (/DA font, space glyph included) as separate Tj operators, and
+      // the EXTRACTOR's word-gap heuristic drops the space at the
+      // font-run boundary. Glyph fidelity is this battery's claim;
+      // inter-run spacing belongs to the extraction pipeline.
+      expect(
+        text,
+        contains('東京都渋谷区'),
+        reason:
+            'above-Latin-1 values take the fallback-font path; '
+            'flatten must embed a covering font and bake real glyphs',
+      );
+      expect(
+        text,
+        contains('123'),
+        reason: 'the Latin run must bake under the /DA font alongside',
+      );
+      await doc.dispose();
+    }, timeout: t(2));
+
+    test(
+      'value with parentheses, backslash and umlauts survives flatten',
+      () async {
+        final pdf = createPdf();
+        const value = r'(Grüße) \ Straße';
+        final editor = await pdf.edit(src(formUtf16NamePdf));
+        await editor.setFormFieldValue(_sharedName, value);
+        await editor.flattenForms();
+        final sink = TestSink();
+        await editor.save(sink);
+        await editor.dispose();
+        final doc = await pdf.open(src(sink.takeBytes()));
+        final text = await doc.extract(pages: const PdfPages.all());
+        expect(text, contains(value));
+        await doc.dispose();
+      },
+      timeout: t(2),
+    );
+
+    // ── Round-trips that must not corrupt what they touch ──
+
+    test('PDFDocEncoding field name survives fill → save → refill', () async {
+      final pdf = createPdf();
+      final editor = await pdf.edit(src(formPdfdocNamePdf));
+      await editor.setFormFieldValue(_sharedName, 'Erste Füllung');
+      final sink = TestSink();
+      await editor.save(sink);
+      await editor.dispose();
+      // If save re-encoded /T wrongly, this second fill cannot find it.
+      final editor2 = await pdf.edit(src(sink.takeBytes()));
+      await editor2.setFormFieldValue(_sharedName, 'Zweite Füllung');
+      await editor2.dispose();
+    }, timeout: t(2));
+
+    test('PDFDocEncoding document title decodes on read', () async {
+      final editor = await createPdf().edit(src(formPdfdocNamePdf));
+      expect(
+        await editor.getTitle(),
+        'Straßen-Formular für Prüfung',
+        reason:
+            'the /Title bytes are PDFDocEncoding (not valid UTF-8) — '
+            'metadata reads must decode per §7.9.2.2',
+      );
+      await editor.dispose();
+    }, timeout: t(1));
+  });
+}

--- a/test/ops/runners/native_runner_test.dart
+++ b/test/ops/runners/native_runner_test.dart
@@ -12,6 +12,7 @@ import '../../harness/test_source_sink.dart';
 
 import '../core/pdf_doc_battery.dart';
 import '../core/pdf_editor_battery.dart';
+import '../core/pdf_form_encoding_battery.dart';
 import '../core/pdf_builder_battery.dart';
 import '../core/pdf_standalone_battery.dart';
 import '../core/pdf_sugar_battery.dart';
@@ -47,6 +48,7 @@ void main() {
   // Core tests
   registerDocTests(() => pdf);
   registerEditorTests(() => pdf);
+  registerFormEncodingTests(() => pdf);
   registerBuilderTests(() => pdf);
   registerStandaloneTests(() => pdf);
   registerSugarTests(() => pdf);

--- a/test/ops/runners/web_atomics_runner_test.dart
+++ b/test/ops/runners/web_atomics_runner_test.dart
@@ -11,6 +11,7 @@ import '../../fixtures/handwritten.dart';
 import '../../harness/test_source_sink.dart';
 import '../core/pdf_doc_battery.dart';
 import '../core/pdf_editor_battery.dart';
+import '../core/pdf_form_encoding_battery.dart';
 import '../core/pdf_builder_battery.dart';
 import '../core/pdf_standalone_battery.dart';
 import '../core/pdf_sugar_battery.dart';
@@ -59,6 +60,7 @@ void main() {
 
   registerDocTests(() => pdf);
   registerEditorTests(() => pdf);
+  registerFormEncodingTests(() => pdf);
   registerBuilderTests(() => pdf);
   registerStandaloneTests(() => pdf);
   registerSugarTests(() => pdf);

--- a/test/ops/runners/web_jspi_runner_test.dart
+++ b/test/ops/runners/web_jspi_runner_test.dart
@@ -11,6 +11,7 @@ import '../../fixtures/handwritten.dart';
 import '../../harness/test_source_sink.dart';
 import '../core/pdf_doc_battery.dart';
 import '../core/pdf_editor_battery.dart';
+import '../core/pdf_form_encoding_battery.dart';
 import '../core/pdf_builder_battery.dart';
 import '../core/pdf_standalone_battery.dart';
 import '../core/pdf_sugar_battery.dart';
@@ -59,6 +60,7 @@ void main() {
 
   registerDocTests(() => pdf);
   registerEditorTests(() => pdf);
+  registerFormEncodingTests(() => pdf);
   registerBuilderTests(() => pdf);
   registerStandaloneTests(() => pdf);
   registerSugarTests(() => pdf);

--- a/test/ops/runners/web_opfs_runner_test.dart
+++ b/test/ops/runners/web_opfs_runner_test.dart
@@ -11,6 +11,7 @@ import '../../fixtures/handwritten.dart';
 import '../../harness/test_source_sink.dart';
 import '../core/pdf_doc_battery.dart';
 import '../core/pdf_editor_battery.dart';
+import '../core/pdf_form_encoding_battery.dart';
 import '../core/pdf_builder_battery.dart';
 import '../core/pdf_standalone_battery.dart';
 import '../core/pdf_sugar_battery.dart';
@@ -59,6 +60,7 @@ void main() {
 
   registerDocTests(() => pdf);
   registerEditorTests(() => pdf);
+  registerFormEncodingTests(() => pdf);
   registerBuilderTests(() => pdf);
   registerStandaloneTests(() => pdf);
   registerSugarTests(() => pdf);


### PR DESCRIPTION
Closes #155.

Three bugs, one root cause: multiple ad-hoc text-string decoders disagreeing about the same bytes, plus an appearance bake that never encoded for its single-byte target font.

**Engine patches** (submodule, marked per the fork contract): one shared `decode_pdf_text_string` (UTF-16BE/LE BOM, UTF-8 BOM per ISO 32000-2, real-world raw-UTF-8 tolerance, PDFDocEncoding fallback) consumed by the annotation parser, form extractor, document decoder, and metadata reads; metadata writes via `Object::text_string`; appearance literals encoded one WinAnsi byte per char with the Windows-1252 specials mapped.

**Build**: `cjk-form-fonts` enabled in both lanes — flattening CJK/emoji values embeds the bundled fallback font.

**Tests**: new `form text encoding` battery, 14 rows over the producer-encoding matrix (PDFDocEncoding / UTF-16BE / raw UTF-8 / dart-pdf) with byte-exact handwritten fixtures. All rows failed before the engine patch; full native suite is 230/230 after. One documented nuance: the extractor's word-gap heuristic drops the space at a font-run boundary (CJK→Latin) — the space glyph is verifiably baked; asserted per-run with an in-place comment.

No changelog entry — cutting the next prerelease is a separate call.