### PR TITLE
ci: one owner for all action refs (whuppi/ci v2.4.0), Dependabot = pub only

### DIFF
--- a/.github/actions/make-target/action.yml
+++ b/.github/actions/make-target/action.yml
@@ -75,7 +75,7 @@ runs:
     # the native/wasm ones (rust, wasm-cache, wasm-build) are pdf-specific and
     # stay local. The shared capabilities were generalized FROM these, so the
     # behavior is identical — only their home moved.
-    - uses: whuppi/ci/actions/capabilities/fvm@v2.0.4
+    - uses: whuppi/ci/actions/capabilities/fvm@v2.4.0
 
     # ── On demand ──
     # Default on: most jobs build the native/wasm engine. Dart-only static
@@ -85,22 +85,22 @@ runs:
     - uses: ./.github/actions/capabilities/rust
       if: inputs.rust == 'true'
 
-    - uses: whuppi/ci/actions/capabilities/free-disk-space@v2.0.4
+    - uses: whuppi/ci/actions/capabilities/free-disk-space@v2.4.0
       if: inputs.free-disk == 'true'
 
-    - uses: whuppi/ci/actions/capabilities/java@v2.0.4
+    - uses: whuppi/ci/actions/capabilities/java@v2.4.0
       if: inputs.java == 'true'
 
-    - uses: whuppi/ci/actions/capabilities/chrome@v2.0.4
+    - uses: whuppi/ci/actions/capabilities/chrome@v2.4.0
       if: inputs.chrome == 'true'
 
-    - uses: whuppi/ci/actions/capabilities/headless-display@v2.0.4
+    - uses: whuppi/ci/actions/capabilities/headless-display@v2.4.0
       if: inputs.headless-display == 'true'
 
-    - uses: whuppi/ci/actions/capabilities/hw-accel@v2.0.4
+    - uses: whuppi/ci/actions/capabilities/hw-accel@v2.4.0
       if: inputs.hw-accel == 'true'
 
-    - uses: whuppi/ci/actions/capabilities/gradle-cache@v2.0.4
+    - uses: whuppi/ci/actions/capabilities/gradle-cache@v2.4.0
       if: inputs.gradle-cache == 'true'
       with:
         phase: restore
@@ -108,13 +108,13 @@ runs:
     # Forward the pdf_oxide submodule rev (set by the rust step above) as the
     # shared xcode-cache's key-extra, preserving the precise cache key the
     # local xcode-cache read from env directly.
-    - uses: whuppi/ci/actions/capabilities/xcode-cache@v2.0.4
+    - uses: whuppi/ci/actions/capabilities/xcode-cache@v2.4.0
       if: inputs.xcode-cache == 'true'
       with:
         target: ${{ inputs.xcode-cache-target }}
         key-extra: ${{ env.SUBMODULE_PDF_OXIDE }}
 
-    - uses: whuppi/ci/actions/capabilities/pods-cache@v2.0.4
+    - uses: whuppi/ci/actions/capabilities/pods-cache@v2.4.0
       if: inputs.pods-cache == 'true'
 
     - uses: ./.github/actions/capabilities/wasm-cache
@@ -123,7 +123,7 @@ runs:
     - uses: ./.github/actions/capabilities/wasm-build
       if: inputs.wasm-build == 'true'
 
-    - uses: whuppi/ci/actions/capabilities/ios-simulator@v2.0.4
+    - uses: whuppi/ci/actions/capabilities/ios-simulator@v2.4.0
       if: inputs.simulator == 'true'
 
     # ── Run ──
@@ -163,12 +163,12 @@ runs:
     # by the capability's teardown-watchdog wrapper. The shared android-emulator
     # reconciles the machine report at its default path (test-results/
     # int-android.json), which is where the android make target writes.
-    - uses: whuppi/ci/actions/capabilities/android-emulator@v2.0.4
+    - uses: whuppi/ci/actions/capabilities/android-emulator@v2.4.0
       if: inputs.emulator == 'true'
       with:
         script: /tmp/make-run.sh "${{ inputs.make-target }}"
 
-    - uses: whuppi/ci/actions/capabilities/gradle-cache@v2.0.4
+    - uses: whuppi/ci/actions/capabilities/gradle-cache@v2.4.0
       if: always() && inputs.gradle-cache == 'true'
       with:
         phase: save

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,27 +39,10 @@ updates:
     open-pull-requests-limit: 5
     cooldown:
       default-days: 7
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    target-branch: "dev"
-    commit-message:
-      prefix: "ci"
-    labels:
-      - "ci"
-    groups:
-      # whuppi/ci shared-CI refs bump together in one PR, ahead of the
-      # third-party catch-all so a ci release lands as its own reviewable
-      # change tested by this repo's own CI. Order matters — a dependency
-      # joins the first group it matches.
-      whuppi-ci:
-        patterns:
-          - "whuppi/ci*"
-      actions:
-        patterns:
-          - "*"
-    open-pull-requests-limit: 5
-    cooldown:
-      default-days: 7
+  # No github-actions ecosystem here on purpose. EVERY action `uses:` ref —
+  # whuppi/ci and third-party, workflows AND composite action.yml — is owned by
+  # the single `action-refs` sweep in whuppi/ci's upgrade-check.yml (opt-in via
+  # sweepActions). Dependabot can't read composite action.yml (dependabot-core#6704)
+  # and splitting action updates workflow-vs-composite splits the pin, which
+  # pin-availability rejects — so one owner takes all of it, and Dependabot here
+  # owns only pub.

