### PR TITLE
ci: Renovate — open bump PRs immediately (drop not-pending)

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -3,10 +3,10 @@
   extends: ["config:recommended", ":semanticCommitsDisabled"],
   // pdf ships its updates to dev, same as the old dependabot target-branch.
   baseBranches: ["dev"],
-  // Match the old 7-day dependabot cooldown for third-party updates.
+  // Match the old 7-day dependabot cooldown for third-party updates. PRs open
+  // as soon as an update is past the cooldown (we merge manually, so no reason
+  // to hold the PR behind pending internal checks).
   minimumReleaseAge: "7 days",
-  internalChecksFilter: "strict",
-  prCreation: "not-pending",
   // Don't set commit statuses. The RENOVATE_TOKEN has no "Commit statuses:
   // write" scope, so a status POST 403s and Renovate mis-reports it as
   // "repository has changed during renovation" and aborts. This only disables


### PR DESCRIPTION
Follow-up: with not-pending+strict the bump PRs sat hidden in the dashboard's Pending Status Checks. We merge manually, so open them as soon as they clear the 7-day cooldown.