### PR TITLE
ci: Renovate — no hourly PR limit for the go-live backlog

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -26,6 +26,9 @@
   labels: ["ci"],
   commitMessagePrefix: "ci:",
   branchPrefix: "renovate/",
+  // pdf's update volume is low and grouping + cooldown already bound the PR
+  // count, so no hourly throttle — let the go-live backlog open at once.
+  prHourlyLimit: 0,
   packageRules: [
     {
       description: "All GitHub Actions grouped (SHA-pinned via pinDigests).",


### PR DESCRIPTION
Default prHourlyLimit=2 only opened 2 of the backlog PRs. pdf's volume is low + grouping/cooldown bound the count, so drop the throttle to open the full go-live batch at once.