--- a/.github/workflows/auto-close.yml
+++ b/.github/workflows/auto-close.yml
@@ -24,7 +24,7 @@ jobs:
   auto-close:
     permissions:
       issues: write  # label, comment on, and close resolved issues
-    uses: whuppi/ci/.github/workflows/auto-close.yml@v2.0.4
+    uses: whuppi/ci/.github/workflows/auto-close.yml@v2.4.0
     with:
       # Team slug for the humans (managed in the org, same team CODEOWNERS
       # uses) + the slopfairy bot as a fixed automation hook. A maintainer

--- a/.github/workflows/debug-ssh.yml
+++ b/.github/workflows/debug-ssh.yml
@@ -65,7 +65,7 @@ jobs:
           submodules: recursive
           persist-credentials: false
 
-      - uses: whuppi/ci/actions/debug-ssh@v2.0.4
+      - uses: whuppi/ci/actions/debug-ssh@v2.4.0
 
       - name: Keep alive (touch /tmp/stop to end)
         shell: bash

--- a/.github/workflows/full-test.yml
+++ b/.github/workflows/full-test.yml
@@ -148,7 +148,7 @@ jobs:
     steps:
       - name: Check filter
         id: filter
-        uses: whuppi/ci/actions/matrix-filter@v2.0.4
+        uses: whuppi/ci/actions/matrix-filter@v2.4.0
         with:
           name: ${{ matrix.name }}
           filter: ${{ needs.inputs.outputs.filter }}

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -23,4 +23,4 @@ jobs:
     permissions:
       contents: read  # checkout reads .github/labels.json
       issues: write   # labels are managed through the Issues API
-    uses: whuppi/ci/.github/workflows/labels.yml@v2.0.4
+    uses: whuppi/ci/.github/workflows/labels.yml@v2.4.0

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -22,7 +22,7 @@ jobs:
   checks:
     permissions:
       contents: read  # the reusable jobs only checkout + lint, read-only
-    uses: whuppi/ci/.github/workflows/pr-checks.yml@v2.0.4
+    uses: whuppi/ci/.github/workflows/pr-checks.yml@v2.4.0
 
   # Runs on PR activity (not just the daily cron, which GitHub disables after
   # ~60 idle days): HEADs every locally-pinned asset so a pruned pin fails the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,14 +88,14 @@ jobs:
       # release a lane whose changelog adds more than one new version.
       # Checks the lane being released (the pushed branch).
       - name: Version sanity
-        uses: whuppi/ci/actions/release-tool@v2.0.4
+        uses: whuppi/ci/actions/release-tool@v2.4.0
         env:
           BRANCH: ${{ inputs.branch || github.ref_name }}
         with:
           mode: --check-versions
       - name: Check changelog relevance
         id: check
-        uses: whuppi/ci/actions/release-tool@v2.0.4
+        uses: whuppi/ci/actions/release-tool@v2.4.0
         env:
           BRANCH: ${{ inputs.branch || github.ref_name }}
           BEFORE: ${{ github.event.before }}
@@ -128,7 +128,7 @@ jobs:
           persist-credentials: false
       - name: Find + create release
         id: find
-        uses: whuppi/ci/actions/release-tool@v2.0.4
+        uses: whuppi/ci/actions/release-tool@v2.4.0
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: ${{ inputs.branch || github.ref_name }}
@@ -244,21 +244,21 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Add git install snippet
-        uses: whuppi/ci/actions/release-tool@v2.0.4
+        uses: whuppi/ci/actions/release-tool@v2.4.0
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           mode: --add-git-install
           tag: ${{ needs.discover.outputs.tag }}
       - name: Stamp asset hashes into tag
-        uses: whuppi/ci/actions/release-tool@v2.0.4
+        uses: whuppi/ci/actions/release-tool@v2.4.0
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           mode: --update-tag-hashes
           tag: ${{ needs.discover.outputs.tag }}
       - name: Build pub.dev changelog for preview
-        uses: whuppi/ci/actions/release-tool@v2.0.4
+        uses: whuppi/ci/actions/release-tool@v2.4.0
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -290,16 +290,16 @@ jobs:
           persist-credentials: false
       # Use the verified fvm capability, not an unverified pub global activate:
       # this job holds the pub.dev credentials, so don't weaken its tooling path.
-      - uses: whuppi/ci/actions/capabilities/fvm@v2.0.4
+      - uses: whuppi/ci/actions/capabilities/fvm@v2.4.0
       - name: Build filtered changelog
