### PR TITLE
ci: bump all action refs (workflows + composites)

### DIFF
--- a/.github/actions/capabilities/rust/action.yml
+++ b/.github/actions/capabilities/rust/action.yml
@@ -18,7 +18,7 @@ runs:
         echo "office_oxide=$(git rev-parse HEAD:vendor/office_oxide)" >> "$GITHUB_OUTPUT"
 
     - name: Cache cargo registry
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: |
           ~/.cargo/registry/index

--- a/.github/actions/capabilities/wasm-cache/action.yml
+++ b/.github/actions/capabilities/wasm-cache/action.yml
@@ -4,7 +4,7 @@ description: Cache WASM build output to skip recompilation.
 runs:
   using: composite
   steps:
-    - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+    - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       id: wasm-cache
       with:
         path: web_assets/pdf_oxide_bg.wasm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       code: ${{ steps.filter.outputs.code }}
       rust: ${{ steps.filter.outputs.rust }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
@@ -83,7 +83,7 @@ jobs:
     permissions:
       contents: read  # checkout + build, read-only
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with: { submodules: recursive, persist-credentials: false }
       - uses: ./.github/actions/make-target
         with:
@@ -101,7 +101,7 @@ jobs:
     permissions:
       contents: read  # checkout + static analyze, read-only
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with: { persist-credentials: false }
       - uses: ./.github/actions/make-target
         with:
@@ -120,7 +120,7 @@ jobs:
     permissions:
       contents: read  # checkout + pana static analyze, read-only
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with: { persist-credentials: false }
       - uses: ./.github/actions/make-target
         with:
@@ -136,7 +136,7 @@ jobs:
     permissions:
       contents: read  # checkout + build, read-only
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with: { submodules: recursive, persist-credentials: false }
       - uses: ./.github/actions/make-target
         with:
@@ -153,7 +153,7 @@ jobs:
     permissions:
       contents: read  # checkout + build, read-only
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with: { submodules: recursive, persist-credentials: false }
       # free-disk: the engine's debug build overruns a stock runner's
       # ~14 GB free; the capability reclaims room (Linux only).

--- a/.github/workflows/debug-ssh.yml
+++ b/.github/workflows/debug-ssh.yml
@@ -60,7 +60,7 @@ jobs:
       contents: read  # checkout only; the SSH tunnel needs no token scope
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
           persist-credentials: false

--- a/.github/workflows/full-test.yml
+++ b/.github/workflows/full-test.yml
@@ -154,7 +154,7 @@ jobs:
           filter: ${{ needs.inputs.outputs.filter }}
           portability: ${{ needs.inputs.outputs.portability }}
           row-portability: ${{ matrix.portability || 'false' }}
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: steps.filter.outputs.match == 'true'
         with: { submodules: recursive, persist-credentials: false }
       - uses: ./.github/actions/make-target

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -34,7 +34,7 @@ jobs:
     permissions:
       contents: read  # checkout only; HEADs the pinned asset URLs
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - name: Pinned assets still reachable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
       should_run: ${{ steps.check.outputs.should_run }}
       version: ${{ steps.check.outputs.version }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           ref: ${{ inputs.branch || github.ref_name }}
@@ -120,7 +120,7 @@ jobs:
       version: ${{ steps.find.outputs.version }}
       has_release: ${{ steps.find.outputs.has_release }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           ref: ${{ inputs.branch || github.ref_name }}
@@ -155,7 +155,7 @@ jobs:
     permissions:
       contents: read  # checkout + build; artifacts use run storage, no API
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.discover.outputs.tag }}
           submodules: recursive
@@ -238,7 +238,7 @@ jobs:
         # gh ships on the runner; the release already exists (discover
         # created it), so just upload the binaries, clobbering on rerun.
         run: gh release upload "$TAG" release/* --clobber
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: '${{ needs.discover.outputs.tag }}'
           fetch-depth: 0
@@ -283,7 +283,7 @@ jobs:
     permissions:
       contents: write  # ephemeral stamp commit + release-notes install snippet
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: '${{ needs.discover.outputs.tag }}'
           fetch-depth: 0

--- a/.github/workflows/upgrade-check.yml
+++ b/.github/workflows/upgrade-check.yml
@@ -54,7 +54,7 @@ jobs:
       issues: write         # gh label create fallback (labels.yml is canonical)
       pull-requests: write  # opens / edits the pins PR
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: dev
           persist-credentials: false


### PR DESCRIPTION
One owner for every `uses:` action ref in `.github` — workflow and
composite alike, no split with Dependabot:

- **whuppi/ci refs** across `.github` (workflows AND composite
  `action.yml`) swept uniform to the latest whuppi/ci release, so the
  pin never splits.
- **Every third-party action** (workflows AND composites) pinned to the
  latest SHA via pinact — including the refs inside composite
  `action.yml` that Dependabot can't read (dependabot-core#6704).

Dependabot owns pub deps only.

Add `ready-to-test` for the full cross-target run, then merge once green.

_Auto-generated by upgrade-check.yml_