-        uses: whuppi/ci/actions/release-tool@v2.0.4
+        uses: whuppi/ci/actions/release-tool@v2.4.0
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           mode: --stamp-changelog
           tag: ${{ needs.discover.outputs.tag }}
       - name: Flatten README banner for pub.dev
-        uses: whuppi/ci/actions/release-tool@v2.0.4
+        uses: whuppi/ci/actions/release-tool@v2.4.0
         with:
           mode: --stamp-readme
       - name: Ephemeral commit (clean git for pub publish)
@@ -319,7 +319,7 @@ jobs:
       - run: fvm dart pub get --no-example
       - run: fvm dart pub publish --force
       - name: Add pub.dev install snippet
-        uses: whuppi/ci/actions/release-tool@v2.0.4
+        uses: whuppi/ci/actions/release-tool@v2.4.0
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/retry.yml
+++ b/.github/workflows/retry.yml
@@ -27,4 +27,4 @@ jobs:
   retry:
     permissions:
       actions: write  # gh run rerun re-runs the failed jobs of the run
-    uses: whuppi/ci/.github/workflows/retry.yml@v2.0.4
+    uses: whuppi/ci/.github/workflows/retry.yml@v2.4.0

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -29,4 +29,4 @@ jobs:
       contents: read        # labeler reads .github/labeler.yml + the PR file list
       issues: write         # assign maintainer on issue-opened events
       pull-requests: write  # apply labels, revoke ready-to-test, post notices
-    uses: whuppi/ci/.github/workflows/triage.yml@v2.0.4
+    uses: whuppi/ci/.github/workflows/triage.yml@v2.4.0

--- a/.github/workflows/upgrade-check.yml
+++ b/.github/workflows/upgrade-check.yml
@@ -4,8 +4,8 @@
 # tool/ci/upgrade.sh with recomputed sha256s in its own reviewed PR.
 #
 # The shared tool pins (fvm, Chrome, bore) live in whuppi/ci — its self-upgrade
-# bumps them, and they reach this repo via a whuppi/ci release + the grouped
-# whuppi-ci Dependabot PR.
+# bumps them, and they reach this repo via a whuppi/ci release + the
+# composite-refs sweep bumping the whuppi/ci refs (workflows and composites).
 name: Upgrade Check
 
 on:
@@ -25,14 +25,22 @@ defaults:
     shell: bash
 
 jobs:
-  # Flutter SDK (.fvmrc + example/.fvmrc) + lockfiles, each its own PR.
+  # Flutter SDK (.fvmrc + example/.fvmrc) + lockfiles, each its own PR — plus
+  # the action-refs sweep (sweepActions), the SINGLE owner of every action
+  # `uses:` ref: whuppi/ci refs (workflows + composites, uniform) and every
+  # third-party action (workflows + composites) to SHA. Dependabot owns pub only
+  # — the github-actions ecosystem is gone from dependabot.yml. The sweep pushes
+  # .github/workflows/ changes, which GITHUB_TOKEN can't — hence CI_ACTIONS_TOKEN.
   shared:
     permissions:
       contents: write       # pushes the chore/flutter-sdk + chore/lockfiles branches
       pull-requests: write  # opens / edits the upgrade PRs
-    uses: whuppi/ci/.github/workflows/upgrade-check.yml@v2.0.4
+    uses: whuppi/ci/.github/workflows/upgrade-check.yml@v2.4.0
     with:
       branch: dev
+      sweepActions: true
+    secrets:
+      CI_ACTIONS_TOKEN: ${{ secrets.CI_ACTIONS_TOKEN }}
 
   # Security-sensitive: this repo's OWN gate tools
   # (pana), sha256s recomputed from upstream assets. Kept in its own PR so a


### PR DESCRIPTION
Opts pdf into the **`action-refs`** sweep (whuppi/ci v2.4.0) — the single owner of every action `uses:` ref. Kills the workflow-vs-composite split.

## Changes
- **`upgrade-check.yml`**: reusable → `@v2.4.0`, `sweepActions: true`, `CI_ACTIONS_TOKEN`. The sweep now owns *all* action refs: whuppi/ci (workflows + composites, uniform tag) and every third-party action (workflows + composites, to SHA via pinact — including the composite refs Dependabot can't read, #6704).
- **`dependabot.yml`**: drop the `github-actions` ecosystem entirely. Dependabot owns **pub only** (root + example).
- Swept all 30 whuppi/ci refs → `@v2.4.0` (uniform pin).

## Why
No more half-and-half — Dependabot did the workflow actions, a sweep did composites, and the whuppi/ci pin split between them. One owner takes all action refs; Dependabot keeps its one unique job (pub).

## Note
The sweep runs on the daily radar and needs the `CI_ACTIONS_TOKEN` org secret (already set). PRs are authored by the token's identity.

Verified: actionlint clean, dependabot.yml valid, refs uniform at v2.4.0.